### PR TITLE
fix java 8 bytebuffer error

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/buffer_builder/fast_sort/MixinBufferBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/buffer_builder/fast_sort/MixinBufferBuilder.java
@@ -8,6 +8,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.util.Arrays;
@@ -33,7 +34,7 @@ public class MixinBufferBuilder {
      */
     @Overwrite
     public void sortQuads(float cameraX, float cameraY, float cameraZ) {
-        this.buffer.clear();
+        ((Buffer)this.buffer).clear();
         FloatBuffer floatBuffer = this.buffer.asFloatBuffer();
 
         int vertexStride = this.format.getVertexSize();


### PR DESCRIPTION
fix java.lang.NoSuchMethodError: java.nio.ByteBuffer.clear()Ljava/nio/ByteBuffer; on java 8