### PR TITLE
Update Gradle + Update fabric.mod.json (Cancelled)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,8 +14,8 @@ jobs:
         java-version: 14
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - name: Build with Gradle
-      run: ./gradlew build
+    - name: Build with Gradle (Using genSources)
+      run: ./gradlew genSources
     - name: Upload build artifacts
       uses: actions/upload-artifact@v1
       with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 When opening issues, please be sure to include the following information as applicable.
 
-- The exact version of the mod you are running, such as `0.1.0-fabric`, and the version of Fabric/Forge you are using.
+- The exact version of the mod you are running, such as `0.1.0-fabric`, and the version of Fabric you are using.
 - If your issue is a crash, attach the latest client or server log and the complete crash report as a file. You can
 attach these as a file (preferred) or host them on a service such as [GitHub Gist](https://gist.github.com/) or [Hastebin](https://hastebin.com/).
 - If your issue is a bug or otherwise unexpected behavior, explain what you expected to happen.

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ minecraft {
 dependencies {
     //to change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
-    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+    mappings "net.fabricmc:yarn:${project.yarn_mappings}"
     modCompile "net.fabricmc:fabric-loader:${project.loader_version}"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ minecraft {
 dependencies {
     //to change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
-    mappings "net.fabricmc:yarn:${project.yarn_mappings}"
+    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
     modCompile "net.fabricmc:fabric-loader:${project.loader_version}"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
 minecraft_version=1.16.4
-yarn_mappings=1.16.4+build.1
-loader_version=0.10.6+build.214
+yarn_mappings=1.16.4+build.7
+loader_version=0.10.8
 
 # Mod Properties
 mod_version=0.1.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -3,7 +3,7 @@
   "id": "sodium",
   "version": "${version}",
   "name": "Sodium",
-  "description": "Sodium is an free and open-source optimization mod for Minecraft which improves frame rates and reduces lag spikes.",
+  "description": "Sodium is a free and open-source optimization mod for Minecraft which improves frame rates and reduces lag spikes.",
   "authors": [
     "JellySquid"
   ],
@@ -32,5 +32,8 @@
   "breaks": {
     "optifabric": "*",
     "canvas": "*"
+  },
+  "conflicts": {
+    "thallium": "*"
   }
 }


### PR DESCRIPTION
A typo has been spotted via the main json where the "an free" string can be seen instead of "a free", The compiling system is also capable of running 6.6.1 however i am unaware if a newer version than that can break something.

One more thing: The mod should warn the user of using thallium because it is a mod that basically fakes the FPS, And thous we don't like this at all and want to prevent this in future.