### PR TITLE
Change GitHub Actions version to JDK 8

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,10 +8,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 14
+    - name: Set up JDK 8
       uses: actions/setup-java@v1
       with:
-        java-version: 14
+        java-version: 8
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle


### PR DESCRIPTION
More and more users are using GitHub actions, and running into #16. This is probably the most efficient way to prevent complaints before they happen.