### PR TITLE
Fix: Remove Math.round() from Entity Distance Slider

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -197,7 +197,7 @@ public class SodiumGameOptionPages {
                         .setTooltip("Controls how far away entities can render from the player. Higher values increase the render distance at the expense " +
                                 "of frame rates.")
                         .setControl(option -> new SliderControl(option, 50, 500, 25, ControlValueFormatter.percentage()))
-                        .setBinding((opts, value) -> opts.entityDistanceScaling = Math.round(value / 100.0F), opts -> Math.round(opts.entityDistanceScaling * 100.0F))
+                        .setBinding((opts, value) -> opts.entityDistanceScaling = value / 100.0F, opts -> Math.round(opts.entityDistanceScaling * 100.0F))
                         .setImpact(OptionImpact.MEDIUM)
                         .build()
                 )


### PR DESCRIPTION
fixes #65 .

Note: I have no Java programming experience or training, I just thought I would open the PR to fix the issue. Are there any code quality concerns with this PR? I tested this and it seemed to save the option fine. I'm not sure what the implications are of not rounding here.