### PR TITLE
new: Item rendering optimization

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/mixin/item_rendering/MixinItemRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/item_rendering/MixinItemRenderer.java
@@ -1,0 +1,28 @@
+package me.jellysquid.mods.sodium.mixin.item_rendering;
+
+import me.jellysquid.mods.sodium.common.util.DirectionUtil;
+import net.minecraft.client.render.item.ItemRenderer;
+import net.minecraft.util.math.Direction;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.Random;
+
+@Mixin(ItemRenderer.class)
+public class MixinItemRenderer {
+    private Random random;
+
+    @Redirect(method = "renderBakedItemModel", at = @At(value = "NEW", target = "java/util/Random"))
+    public Random reduceRandomAllocations() {
+        // Random instance can be safely reused, since renderBakedItemModel always resets its seed to 42L anyways
+        if (random == null)
+            random = new Random();
+        return random;
+    }
+
+    @Redirect(method = "renderBakedItemModel", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/util/math/Direction;values()[Lnet/minecraft/util/math/Direction;"))
+    public Direction[] reduceDirectionArrayAllocations() {
+        return DirectionUtil.ALL_DIRECTIONS;
+    }
+}

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/item_rendering/MixinItemRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/item_rendering/MixinItemRenderer.java
@@ -21,7 +21,7 @@ public class MixinItemRenderer {
         return random;
     }
 
-    @Redirect(method = "renderBakedItemModel", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/util/math/Direction;values()[Lnet/minecraft/util/math/Direction;"))
+    @Redirect(method = "renderBakedItemModel", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/math/Direction;values()[Lnet/minecraft/util/math/Direction;"))
     public Direction[] reduceDirectionArrayAllocations() {
         return DirectionUtil.ALL_DIRECTIONS;
     }

--- a/src/main/resources/sodium.mixins.json
+++ b/src/main/resources/sodium.mixins.json
@@ -18,6 +18,7 @@
     "entity_rendering.MixinModelPart",
     "gui.MixinDebugHud",
     "gui.font.MixinGlyphRenderer",
+    "item_rendering.MixinItemRenderer",
     "models.MixinBlockColors",
     "models.MixinMultipartBakedModel",
     "mojmath.MixinFrustum",


### PR DESCRIPTION
Apparently `ItemRenderer.renderBakedItemModel` creates a new `Random` instance every time it's called, I.E. *every time an item is drawn on-screen or in the world*. Which is a lot. Thanks, Mojang.

Also, there's a call to `Direction.values()` there.

Props to `vini2003#0875` on the Fabricord for putting this stupidity on blast.