### PR TITLE
Remove a few unnecessary lines from MixinBufferBuilder

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/buffer_builder/intrinsics/MixinBufferBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/buffer_builder/intrinsics/MixinBufferBuilder.java
@@ -104,7 +104,6 @@ public abstract class MixinBufferBuilder extends FixedColorVertexConsumer
         i += 4;
 
         buffer.putInt(i, light);
-        i += 4;
     }
 
     private void vertexParticleUnsafe(float x, float y, float z, float u, float v, int color, int light) {
@@ -130,7 +129,6 @@ public abstract class MixinBufferBuilder extends FixedColorVertexConsumer
         i += 4;
 
         unsafe.putInt(i, light);
-        i += 4;
     }
 
     @Override
@@ -357,7 +355,6 @@ public abstract class MixinBufferBuilder extends FixedColorVertexConsumer
         i += 4;
 
         buffer.putInt(i, light);
-        i += 4;
     }
 
     private void vertexGlyphUnsafe(float x, float y, float z, int color, float u, float v, int light) {
@@ -383,6 +380,5 @@ public abstract class MixinBufferBuilder extends FixedColorVertexConsumer
         i += 4;
 
         unsafe.putInt(i, light);
-        i += 4;
     }
 }


### PR DESCRIPTION
In the modified functions, since `i` goes out of scope and is not used after the function completes, it's unnecessary to increment `i`.