### PR TITLE
fix: Set current world to null when unloading a world

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -117,6 +117,7 @@ public class SodiumWorldRenderer implements ChunkStatusListener {
 
     private void unloadWorld() {
         GlobalRenderContext.destroyRenderContext(this.world);
+        this.world = null;
 
         if (this.chunkRenderManager != null) {
             this.chunkRenderManager.destroy();


### PR DESCRIPTION
This PR adds a single line of code which fixes #430, a crash caused by commit [`ef6c9bd`](https://github.com/jellysquid3/sodium-fabric/commit/ef6c9bd29b412897997f1fe3a26dfe227399baba). This crash occurs when a user leaves a world and joins another in the same session due to the attempted unloading of a world twice.

_(Copied from commit message)_
When the client world is changed, a check is present to decide if the current world should be unloaded or not. Currently, the world is only unloaded if the current world is not null. However, the current world is never set to null when unloading it. This means the check (if world is not null) becomes meaningless after a world is loaded for the first time, allowing the unload method to run whenever the client world changes even if the world is already unloaded. Because of this behavior, an unhandled exception is thrown when the unload method attempts to unload a world that doesn't exist (specifically having no render context). This specific situation can occur when leaving a world and joining another. When the second world is being loaded, the unload method is called even though the first world has already been unloaded, leading to the crash. In order to prevent this from happening, a single line is added after the unload method which sets the current world to null.