### PR TITLE
remove redundant chmod +x gradlew

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,8 +12,6 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 14
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build
     - name: Upload build artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
       - name: Upload assets to CurseForge
         run: ./gradlew build
         env:


### PR DESCRIPTION
CI adds the execute bit to `gradlew`.
![Screenshot_14:15:19](https://user-images.githubusercontent.com/39013340/107852046-2edc9800-6e06-11eb-946f-51dde03558b0.png)

I simply removed these two lines as it's already set.