### PR TITLE
Mod overrides for config values

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/common/config/Option.java
+++ b/src/main/java/me/jellysquid/mods/sodium/common/config/Option.java
@@ -1,8 +1,13 @@
 package me.jellysquid.mods.sodium.common.config;
 
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 public class Option {
     private boolean enabled;
     private boolean userDefined;
+    private Set<String> modDefined = new LinkedHashSet<>(0);
 
     public Option(boolean enabled, boolean userDefined) {
         this.enabled = enabled;
@@ -14,11 +19,24 @@ public class Option {
         this.userDefined = userDefined;
     }
 
+    public void addModOverride(boolean enabled, String modId) {
+        this.enabled = enabled;
+        this.modDefined.add(modId);
+    }
+
     public boolean isEnabled() {
         return this.enabled;
     }
 
     public boolean isUserDefined() {
         return this.userDefined;
+    }
+
+    public void clearModsDefiningValue() {
+        this.modDefined.clear();
+    }
+
+    public Collection<String> getModsDefiningValue() {
+        return this.modDefined;
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/SodiumMixinPlugin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/SodiumMixinPlugin.java
@@ -27,7 +27,7 @@ public class SodiumMixinPlugin implements IMixinConfigPlugin {
             throw new RuntimeException("Could not load configuration file for Sodium", e);
         }
 
-        this.logger.info("Loaded configuration file for Sodium ({} options available, {} user overrides)",
+        this.logger.info("Loaded configuration file for Sodium ({} options available, {} overrides)",
                 this.config.getOptionCount(), this.config.getOptionOverrideCount());
         this.logger.info("Sodium has been successfully discovered and initialized -- your game is now faster!");
     }
@@ -46,7 +46,13 @@ public class SodiumMixinPlugin implements IMixinConfigPlugin {
         String mixin = mixinClassName.substring(MIXIN_PACKAGE_ROOT.length());
         Option option = this.config.getOptionForMixin(mixin);
 
-        if (option.isUserDefined()) {
+        if (!option.getModsDefiningValue().isEmpty()) {
+            if (option.isEnabled()) {
+                this.logger.warn("Applying mixin '{}' as mod(s) {} forcefully enable it", mixin, option.getModsDefiningValue());
+            } else {
+                this.logger.warn("Not applying mixin '{}' as mod(s) {} forcefully disable it", mixin, option.getModsDefiningValue());
+            }
+        } else if (option.isUserDefined()) {
             if (option.isEnabled()) {
                 this.logger.warn("Applying mixin '{}' as user configuration forcefully enables it", mixin);
             } else {


### PR DESCRIPTION
Same as https://github.com/jellysquid3/lithium-fabric/pull/74 but for Sodium. It works in exactly the same way, except `sodium:options` is used instead of `lithium:options` in the `fabric.mod.json`.