### PR TITLE
Explicitly depend on Java 9+

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/common/SodiumMod.java
+++ b/src/main/java/me/jellysquid/mods/sodium/common/SodiumMod.java
@@ -8,6 +8,12 @@ public class SodiumMod implements ModInitializer {
 
     @Override
     public void onInitialize() {
+        String javaVersion = System.getProperty("java.specification.version");
+        String[] parsed = javaVersion.split("\\.");
+        if (Integer.parseInt(parsed[parsed.length > 1 ? 1 : 0]) < 9) {
+            throw new IllegalStateException("Sodium requires Java 9 or newer!");
+        }
+
         if (CONFIG == null) {
             throw new IllegalStateException("The mixin plugin did not initialize the config! Did it not load?");
         }


### PR DESCRIPTION
Crash and state that Java 9+ is needed on startup.