### PR TITLE
fix: Broken block and fluid animations

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildBuffers.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildBuffers.java
@@ -9,6 +9,7 @@ import me.jellysquid.mods.sodium.client.render.chunk.compile.buffers.BakedChunkM
 import me.jellysquid.mods.sodium.client.render.chunk.compile.buffers.ChunkModelBuffers;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.buffers.ChunkModelVertexTransformer;
 import me.jellysquid.mods.sodium.client.render.chunk.data.ChunkMeshData;
+import me.jellysquid.mods.sodium.client.render.chunk.data.ChunkRenderData;
 import me.jellysquid.mods.sodium.client.render.chunk.format.ChunkModelOffset;
 import me.jellysquid.mods.sodium.client.render.chunk.passes.BlockRenderPass;
 import me.jellysquid.mods.sodium.client.render.chunk.passes.BlockRenderPassManager;
@@ -52,7 +53,7 @@ public class ChunkBuildBuffers {
         }
     }
 
-    public void init() {
+    public void init(ChunkRenderData.Builder renderData) {
         for (int i = 0; i < this.buffersByLayer.length; i++) {
             ChunkModelVertexTransformer[] writers = new ChunkModelVertexTransformer[ModelQuadFacing.COUNT];
 
@@ -60,7 +61,7 @@ public class ChunkBuildBuffers {
                 writers[facing.ordinal()] = new ChunkModelVertexTransformer(this.vertexType.createBufferWriter(this.buffersByLayer[i][facing.ordinal()], UnsafeUtil.isAvailable()), this.offset);
             }
 
-            this.delegates[i] = new BakedChunkModelBuffers(writers);
+            this.delegates[i] = new BakedChunkModelBuffers(writers, renderData);
         }
     }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/buffers/BakedChunkModelBuffers.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/buffers/BakedChunkModelBuffers.java
@@ -1,17 +1,25 @@
 package me.jellysquid.mods.sodium.client.render.chunk.compile.buffers;
 
 import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadFacing;
+import me.jellysquid.mods.sodium.client.render.chunk.data.ChunkRenderData;
 import me.jellysquid.mods.sodium.client.render.chunk.format.ModelVertexSink;
 
 public class BakedChunkModelBuffers implements ChunkModelBuffers {
     private final ModelVertexSink[] builders;
+    private final ChunkRenderData.Builder renderData;
 
-    public BakedChunkModelBuffers(ModelVertexSink[] builders) {
+    public BakedChunkModelBuffers(ModelVertexSink[] builders, ChunkRenderData.Builder renderData) {
         this.builders = builders;
+        this.renderData = renderData;
     }
 
     @Override
     public ModelVertexSink getSink(ModelQuadFacing facing) {
         return this.builders[facing.ordinal()];
+    }
+
+    @Override
+    public ChunkRenderData.Builder getRenderData() {
+        return this.renderData;
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/buffers/ChunkModelBuffers.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/buffers/ChunkModelBuffers.java
@@ -1,8 +1,11 @@
 package me.jellysquid.mods.sodium.client.render.chunk.compile.buffers;
 
 import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadFacing;
+import me.jellysquid.mods.sodium.client.render.chunk.data.ChunkRenderData;
 import me.jellysquid.mods.sodium.client.render.chunk.format.ModelVertexSink;
 
 public interface ChunkModelBuffers {
     ModelVertexSink getSink(ModelQuadFacing facing);
+
+    ChunkRenderData.Builder getRenderData();
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/buffers/FallbackChunkModelBuffers.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/buffers/FallbackChunkModelBuffers.java
@@ -1,6 +1,7 @@
 package me.jellysquid.mods.sodium.client.render.chunk.compile.buffers;
 
 import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadFacing;
+import me.jellysquid.mods.sodium.client.render.chunk.data.ChunkRenderData;
 import me.jellysquid.mods.sodium.client.render.chunk.format.ModelVertexSink;
 
 public class FallbackChunkModelBuffers implements ChunkModelBuffers {
@@ -10,6 +11,11 @@ public class FallbackChunkModelBuffers implements ChunkModelBuffers {
 
     @Override
     public ModelVertexSink getSink(ModelQuadFacing facing) {
+        return null;
+    }
+
+    @Override
+    public ChunkRenderData.Builder getRenderData() {
         return null;
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/tasks/ChunkRenderRebuildTask.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/tasks/ChunkRenderRebuildTask.java
@@ -54,7 +54,7 @@ public class ChunkRenderRebuildTask<T extends ChunkGraphicsState> extends ChunkR
         ChunkOcclusionDataBuilder occluder = new ChunkOcclusionDataBuilder();
         ChunkRenderBounds.Builder bounds = new ChunkRenderBounds.Builder();
 
-        buffers.init();
+        buffers.init(renderData);
         pipeline.init(this.slice, this.slice.getOrigin());
 
         int baseX = this.render.getOriginX();

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/BlockRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/BlockRenderer.java
@@ -9,6 +9,7 @@ import me.jellysquid.mods.sodium.client.model.quad.blender.BiomeColorBlender;
 import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadFacing;
 import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadOrientation;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.buffers.ChunkModelBuffers;
+import me.jellysquid.mods.sodium.client.render.chunk.data.ChunkRenderData;
 import me.jellysquid.mods.sodium.client.render.chunk.format.ModelVertexSink;
 import me.jellysquid.mods.sodium.client.render.occlusion.BlockOcclusionCache;
 import me.jellysquid.mods.sodium.client.util.color.ColorABGR;
@@ -94,6 +95,8 @@ public class BlockRenderer {
         ModelVertexSink sink = buffers.getSink(facing);
         sink.ensureCapacity(quads.size() * 4);
 
+        ChunkRenderData.Builder renderData = buffers.getRenderData();
+
         // This is a very hot allocation, iterate over it manually
         // noinspection ForLoopReplaceableByForEach
         for (int i = 0, quadsSize = quads.size(); i < quadsSize; i++) {
@@ -106,14 +109,14 @@ public class BlockRenderer {
                 colorizer = this.blockColors.getColorProvider(state);
             }
 
-            this.renderQuad(world, state, pos, sink, offset, buffers, colorizer, quad, light);
+            this.renderQuad(world, state, pos, sink, offset, colorizer, quad, light, renderData);
         }
 
         sink.flush();
     }
 
     private void renderQuad(BlockRenderView world, BlockState state, BlockPos pos, ModelVertexSink sink, Vec3d offset,
-                            ChunkModelBuffers buffers, BlockColorProvider colorProvider, BakedQuad bakedQuad, QuadLightData light) {
+                            BlockColorProvider colorProvider, BakedQuad bakedQuad, QuadLightData light, ChunkRenderData.Builder renderData) {
         ModelQuadView src = (ModelQuadView) bakedQuad;
 
         ModelQuadOrientation order = ModelQuadOrientation.orient(light.br);
@@ -144,7 +147,7 @@ public class BlockRenderer {
         Sprite sprite = src.getSprite();
 
         if (sprite != null) {
-            buffers.getRenderData().addSprite(sprite);
+            renderData.addSprite(sprite);
         }
     }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/BlockRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/BlockRenderer.java
@@ -20,6 +20,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.color.block.BlockColorProvider;
 import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.client.render.model.BakedQuad;
+import net.minecraft.client.texture.Sprite;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
@@ -105,14 +106,14 @@ public class BlockRenderer {
                 colorizer = this.blockColors.getColorProvider(state);
             }
 
-            this.renderQuad(world, state, pos, sink, offset, colorizer, quad, light);
+            this.renderQuad(world, state, pos, sink, offset, buffers, colorizer, quad, light);
         }
 
         sink.flush();
     }
 
     private void renderQuad(BlockRenderView world, BlockState state, BlockPos pos, ModelVertexSink sink, Vec3d offset,
-                            BlockColorProvider colorProvider, BakedQuad bakedQuad, QuadLightData light) {
+                            ChunkModelBuffers buffers, BlockColorProvider colorProvider, BakedQuad bakedQuad, QuadLightData light) {
         ModelQuadView src = (ModelQuadView) bakedQuad;
 
         ModelQuadOrientation order = ModelQuadOrientation.orient(light.br);
@@ -138,6 +139,12 @@ public class BlockRenderer {
             int lm = light.lm[srcIndex];
 
             sink.writeQuad(x, y, z, color, u, v, lm);
+        }
+
+        Sprite sprite = src.getSprite();
+
+        if (sprite != null) {
+            buffers.getRenderData().addSprite(sprite);
         }
     }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/FluidRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/FluidRenderer.java
@@ -396,6 +396,12 @@ public class FluidRenderer {
             vertexIdx += lightOrder;
         }
 
+        Sprite sprite = quad.getSprite();
+
+        if (sprite != null) {
+            buffers.getRenderData().addSprite(sprite);
+        }
+
         sink.flush();
     }
 


### PR DESCRIPTION
This fixes broken block and fluid animations when **Animate Only Visible Textures** is enabled.

Closes: #458