### PR TITLE
Update to Minecraft 1.16.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.5.28'
+    id 'fabric-loom' version '0.6.35'
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.16.4
-yarn_mappings=1.16.4+build.1
-loader_version=0.10.6+build.214
+minecraft_version=1.16.5
+yarn_mappings=1.16.5+build.3
+loader_version=0.11.1
 
 # Mod Properties
 mod_version=0.1.1

--- a/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
@@ -450,7 +450,7 @@ public class WorldSlice extends ReusableObject implements BlockRenderView, Biome
     private static ChunkSection getChunkSection(Chunk chunk, ChunkSectionPos pos) {
         ChunkSection section = null;
 
-        if (!World.isHeightInvalid(ChunkSectionPos.getBlockCoord(pos.getY()))) {
+        if (!World.isOutOfBuildLimitVertically(ChunkSectionPos.getBlockCoord(pos.getY()))) {
             section = chunk.getSectionArray()[pos.getY()];
         }
 


### PR DESCRIPTION
This should update sodium to 1.16.5.

This need to be tested more. (Currently testing it)

- [x] Faced no problems