### PR TITLE
change: Invoke Fabric API's ClientChunkEvents in SodiumChunkManager

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,10 @@ dependencies {
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
     modCompile "net.fabricmc:fabric-loader:${project.loader_version}"
+
+    // Fabric Lifecycle Events for hooking ClientChunkEvents
+    modCompile fabricApi.module("fabric-lifecycle-events-v1", project.fabric_api_version)
+    include fabricApi.module("fabric-lifecycle-events-v1", project.fabric_api_version)
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,9 @@ mod_version=0.1.1
 maven_group=me.jellysquid.mods
 archives_base_name=sodium-fabric
 
+# Fabric API version
+fabric_api_version=0.31.0+1.16
+
 # If true, third-party mods will be loaded during runtime in the developer run configurations
 use_third_party_mods = true
 databreaker_version = 0.2.6

--- a/src/main/java/me/jellysquid/mods/sodium/client/world/SodiumChunkManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/SodiumChunkManager.java
@@ -4,6 +4,7 @@ import it.unimi.dsi.fastutil.Hash;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.objects.ObjectIterator;
 import me.jellysquid.mods.sodium.client.util.collections.FixedLongHashTable;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientChunkEvents;
 import net.minecraft.client.world.ClientChunkManager;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.nbt.CompoundTag;
@@ -60,6 +61,9 @@ public class SodiumChunkManager extends ClientChunkManager implements ChunkStatu
         if (unloadedChunk != null) {
             this.world.unloadBlockEntities(unloadedChunk);
             this.onChunkUnloaded(x, z);
+
+            // Invoke Fabric API's ClientChunkEvents
+            ClientChunkEvents.CHUNK_UNLOAD.invoker().onChunkUnload(this.world, unloadedChunk);
         }
     }
 
@@ -125,6 +129,9 @@ public class SodiumChunkManager extends ClientChunkManager implements ChunkStatu
 
         // Perform post-load actions and notify the chunk listener that a chunk was just loaded
         this.onChunkLoaded(x, z, chunk);
+
+        // Invoke Fabric API's ClientChunkEvents
+        ClientChunkEvents.CHUNK_LOAD.invoker().onChunkLoad(this.world, chunk);
 
         return chunk;
     }


### PR DESCRIPTION
Invoke chunk load/unload events as Sodium overrides ClientChunkManager with it's own. Fixes #228.