### PR TITLE
fix: Use auto GUI scale as GUI scale limit

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -74,7 +74,9 @@ public class SodiumGameOptionPages {
                 .add(OptionImpl.createBuilder(int.class, vanillaOpts)
                         .setName(I18n.translate("options.guiScale"))
                         .setTooltip(I18n.translate("sodium.options.gui_scale.tooltip"))
-                        .setControl(option -> new SliderControl(option, 0, 4, 1, ControlValueFormatter.guiScale()))
+                        .setControl(option -> new SliderControl(option, 0, MinecraftClient.getInstance().getWindow().
+                                calculateScaleFactor(0, MinecraftClient.getInstance().forcesUnicodeFont()), 1,
+                                ControlValueFormatter.guiScale()))
                         .setBinding((opts, value) -> {
                             opts.guiScale = value;
 


### PR DESCRIPTION
**EDIT:**
No longer valid, as new default branch is [`1.16.x/next`](https://github.com/jellysquid3/sodium-fabric/tree/1.16.x/next) instead of [`1.16.x/dev`](https://github.com/jellysquid3/sodium-fabric/tree/1.16.x/dev).

---

Instead of using a fixed value of 4 for the maximum GUI scale in the Sodium options page, the auto GUI scale (largest calculated size) will be used. Allowing the GUI scale to extend above 4 is helpful on high-dpi displays, where significantly larger GUI scales are necessary to match the physical size of equivalent low-dpi displays. This small change matches vanilla behavior and fixes #259.

_Note: Correction for #378, target branch is now [`1.16.x/dev`](https://github.com/jellysquid3/sodium-fabric/tree/1.16.x/dev)._