### PR TITLE
Fix javadoc task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,16 @@ task sourcesJar(type: Jar, dependsOn: classes) {
     from sourceSets.main.allSource
 }
 
+javadoc {
+    options {
+        encoding = "UTF-8"
+        charSet = "UTF-8"
+        addStringOption("Xdoclint:none", "-quiet")
+    }
+    classpath = sourceSets.main.compileClasspath
+    include("me/jellysquid/mods/sodium/**")
+}
+
 jar {
     from "LICENSE.txt"
 }


### PR DESCRIPTION
`./gradlew javadoc` would previously fail, complaining about invalid syntax and tags.
This PR adds javadoc configuration to `build.gradle` in order to fix this issue and make the task succeed.