### PR TITLE
Fix guardian beams disappearing after long periods of time in a world (#415)

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/entity/guardian/MixinGuardianEntityRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/entity/guardian/MixinGuardianEntityRenderer.java
@@ -1,0 +1,19 @@
+package me.jellysquid.mods.sodium.mixin.features.entity.guardian;
+
+import net.minecraft.client.render.entity.GuardianEntityRenderer;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(GuardianEntityRenderer.class)
+public class MixinGuardianEntityRenderer {
+    /**
+     * @reason Use the time of day instead of the time of the world in guardian beam rendering
+     * @author AMereBagatelle
+     */
+    @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getTime()J"))
+    private long useTimeOfDay(World world) {
+        return world.getTimeOfDay();
+    }
+}

--- a/src/main/resources/sodium.mixins.json
+++ b/src/main/resources/sodium.mixins.json
@@ -28,6 +28,7 @@
     "features.debug.MixinDebugHud",
     "features.entity.fast_render.MixinCuboid",
     "features.entity.fast_render.MixinModelPart",
+    "features.entity.guardian.MixinGuardianEntityRenderer",
     "features.entity.smooth_lighting.MixinEntityRenderer",
     "features.gui.MixinDebugHud",
     "features.gui.font.MixinGlyphRenderer",


### PR DESCRIPTION
I saw how easy the fix was, so I couldn't help myself :P

Adds one mixin, to use the time of day instead of the world time when rendering the guardian beams.