### PR TITLE
Automatically catching and fixing invalid option files.  Fix for #219

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -3,6 +3,7 @@ package me.jellysquid.mods.sodium.client.gui;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
 import me.jellysquid.mods.sodium.client.SodiumClientMod;
 import me.jellysquid.mods.sodium.client.gui.options.TextProvider;
 import me.jellysquid.mods.sodium.client.render.chunk.backends.gl20.GL20ChunkRenderBackend;
@@ -149,6 +150,9 @@ public class SodiumGameOptions {
                 config = gson.fromJson(reader, SodiumGameOptions.class);
             } catch (IOException e) {
                 throw new RuntimeException("Could not parse config", e);
+            } catch (JsonSyntaxException e) {
+                SodiumClientMod.logger().warn("Could not parse broken options file, reverting to defaults.");
+                config = new SodiumGameOptions();
             }
 
             config.sanitize();


### PR DESCRIPTION
This PR adds the following:

- One catch clause to check if the JsonSyntaxException is thrown and if so revert to the defaults for Sodium's options as the file is invalid.