### PR TITLE
Attempt fix for IndexOutOfBoundsException while rendering boats

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/mixin/buffers/MixinBufferBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/buffers/MixinBufferBuilder.java
@@ -67,6 +67,16 @@ public abstract class MixinBufferBuilder extends FixedColorVertexConsumer implem
     public void vertexQuad(float x, float y, float z, int color, float u, float v, int overlay, int light, int normal) {
         if (this.colorFixed) {
             throw new IllegalStateException();
+        } else if (!this.field_21594) {
+            int r = ColorARGB.unpackRed(color);
+            int g = ColorARGB.unpackGreen(color);
+            int b = ColorARGB.unpackBlue(color);
+            int a = ColorARGB.unpackAlpha(color);
+            float normX = Norm3b.unpackX(normal);
+            float normY = Norm3b.unpackY(normal);
+            float normZ = Norm3b.unpackZ(normal);
+            super.vertex(x, y, z, r, g, b, a, u, v, overlay, light, normX, normY, normZ);
+            return;
         }
 
         int size = this.format.getVertexSize();


### PR DESCRIPTION
Note: The fix is bad.

The exception occurs when the `BufferBuilder` instance has a `VertexFormat` of size less than 32. `BufferBuilder.vertexQuad` writes at least 32 bytes to the internal `ByteBuffer`, but the buffer is grown by the size of the vertex format, so if the wrong vertex format is provided, a crash will occur. If the "Use memory intrinsics" operation is enabled, a JVM crash will occur instead.

The vanilla `BufferBuilder` implementation checks the field `field_21594` (labeled `canUseVertexPath`) before writing to the internal buffer. Adding the same check seems to have fixed the issue.