### PR TITLE
fix: Use block height to check for invalid subchunks and remove unnecessary height check 

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
@@ -454,7 +454,7 @@ public class WorldSlice extends ReusableObject implements BlockRenderView, Biome
     private static ChunkSection getChunkSection(Chunk chunk, ChunkSectionPos pos) {
         ChunkSection section = null;
 
-        if (!World.isHeightInvalid(pos.getY())) {
+        if (!World.isHeightInvalid(ChunkSectionPos.getBlockCoord(pos.getY()))) {
             section = chunk.getSectionArray()[pos.getY()];
         }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
@@ -216,10 +216,6 @@ public class WorldSlice extends ReusableObject implements BlockRenderView, Biome
     }
 
     private void populateLightArrays(int sectionIdx, ChunkSectionPos pos) {
-        if (World.isHeightInvalid(pos.getY())) {
-            return;
-        }
-
         ChunkLightingView blockLightProvider = this.world.getLightingProvider().get(LightType.BLOCK);
         ChunkLightingView skyLightProvider = this.world.getLightingProvider().get(LightType.SKY);
         


### PR DESCRIPTION
This PR addresses two issues brought up in commit [`eb664ec`](https://github.com/jellysquid3/sodium-fabric/commit/eb664ec9bf22428678691f761fa0a6a73c916410) relating to checks for valid subchunks.

In summary, the chunk height (ranging from 0-15) was used to check for valid chunks, when the block height (ranging from 0-255) is expected instead, causing invalid heights (ex. 16 chunk, 256-272 block) to pass the check (0-255 block) incorrectly. This fixes #425. Additionally, one of these checks was removed due to it causing subchunks directly above and below world limits to have no light arrays, making block faces adjacent to these appear black.

See commit messages for more details.