### PR TITLE
new: Add smooth lighting for paintings

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/entity/smooth_lighting/MixinPaintingEntityRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/entity/smooth_lighting/MixinPaintingEntityRenderer.java
@@ -29,7 +29,7 @@ public abstract class MixinPaintingEntityRenderer extends EntityRenderer<Paintin
     }
 
     @Inject(method = "render", at = @At(value = "HEAD"))
-    public void preRender(PaintingEntity paintingEntity, float f, float g, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, CallbackInfo ci){
+    public void preRender(PaintingEntity paintingEntity, float f, float g, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, CallbackInfo ci) {
         this.entity = paintingEntity;
         this.tickDelta = g;
     }
@@ -39,10 +39,10 @@ public abstract class MixinPaintingEntityRenderer extends EntityRenderer<Paintin
      * @reason Redirect Lightmap coord with Sodium's EntityLighter.
      */
     @Redirect(method = "method_4074", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/WorldRenderer;getLightmapCoordinates(Lnet/minecraft/world/BlockRenderView;Lnet/minecraft/util/math/BlockPos;)I"))
-    public int redirectLightmapCoord(BlockRenderView world, BlockPos pos){
+    public int redirectLightmapCoord(BlockRenderView world, BlockPos pos) {
         if (SodiumClientMod.options().quality.smoothLighting == SodiumGameOptions.LightingQuality.HIGH) {
             return EntityLighter.getBlendedLight(this, this.entity, tickDelta);
-        }else{
+        } else {
             return WorldRenderer.getLightmapCoordinates(world, pos);
         }
     }

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/entity/smooth_lighting/MixinPaintingEntityRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/entity/smooth_lighting/MixinPaintingEntityRenderer.java
@@ -1,0 +1,59 @@
+package me.jellysquid.mods.sodium.mixin.features.entity.smooth_lighting;
+
+import me.jellysquid.mods.sodium.client.SodiumClientMod;
+import me.jellysquid.mods.sodium.client.gui.SodiumGameOptions;
+import me.jellysquid.mods.sodium.client.model.light.EntityLighter;
+import me.jellysquid.mods.sodium.client.render.entity.EntityLightSampler;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.WorldRenderer;
+import net.minecraft.client.render.entity.EntityRenderDispatcher;
+import net.minecraft.client.render.entity.EntityRenderer;
+import net.minecraft.client.render.entity.PaintingEntityRenderer;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.decoration.painting.PaintingEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.BlockRenderView;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(PaintingEntityRenderer.class)
+public abstract class MixinPaintingEntityRenderer extends EntityRenderer<PaintingEntity> implements EntityLightSampler<PaintingEntity> {
+    private PaintingEntity entity;
+    private float tickDelta;
+
+    protected MixinPaintingEntityRenderer(EntityRenderDispatcher dispatcher) {
+        super(dispatcher);
+    }
+
+    @Inject(method = "render", at = @At(value = "HEAD"))
+    public void preRender(PaintingEntity paintingEntity, float f, float g, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, CallbackInfo ci){
+        this.entity = paintingEntity;
+        this.tickDelta = g;
+    }
+
+    /**
+     * @author FlashyReese
+     * @reason Redirect Lightmap coord with Sodium's EntityLighter.
+     */
+    @Redirect(method = "method_4074", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/WorldRenderer;getLightmapCoordinates(Lnet/minecraft/world/BlockRenderView;Lnet/minecraft/util/math/BlockPos;)I"))
+    public int redirectLightmapCoord(BlockRenderView world, BlockPos pos){
+        if (SodiumClientMod.options().quality.smoothLighting == SodiumGameOptions.LightingQuality.HIGH) {
+            return EntityLighter.getBlendedLight(this, this.entity, tickDelta);
+        }else{
+            return WorldRenderer.getLightmapCoordinates(world, pos);
+        }
+    }
+
+    @Override
+    public int bridge$getBlockLight(PaintingEntity entity, BlockPos pos) {
+        return this.getBlockLight(entity, pos);
+    }
+
+    @Override
+    public int bridge$getSkyLight(PaintingEntity entity, BlockPos pos) {
+        return this.method_27950(entity, pos);
+    }
+}

--- a/src/main/resources/sodium.mixins.json
+++ b/src/main/resources/sodium.mixins.json
@@ -30,6 +30,7 @@
     "features.entity.fast_render.MixinCuboid",
     "features.entity.fast_render.MixinModelPart",
     "features.entity.smooth_lighting.MixinEntityRenderer",
+    "features.entity.smooth_lighting.MixinPaintingEntityRenderer",
     "features.gui.MixinDebugHud",
     "features.gui.fast_loading_screen.MixinLevelLoadingScreen",
     "features.gui.font.MixinGlyphRenderer",


### PR DESCRIPTION
Painting light is calculated using WorldRenderer#getLightmapCoord unlike traditional Entity Rendering hence it is not covered by the current implementation. This commit calculates the light using Sodium's EntityLighter and redirects it. Fixes #90.

Without
![2021-02-28_23 22 47](https://user-images.githubusercontent.com/30311066/109455352-0bc40200-7a1c-11eb-9897-a233b0fbe199.png)
With
![2021-02-28_23 22 59](https://user-images.githubusercontent.com/30311066/109455362-14b4d380-7a1c-11eb-81de-197f0ee49cbb.png)
