### PR TITLE
fix: unloading chunks not removing block entities

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/world/SodiumChunkManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/SodiumChunkManager.java
@@ -56,7 +56,9 @@ public class SodiumChunkManager extends ClientChunkManager implements ChunkStatu
     @Override
     public void unload(int x, int z) {
         // If this request unloads a chunk, notify the listener
-        if (this.chunks.remove(createChunkKey(x, z)) != null) {
+        WorldChunk unloadedChunk = this.chunks.remove(createChunkKey(x, z));
+        if (unloadedChunk != null) {
+            this.world.unloadBlockEntities(unloadedChunk);
             this.onChunkUnloaded(x, z);
         }
     }


### PR DESCRIPTION
Fixes: https://github.com/jellysquid3/sodium-fabric/issues/141

SodiumChunkManager did not unload blockentities, as it replaced the code of compareAndSet, which for some reason contains the blockentity unloading code in vanilla. This PR adds the call to unload blockentities from the client world to the chunk unloading code.