### PR TITLE
Fix block rendering with compact vertex format disabled

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gl/SodiumVertexFormats.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gl/SodiumVertexFormats.java
@@ -40,10 +40,10 @@ public class SodiumVertexFormats {
                 buffer.putFloat(position + 4, quad.getY(i));
                 buffer.putFloat(position + 8, quad.getZ(i));
                 buffer.putFloat(position + 12, mipped ? 1.0f : 0.0f);
-                buffer.putInt(position + 12, quad.getColor(i));
-                buffer.putFloat(position + 16, quad.getTexU(i));
-                buffer.putFloat(position + 20, quad.getTexV(i));
-                buffer.putInt(position + 24, encodeLightMapTexCoord(quad.getLight(i)));
+                buffer.putInt(position + 16, quad.getColor(i));
+                buffer.putFloat(position + 20, quad.getTexU(i));
+                buffer.putFloat(position + 24, quad.getTexV(i));
+                buffer.putInt(position + 28, encodeLightMapTexCoord(quad.getLight(i)));
 
                 position += 32;
             }


### PR DESCRIPTION
fixes #136 (a dev branch bug)

`7aef096` with compact vertex format disabled:
![2020-11-01_17 12 48](https://user-images.githubusercontent.com/40721769/97816788-a62a5980-1c65-11eb-8a36-580729aff153.png)

This fix with compact vertex format disabled:
![2020-11-01_17 16 51](https://user-images.githubusercontent.com/40721769/97816817-0f11d180-1c66-11eb-8bba-cc701feb13e9.png)



