### PR TITLE
Change Biome Blend Default to match vanilla

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -38,7 +38,7 @@ public class SodiumGameOptions {
         public boolean enableClouds = true;
 
         public LightingQuality smoothLighting = LightingQuality.HIGH;
-        public int biomeBlendDistance = 3;
+        public int biomeBlendDistance = 5;
     }
 
     public enum DefaultGraphicsQuality implements TextProvider {


### PR DESCRIPTION
Vanilla's default biome blend setting is 5x5 but Sodium's is 3x3