### PR TITLE
fix an --> a in mod description

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -3,7 +3,7 @@
   "id": "sodium",
   "version": "${version}",
   "name": "Sodium",
-  "description": "Sodium is an free and open-source optimization mod for Minecraft which improves frame rates and reduces lag spikes.",
+  "description": "Sodium is a free and open-source optimization mod for Minecraft which improves frame rates and reduces lag spikes.",
   "authors": [
     "JellySquid"
   ],


### PR DESCRIPTION
It got added to 1.16.x/dev, but the commit wasn't cherry-picked to 1.16.x/next