### PR TITLE
Change Block method calls to use BlockState method calls

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/tasks/ChunkRenderRebuildTask.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/tasks/ChunkRenderRebuildTask.java
@@ -83,7 +83,7 @@ public class ChunkRenderRebuildTask<T extends ChunkGraphicsState> extends ChunkR
                     int y = baseY + relY;
                     int z = baseZ + relZ;
 
-                    if (block.getRenderType(blockState) == BlockRenderType.MODEL) {
+                    if (blockState.getRenderType() == BlockRenderType.MODEL) {
                         buffers.setRenderOffset(x - offset.getX(), y - offset.getY(), z - offset.getZ());
 
                         RenderLayer layer = RenderLayers.getBlockLayer(blockState);
@@ -93,7 +93,7 @@ public class ChunkRenderRebuildTask<T extends ChunkGraphicsState> extends ChunkR
                         }
                     }
 
-                    FluidState fluidState = block.getFluidState(blockState);
+                    FluidState fluidState = blockState.getFluidState();
 
                     if (!fluidState.isEmpty()) {
                         buffers.setRenderOffset(x - offset.getX(), y - offset.getY(), z - offset.getZ());


### PR DESCRIPTION
Certain methods in `AbstractBlock` are not meant to be called directly, as shown by their being deprecated. They are meant to be called from a `BlockState`. This wasn't respected in Sodium, and it created an issue with Enhanced Block Entities.