### PR TITLE
ModMenu integration again!

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     // Fabric Resource Loader for translations
     modCompile "net.fabricmc.fabric-api:fabric-resource-loader-v0:${project.fabric_resource_loader_version}"
     include "net.fabricmc.fabric-api:fabric-resource-loader-v0:${project.fabric_resource_loader_version}"
+
+    // ModMenu integration
+    modImplementation "io.github.prospector:modmenu:${project.modmenu_version}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,8 @@ archives_base_name=sodium-fabric
 
 # Fabric API Resource Loader version
 fabric_resource_loader_version=0.2.5+059ea86602
+# ModMenu version
+modmenu_version=1.14.5+build.30
 
 # If true, third-party mods will be loaded during runtime in the developer run configurations
 use_third_party_mods = true

--- a/src/main/java/me/jellysquid/mods/sodium/client/SodiumModMenu.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/SodiumModMenu.java
@@ -1,0 +1,16 @@
+package me.jellysquid.mods.sodium.client;
+
+import io.github.prospector.modmenu.api.ConfigScreenFactory;
+import io.github.prospector.modmenu.api.ModMenuApi;
+import me.jellysquid.mods.sodium.client.gui.SodiumOptionsGUI;
+
+/**
+ * Represents the ModMenu integration.
+ */
+public class SodiumModMenu implements ModMenuApi
+{
+    @Override
+    public ConfigScreenFactory<?> getModConfigScreenFactory() {
+        return SodiumOptionsGUI::new;
+    }
+}

--- a/src/main/java/me/jellysquid/mods/sodium/client/SodiumModMenu.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/SodiumModMenu.java
@@ -7,8 +7,7 @@ import me.jellysquid.mods.sodium.client.gui.SodiumOptionsGUI;
 /**
  * Represents the ModMenu integration.
  */
-public class SodiumModMenu implements ModMenuApi
-{
+public class SodiumModMenu implements ModMenuApi {
     @Override
     public ConfigScreenFactory<?> getModConfigScreenFactory() {
         return SodiumOptionsGUI::new;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,8 +24,7 @@
     ]
   },
   "custom": {
-    "fabric-renderer-api-v1:contains_renderer": true,
-    "modmenu:clientsideOnly": true
+    "fabric-renderer-api-v1:contains_renderer": true
   },
   "accessWidener": "sodium.accesswidener",
   "mixins": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -9,7 +9,8 @@
   ],
   "contact": {
     "homepage": "https://jellysquid.me",
-    "sources": "https://github.com/jellysquid3/sodium"
+    "sources": "https://github.com/jellysquid3/sodium",
+    "issues": "https://github.com/jellysquid3/sodium/issues"
   },
   "license": "LGPL-3.0-only",
   "icon": "assets/sodium/icon.png",
@@ -17,10 +18,14 @@
   "entrypoints": {
     "client": [
       "me.jellysquid.mods.sodium.client.SodiumClientMod"
+    ],
+    "modmenu": [
+      "me.jellysquid.mods.sodium.client.SodiumModMenu"
     ]
   },
   "custom": {
-    "fabric-renderer-api-v1:contains_renderer": true
+    "fabric-renderer-api-v1:contains_renderer": true,
+    "modmenu:clientsideOnly": true
   },
   "accessWidener": "sodium.accesswidener",
   "mixins": [


### PR DESCRIPTION
Time to try another ModMenu integration as #18 and #29 did not made it.

While #33 is still opened, it still target the 1.15 branch, this one targets the 1.16/dev branch. Hopefully this is not an issue.

 - ~~Added "Client" badge to mod listing in the ModMenu.~~ (Already automatic now, oops)
 - Added config button for mod listing that sends you to Sodium's video settings GUI.
 - Added issues link.