### PR TITLE
Added workaround for GL4.3/multidraw on closed-source AMD and some Intel GPUs.

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gl/func/GlIndirectMultiDrawFunctions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gl/func/GlIndirectMultiDrawFunctions.java
@@ -9,19 +9,19 @@ import java.nio.ByteBuffer;
 public enum GlIndirectMultiDrawFunctions {
     CORE {
         @Override
-        public void glMultiDrawArraysIndirect(int mode, ByteBuffer indirect, int primcount, int stride) {
+        public void glMultiDrawArraysIndirect(int mode, long indirect, int primcount, int stride) {
             GL43.glMultiDrawArraysIndirect(mode, indirect, primcount, stride);
         }
     },
     ARB {
         @Override
-        public void glMultiDrawArraysIndirect(int mode, ByteBuffer indirect, int primcount, int stride) {
+        public void glMultiDrawArraysIndirect(int mode, long indirect, int primcount, int stride) {
             ARBMultiDrawIndirect.glMultiDrawArraysIndirect(mode, indirect, primcount, stride);
         }
     },
     UNSUPPORTED {
         @Override
-        public void glMultiDrawArraysIndirect(int mode, ByteBuffer indirect, int primcount, int stride) {
+        public void glMultiDrawArraysIndirect(int mode, long indirect, int primcount, int stride) {
             throw new UnsupportedOperationException();
         }
     };
@@ -36,5 +36,5 @@ public enum GlIndirectMultiDrawFunctions {
         }
     }
 
-    public abstract void glMultiDrawArraysIndirect(int mode, ByteBuffer indirect, int primcount, int stride);
+    public abstract void glMultiDrawArraysIndirect(int mode, long indirect, int primcount, int stride);
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/backends/gl43/GL43ChunkRenderBackend.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/backends/gl43/GL43ChunkRenderBackend.java
@@ -200,7 +200,8 @@ public class GL43ChunkRenderBackend extends ChunkRenderBackendMultiDraw<GL43Grap
             ChunkDrawCallBatcher batch = region.getDrawBatcher();
             batch.end();
 
-            GlFunctions.INDIRECT_DRAW.glMultiDrawArraysIndirect(GL11.GL_QUADS, batch.getBuffer(), batch.getCount(), 0 /* tightly packed */);
+            batch.upload();
+            GlFunctions.INDIRECT_DRAW.glMultiDrawArraysIndirect(GL11.GL_QUADS, 0, batch.getCount(), 0 /* tightly packed */);
 
             prevVao = vao;
         }


### PR DESCRIPTION
Fixed the OpenGL 4.3/multidraw render path on AMD/some Intel GPUs.

### Current Sodium render path

The currently used path for **glMultiDrawArraysIndirect** uses a client buffer for the indirection data, which is broken on AMD/some Intel graphics cards.

### Workaround render path

The workaround involves copying the indirection data into a standalone GPU-side buffer bound as **GL_DRAW_INDIRECT_BUFFER**, if such a buffer is bound when **glMultiDrawArraysIndirect** is called, the submitted pointer for the client buffer represents a byte offset into this **GL_DRAW_INDIRECT_BUFFER** buffer instead, this path works properly (and is typically regarded as the more optimal path, though for sodium's use-case it is slightly less optimal).

### Performance with 32 chunks

AMD tests:
CPU: AMD Ryzen Threadripper 3960X
GPU: AMD Radeon RX480
GL 3.0 path: ~60fps
GL 4.3 path: ~250fps

NVIDIA tests:
CPU: AMD Ryzen Threadripper 3960X
GPU: NVIDIA GeForce GTX 1660
GL 4.3 pre-patch path: ~350fps
GL 4.3 post-patch path: ~320fps

Please note these performance tests are only to show "it works", the performance regression on NVIDIA is relatively small (imo), though further optimization is always possible.