### PR TITLE
fix: Update project homepage to curseforge

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -8,7 +8,7 @@
     "JellySquid"
   ],
   "contact": {
-    "homepage": "https://jellysquid.me",
+    "homepage": "https://www.curseforge.com/minecraft/mc-mods/sodium",
     "sources": "https://github.com/jellysquid3/sodium"
   },
   "license": "LGPL-3.0-only",


### PR DESCRIPTION
Hi, this is a tiny change but quite useful, unless project homepage points to your website intentionally.