### PR TITLE
Change: Remove Unused Translation String

### DIFF
--- a/src/main/resources/assets/sodium/lang/en_us.json
+++ b/src/main/resources/assets/sodium/lang/en_us.json
@@ -14,7 +14,6 @@
   "sodium.options.fog.tooltip": "If enabled, a fog effect will be used for terrain in the distance. Disabling this option will not change fog effects used underwater or in the Nether.",
   "sodium.options.gui_scale.tooltip": "Sets the maximum scale factor to be used for the user interface. If 'auto' is used, then the largest scale factor will always be used.",
   "sodium.options.fullscreen.tooltip": "If enabled, the game will display in full-screen (if supported).",
-  "sodium.options.v_sync.name": "V-Sync",
   "sodium.options.v_sync.tooltip": "If enabled, the game's frame rate will be synchronized to the monitor's refresh rate, making for a generally smoother experience at the expense of overall input latency. This setting might reduce performance if your system is too slow.",
   "sodium.options.fps_limit.tooltip": "Limits the maximum number of frames per second. In effect, this will throttle the game and can be useful when you want to conserve battery life or multi-task between other applications. If V-Sync is enabled, this option will be ignored unless it is lower than your display's refresh rate.",
   "sodium.options.view_bobbing.tooltip": "If enabled, the player's view will sway and bob when moving around. Players who suffer from motion sickness can benefit from disabling this.",


### PR DESCRIPTION
`sodium.options.v_sync.name` is unused since we're using `options.vsync` [here](https://github.com/jellysquid3/sodium-fabric/blob/f8c3a67822ca594ee934d5da0fd12097f4daf5d1/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java#L104). Alternatively, if "Vsync" is preferred to Vanilla's "Use Vsync" we should swap the string out with a custom one.