### PR TITLE
fix: Respect entity render distance setting

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -215,7 +215,7 @@ public class SodiumWorldRenderer implements ChunkStatusListener {
 
         profiler.pop();
 
-        Entity.setRenderDistanceMultiplier(MathHelper.clamp((double) this.client.options.viewDistance / 8.0D, 1.0D, 2.5D));
+        Entity.setRenderDistanceMultiplier(MathHelper.clamp((double) this.client.options.viewDistance / 8.0D, 1.0D, 2.5D) * (double) this.client.options.entityDistanceScaling);
     }
 
     /**


### PR DESCRIPTION
Setting isn't actually used currently, rarely relevant but speedrunners discovered they weren't seeing any difference in entity count in f3 when adjusting it recently.