### PR TITLE
Add render distance formula option

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -251,6 +251,14 @@ public class SodiumGameOptionPages {
                         .setBinding((opts, value) -> opts.advanced.chunkRendererBackend = value, opts -> opts.advanced.chunkRendererBackend)
                         .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)
                         .build())
+                .add(OptionImpl.createBuilder(boolean.class, sodiumOpts)
+                        .setName("Use Circular Chunk Load Radius")
+                        .setTooltip("If enabled, only the chunks inside the render distance radius will be loaded. If disabled, the render distance will load chunks inside the square render distance. This setting loads only 78.5% of the chunks compared with the default setting.")
+                        .setControl(TickBoxControl::new)
+                        .setImpact(OptionImpact.LOW)
+                        .setBinding((opts, value) -> opts.advanced.useCircularChunkLoadRadius = value, opts -> opts.advanced.useCircularChunkLoadRadius)
+                        .build()
+                )
                 .build());
 
         groups.add(OptionGroup.createBuilder()

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -38,6 +38,7 @@ public class SodiumGameOptions {
         public boolean useChunkFaceCulling = true;
         public boolean useMemoryIntrinsics = true;
         public boolean disableDriverBlacklist = false;
+        public boolean useCircularChunkLoadRadius = false;
     }
 
     public static class QualitySettings {
@@ -46,6 +47,7 @@ public class SodiumGameOptions {
 
         public boolean enableVignette = true;
         public boolean enableClouds = true;
+        public boolean enableFog = true;
 
         public LightingQuality smoothLighting = LightingQuality.HIGH;
     }

--- a/src/main/java/me/jellysquid/mods/sodium/client/world/SodiumChunkManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/SodiumChunkManager.java
@@ -3,6 +3,8 @@ package me.jellysquid.mods.sodium.client.world;
 import it.unimi.dsi.fastutil.Hash;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.objects.ObjectIterator;
+import me.jellysquid.mods.sodium.client.SodiumClientMod;
+import me.jellysquid.mods.sodium.client.gui.SodiumGameOptions;
 import me.jellysquid.mods.sodium.client.util.collections.FixedLongHashTable;
 import net.minecraft.client.world.ClientChunkManager;
 import net.minecraft.client.world.ClientWorld;
@@ -137,6 +139,8 @@ public class SodiumChunkManager extends ClientChunkManager implements ChunkStatu
 
     @Override
     public void updateLoadDistance(int loadDistance) {
+        SodiumGameOptions options = SodiumClientMod.options();
+
         this.radius = getChunkMapRadius(loadDistance);
 
         FixedLongHashTable<WorldChunk> copy = new FixedLongHashTable<>(getChunkMapSize(this.radius), Hash.FAST_LOAD_FACTOR);
@@ -154,7 +158,9 @@ public class SodiumChunkManager extends ClientChunkManager implements ChunkStatu
                 int z = ChunkPos.getPackedZ(pos);
 
                 // Remove any chunks which are outside the load radius
-                if (Math.abs(x - this.centerX) <= this.radius && Math.abs(z - this.centerZ) <= this.radius) {
+                if (options.advanced.useCircularChunkLoadRadius ?
+                        (((x - this.centerX) * (x - this.centerX)) + ((z - this.centerZ) * (z - this.centerZ)) <= this.radius * this.radius)
+                        : (Math.abs(x - this.centerX) <= this.radius && Math.abs(z - this.centerZ) <= this.radius)) {
                     copy.put(pos, entry.getValue());
                 }
             }


### PR DESCRIPTION
Implements #433.
This option reduces the amount of loaded chunks by 20%.
A circular area is always 20% smaller than a square with the width equal to the diameter of that circle.