### PR TITLE
fix: Leave direction of diagonal faces unassigned to prevent improper culling (#171)

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/data/ChunkRenderBounds.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/data/ChunkRenderBounds.java
@@ -57,15 +57,14 @@ public class ChunkRenderBounds {
             int z1 = origin.getMinZ() + leftBound(this.z);
             int z2 = origin.getMinZ() + rightBound(this.z);
 
-            // Expand the bounding box by 8 blocks (half a chunk) in order to deal with diagonal surfaces
             return new ChunkRenderBounds(
-                    Math.max(x1, origin.getMinX()) - 8.0f,
-                    Math.max(y1, origin.getMinY()) - 8.0f,
-                    Math.max(z1, origin.getMinZ()) - 8.0f,
+                    Math.max(x1, origin.getMinX()) - 0.5f,
+                    Math.max(y1, origin.getMinY()) - 0.5f,
+                    Math.max(z1, origin.getMinZ()) - 0.5f,
 
-                    Math.min(x2, origin.getMaxX()) + 8.0f,
-                    Math.min(y2, origin.getMaxY()) + 8.0f,
-                    Math.min(z2, origin.getMaxZ()) + 8.0f
+                    Math.min(x2, origin.getMaxX()) + 0.5f,
+                    Math.min(y2, origin.getMaxY()) + 0.5f,
+                    Math.min(z2, origin.getMaxZ()) + 0.5f
             );
         }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/FluidRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/FluidRenderer.java
@@ -152,11 +152,13 @@ public class FluidRenderer {
             Vec3d velocity = fluidState.getVelocity(world, pos);
 
             Sprite sprite;
+            ModelQuadFacing facing;
             float u1, u2, u3, u4;
             float v1, v2, v3, v4;
 
             if (velocity.x == 0.0D && velocity.z == 0.0D) {
                 sprite = sprites[0];
+                facing = ModelQuadFacing.UP;
                 u1 = sprite.getFrameU(0.0D);
                 v1 = sprite.getFrameV(0.0D);
                 u2 = u1;
@@ -167,6 +169,7 @@ public class FluidRenderer {
                 v4 = v1;
             } else {
                 sprite = sprites[1];
+                facing = ModelQuadFacing.UNASSIGNED;
                 float dir = (float) MathHelper.atan2(velocity.z, velocity.x) - (1.5707964f);
                 float sin = MathHelper.sin(dir) * 0.25F;
                 float cos = MathHelper.cos(dir) * 0.25F;
@@ -203,7 +206,7 @@ public class FluidRenderer {
             this.setVertex(quad, 3, 1.0F, h4, 0.0f, u4, v4);
 
             this.calculateQuadColors(quad, world, pos, lighter, Direction.UP, 1.0F, !lava);
-            this.flushQuad(buffers, quad, Direction.UP, false);
+            this.flushQuad(buffers, quad, facing, false);
 
             if (fluidState.method_15756(world, this.scratchPos.set(posX, posY + 1, posZ))) {
                 this.setVertex(quad, 3, 0.0f, h1, 0.0f, u1, v1);
@@ -211,7 +214,7 @@ public class FluidRenderer {
                 this.setVertex(quad, 1, 1.0F, h3, 1.0F, u3, v3);
                 this.setVertex(quad, 0, 1.0F, h4, 0.0f, u4, v4);
 
-                this.flushQuad(buffers, quad, Direction.DOWN, true);
+                this.flushQuad(buffers, quad, ModelQuadFacing.DOWN, true);
             }
 
             rendered = true;
@@ -232,7 +235,7 @@ public class FluidRenderer {
             this.setVertex(quad, 3, 1.0F, yOffset, 1.0F, maxU, maxV);
 
             this.calculateQuadColors(quad, world, pos, lighter, Direction.DOWN, 1.0F, !lava);
-            this.flushQuad(buffers, quad, Direction.DOWN, false);
+            this.flushQuad(buffers, quad, ModelQuadFacing.DOWN, false);
 
             rendered = true;
         }
@@ -332,7 +335,7 @@ public class FluidRenderer {
                 float br = dir.getAxis() == Direction.Axis.Z ? 0.8F : 0.6F;
 
                 this.calculateQuadColors(quad, world, pos, lighter, dir, br, !lava);
-                this.flushQuad(buffers, quad, dir, false);
+                this.flushQuad(buffers, quad, ModelQuadFacing.fromDirection(dir), false);
 
                 if (sprite != this.waterOverlaySprite) {
                     this.setVertex(quad, 0, x1, c1, z1, u1, v1);
@@ -340,7 +343,7 @@ public class FluidRenderer {
                     this.setVertex(quad, 2, x2, yOffset, z2, u2, v3);
                     this.setVertex(quad, 3, x2, c2, z2, u2, v2);
 
-                    this.flushQuad(buffers, quad, dir, true);
+                    this.flushQuad(buffers, quad, ModelQuadFacing.fromDirection(dir), true);
                 }
 
                 rendered = true;
@@ -365,7 +368,7 @@ public class FluidRenderer {
         }
     }
 
-    private void flushQuad(ChunkModelBuffers buffers, ModelQuadView quad, Direction dir, boolean flip) {
+    private void flushQuad(ChunkModelBuffers buffers, ModelQuadView quad, ModelQuadFacing facing, boolean flip) {
         int vertexIdx, lightOrder;
 
         if (flip) {
@@ -376,7 +379,7 @@ public class FluidRenderer {
             lightOrder = 1;
         }
 
-        ModelVertexSink sink = buffers.getSink(ModelQuadFacing.fromDirection(dir));
+        ModelVertexSink sink = buffers.getSink(facing);
         sink.ensureCapacity(4);
 
         for (int i = 0; i < 4; i++) {


### PR DESCRIPTION
Fixes #171. Proper culling of these faces could be implemented by using the fluid velocity, but the added complexity doesn't seem worth it. I've also removed the padding on the bounding box completely, I see that before being set to 8 it was 0.5, but it wasn't immediately obvious to me why and I'm not seeing any issues with it removed.

Edit: added back 0.5 block padding to account for odd block models