### PR TITLE
Fix: Offset denormalizeFloatAsShort multiplier by one

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gl/SodiumVertexFormats.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gl/SodiumVertexFormats.java
@@ -94,7 +94,7 @@ public class SodiumVertexFormats {
      * @return The resulting de-normalized unsigned short
      */
     private static short denormalizeFloatAsShort(float value) {
-        return (short) (value * 65536.0f);
+        return (short) (value * 65535.0f);
     }
 
     /**


### PR DESCRIPTION
This PR makes a single change. Which address #36 and #120 