### PR TITLE
change: Better configuration handling

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
@@ -3,10 +3,9 @@ package me.jellysquid.mods.sodium.client;
 import me.jellysquid.mods.sodium.client.gui.SodiumGameOptions;
 import me.jellysquid.mods.sodium.client.util.UnsafeUtil;
 import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.loader.api.FabricLoader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
-import java.io.File;
 
 public class SodiumClientMod implements ClientModInitializer {
     private static SodiumGameOptions CONFIG;
@@ -34,7 +33,7 @@ public class SodiumClientMod implements ClientModInitializer {
     }
 
     private static SodiumGameOptions loadConfig() {
-        SodiumGameOptions config = SodiumGameOptions.load(new File("config/sodium-options.json"));
+        SodiumGameOptions config = SodiumGameOptions.load(FabricLoader.getInstance().getConfigDir().resolve("sodium-options.json").normalize());
         onConfigChanged(config);
 
         return config;

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -188,7 +188,7 @@ public class SodiumGameOptions {
     }
 
     public void writeChanges() {
-        Path dir = path.getParent();
+        Path dir = this.path.getParent();
 
         if (!Files.exists(dir)) {
             try {
@@ -201,12 +201,12 @@ public class SodiumGameOptions {
             LOGGER.error("Parent directory \"{}\" is, in fact, not a directory!", dir);
         }
 
-        try (OutputStream os = Files.newOutputStream(path);
+        try (OutputStream os = Files.newOutputStream(this.path);
              OutputStreamWriter osw = new OutputStreamWriter(os);
              BufferedWriter writer = new BufferedWriter(osw)) {
             gson.toJson(this, writer);
         } catch (IOException e) {
-            LOGGER.error("Could not save config file to \"" + path + "\"!", e);
+            LOGGER.error("Could not save config file to \"" + this.path + "\"!", e);
         }
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -221,7 +221,7 @@ public class SodiumGameOptions {
         try {
             Files.move(tempPath, this.path, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
-            LOGGER.error("Failed to move config file \"" + tempPath + "\" into place at \"" + this.path + "!", e);
+            LOGGER.error("Failed to move config file \"" + tempPath + "\" into place at \"" + this.path + "\"!", e);
         }
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -199,6 +199,7 @@ public class SodiumGameOptions {
             }
         } else if (!Files.isDirectory(dir)) {
             LOGGER.error("Parent directory \"{}\" is, in fact, not a directory!", dir);
+            return;
         }
 
         try (OutputStream os = Files.newOutputStream(this.path);

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -147,6 +147,7 @@ public class SodiumGameOptions {
     public static SodiumGameOptions load(Path path) {
         SodiumGameOptions config;
 
+        boolean write = false;
         if (Files.exists(path)) {
             try (InputStream is = Files.newInputStream(path);
                  InputStreamReader isr = new InputStreamReader(is);
@@ -167,16 +168,20 @@ public class SodiumGameOptions {
                 }
                 LOGGER.info("Loading default values");
                 config = new SodiumGameOptions();
+                write = true;
             }
 
             config.sanitize();
         } else {
             LOGGER.info("Could not find options file, loading default values");
             config = new SodiumGameOptions();
+            write = true;
         }
 
         config.path = path;
-        config.writeChanges();
+        if (write) {
+            config.writeChanges();
+        }
 
         return config;
     }

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -14,7 +14,9 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.*;
 import java.lang.reflect.Modifier;
-import java.nio.file.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
@@ -216,25 +218,8 @@ public class SodiumGameOptions {
             return;
         }
 
-        // need to delete file first, since we can't rely on ATOMIC_MOVE replacing existing files
         try {
-            Files.delete(this.path);
-        } catch (NoSuchFileException ignored) {
-        } catch (IOException e) {
-            LOGGER.error("Failed to delete current config file \"" + this.path +
-                    "\" to replace it with new config file\"" + tempPath + "\"!", e);
-            return;
-        }
-
-        try {
-            Files.move(tempPath, this.path, StandardCopyOption.ATOMIC_MOVE);
-        } catch (AtomicMoveNotSupportedException e) {
-            LOGGER.warn("Atomic move is not supported, trying without it", e);
-            try {
-                Files.move(tempPath, this.path);
-            } catch (IOException e2) {
-                LOGGER.error("Failed to move config file \"" + tempPath + "\" into place at \"" + this.path + "!", e2);
-            }
+            Files.move(tempPath, this.path, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
             LOGGER.error("Failed to move config file \"" + tempPath + "\" into place at \"" + this.path + "!", e);
         }

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -9,7 +9,6 @@ import me.jellysquid.mods.sodium.client.render.chunk.backends.gl20.GL20ChunkRend
 import me.jellysquid.mods.sodium.client.render.chunk.backends.gl30.GL30ChunkRenderBackend;
 import me.jellysquid.mods.sodium.client.render.chunk.backends.gl43.GL43ChunkRenderBackend;
 import net.minecraft.client.options.GraphicsMode;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.*;
@@ -23,7 +22,7 @@ import java.util.Arrays;
 import java.util.stream.Stream;
 
 public class SodiumGameOptions {
-    private static final Logger LOGGER = LogManager.getLogger("Sodium|GameOptions");
+    private static final Logger LOGGER = SodiumClientMod.logger();
 
     public final QualitySettings quality = new QualitySettings();
     public final AdvancedSettings advanced = new AdvancedSettings();

--- a/src/main/java/me/jellysquid/mods/sodium/common/config/ForcedOption.java
+++ b/src/main/java/me/jellysquid/mods/sodium/common/config/ForcedOption.java
@@ -1,0 +1,25 @@
+package me.jellysquid.mods.sodium.common.config;
+
+import me.jellysquid.mods.sodium.client.SodiumClientMod;
+
+/**
+ * An {@link Option} that's always enabled, ignoring user configuration or any mod overrides.
+ */
+public class ForcedOption extends Option {
+    public ForcedOption(String name) {
+        super(name, true, false);
+    }
+
+    @Override
+    public void setEnabled(boolean enabled, boolean userDefined) {
+        if (userDefined)
+            SodiumClientMod.logger().warn("User tried to {} forced configuration option \"{}\", ignoring",
+                    enabled ? "enable" : "disable", getName());
+    }
+
+    @Override
+    public void addModOverride(boolean enabled, String modId) {
+        SodiumClientMod.logger().warn("Mod {} tried to {} forced configuration option \"{}\", ignoring",
+                modId, enabled ? "enable" : "disable", getName());
+    }
+}

--- a/src/main/java/me/jellysquid/mods/sodium/common/config/SodiumConfig.java
+++ b/src/main/java/me/jellysquid/mods/sodium/common/config/SodiumConfig.java
@@ -227,11 +227,10 @@ public class SodiumConfig {
             try {
                 Files.createDirectories(dir);
             } catch (IOException e) {
-                LOGGER.error("Could not create parent directories for \"" + dir + "\"!", e);
-                return;
+                throw new IOException("Could not create parent directories for \"" + dir + "\"!", e);
             }
         } else if (!Files.isDirectory(dir)) {
-            LOGGER.error("Parent directory \"{}\" is, in fact, not a directory!", dir);
+            throw new IOException("Parent directory \"" + dir + "\" is, in fact, not a directory!");
         }
 
         try (OutputStream os = Files.newOutputStream(path);

--- a/src/main/java/me/jellysquid/mods/sodium/common/config/SodiumConfig.java
+++ b/src/main/java/me/jellysquid/mods/sodium/common/config/SodiumConfig.java
@@ -218,10 +218,20 @@ public class SodiumConfig {
                 LOGGER.error("Failed to back up config to \"" + backupPath + "\"!", be);
             }
 
+            boolean tempSuccess = true;
+            Path tempPath = PathUtil.resolveTimestampedSibling(path, "TEMP");
             try {
-                writeDefaultConfig(path);
-            } catch (IOException e2) {
-                LOGGER.error("Could not write default configuration file to \"" + path + "\"!", e2);
+                writeDefaultConfig(tempPath);
+            } catch (IOException te) {
+                LOGGER.error("Could not write default configuration file to \"" + path + "\"!", te);
+                tempSuccess = false;
+            }
+            if (tempSuccess) {
+                try {
+                    Files.move(tempPath, path, StandardCopyOption.REPLACE_EXISTING);
+                } catch (IOException te) {
+                    LOGGER.error("Failed to move config file \"" + tempPath + "\" into place at \"" + path + "\"!", te);
+                }
             }
         }
 

--- a/src/main/java/me/jellysquid/mods/sodium/common/config/SodiumConfig.java
+++ b/src/main/java/me/jellysquid/mods/sodium/common/config/SodiumConfig.java
@@ -12,8 +12,6 @@ import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;

--- a/src/main/java/me/jellysquid/mods/sodium/common/config/SodiumConfig.java
+++ b/src/main/java/me/jellysquid/mods/sodium/common/config/SodiumConfig.java
@@ -28,7 +28,7 @@ public class SodiumConfig {
     private SodiumConfig() {
         // Defines the default rules which can be configured by the user or other mods.
         // You must manually add a rule for any new mixins not covered by an existing package rule.
-        this.addMixinRule("core", true); // TODO: Don't actually allow the user to disable this
+        this.addForcedMixinRule("core");
 
         this.addMixinRule("features.block", true);
         this.addMixinRule("features.buffer_builder", true);
@@ -65,6 +65,19 @@ public class SodiumConfig {
         String name = getMixinRuleName(mixin);
 
         if (this.options.putIfAbsent(name, new Option(name, enabled, false)) != null) {
+            throw new IllegalStateException("Mixin rule already defined: " + mixin);
+        }
+    }
+
+    /**
+     * Defines a Mixin rule which is always enabled and <em>cannot</em> be configured by users and other mods.
+     * @throws IllegalStateException If a rule with that name already exists
+     * @param mixin The name of the mixin package which will be controlled by this rule
+     */
+    private void addForcedMixinRule(String mixin) {
+        String name = getMixinRuleName(mixin);
+
+        if (this.options.putIfAbsent(name, new ForcedOption(name)) != null) {
             throw new IllegalStateException("Mixin rule already defined: " + mixin);
         }
     }

--- a/src/main/java/me/jellysquid/mods/sodium/common/config/SodiumConfig.java
+++ b/src/main/java/me/jellysquid/mods/sodium/common/config/SodiumConfig.java
@@ -9,9 +9,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.*;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
+import java.nio.file.*;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -198,12 +196,19 @@ public class SodiumConfig {
             props.load(fin);
         } catch (IOException e) {
             LOGGER.error("Could not load config file from \"" + path + "\"! Loading default values", e);
+
             Path backupPath = PathUtil.resolveTimestampedSibling(path, "BACKUP");
             LOGGER.info("Backing up config to \"{}\"...", backupPath.toString());
             try {
                 Files.move(path, backupPath, StandardCopyOption.REPLACE_EXISTING);
             } catch (IOException be) {
-                LOGGER.error("Failed to back up config!", be);
+                LOGGER.error("Failed to back up config to \"" + backupPath + "\"!", be);
+            }
+
+            try {
+                writeDefaultConfig(path);
+            } catch (IOException e2) {
+                LOGGER.error("Could not write default configuration file to \"" + path + "\"!", e2);
             }
         }
 

--- a/src/main/java/me/jellysquid/mods/sodium/common/util/PathUtil.java
+++ b/src/main/java/me/jellysquid/mods/sodium/common/util/PathUtil.java
@@ -10,33 +10,34 @@ import static java.time.temporal.ChronoField.*;
 
 public class PathUtil {
     /**
-     * A variant of {@link DateTimeFormatter#ISO_LOCAL_DATE_TIME} that is safe for file names (IE doesn't contain colons).
+     * A variant of {@link DateTimeFormatter#ISO_LOCAL_DATE_TIME} that is:
+     * - Safe for file names (IE doesn't contain colons).
+     * - More compact (uses {@link DateTimeFormatter#BASIC_ISO_DATE}'s format for date component and a similar format for time component).
      */
     private static final DateTimeFormatter ISO_LOCAL_DATE_TIME_SAFE = new DateTimeFormatterBuilder()
             .parseCaseInsensitive().parseStrict()
-            .append(DateTimeFormatter.ISO_LOCAL_DATE)
+            .appendValue(YEAR, 4)
+            .appendValue(MONTH_OF_YEAR, 2)
+            .appendValue(DAY_OF_MONTH, 2)
             .appendLiteral('T')
             .appendValue(HOUR_OF_DAY, 2)
-            .appendLiteral('-')
             .appendValue(MINUTE_OF_HOUR, 2)
             .optionalStart()
-            .appendLiteral('-')
             .appendValue(SECOND_OF_MINUTE, 2)
             .optionalStart()
-            .appendFraction(NANO_OF_SECOND, 0, 9, true)
+            .appendLiteral('N')
+            .appendFraction(NANO_OF_SECOND, 0, 9, false)
             .toFormatter(Locale.ROOT);
 
     /**
-     * Resolves a timestamped sibling of the base path - {@code "{base_dir}/{base_name}_{tag}_{timestamp}.{base_ext}"}.
+     * Resolves a timestamped sibling of the base path - {@code "{base}-{tag}-{timestamp}"}.
      * @param base Base path
      * @param tag Tag to add to sibling's name
      * @return Sibling path
      */
     public static Path resolveTimestampedSibling(Path base, String tag) {
-        LocalDateTime now = LocalDateTime.now();
-        String backupName = base.getFileName().toString();
-        backupName = backupName.substring(0, backupName.lastIndexOf('.') - 1);
-        backupName += "_" + tag + "_" + now.format(ISO_LOCAL_DATE_TIME_SAFE) + ".json";
-        return base.resolveSibling(backupName);
+        return base.resolveSibling(base.getFileName().toString()
+                + "-" + tag
+                + "-" + LocalDateTime.now().format(ISO_LOCAL_DATE_TIME_SAFE));
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/common/util/PathUtil.java
+++ b/src/main/java/me/jellysquid/mods/sodium/common/util/PathUtil.java
@@ -1,0 +1,15 @@
+package me.jellysquid.mods.sodium.common.util;
+
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class PathUtil {
+    public static Path resolveTimestampedSibling(Path base, String tag) {
+        LocalDateTime now = LocalDateTime.now();
+        String backupName = base.getFileName().toString();
+        backupName = backupName.substring(0, backupName.lastIndexOf('.') - 1);
+        backupName += "_" + tag + "_" + now.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) + ".json";
+        return base.resolveSibling(backupName);
+    }
+}

--- a/src/main/java/me/jellysquid/mods/sodium/common/util/PathUtil.java
+++ b/src/main/java/me/jellysquid/mods/sodium/common/util/PathUtil.java
@@ -3,8 +3,29 @@ package me.jellysquid.mods.sodium.common.util;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.Locale;
+
+import static java.time.temporal.ChronoField.*;
 
 public class PathUtil {
+    /**
+     * A variant of {@link DateTimeFormatter#ISO_LOCAL_DATE_TIME} that is safe for file names (IE doesn't contain colons).
+     */
+    private static final DateTimeFormatter ISO_LOCAL_DATE_TIME_SAFE = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive().parseStrict()
+            .append(DateTimeFormatter.ISO_LOCAL_DATE)
+            .appendLiteral('T')
+            .appendValue(HOUR_OF_DAY, 2)
+            .appendLiteral('-')
+            .appendValue(MINUTE_OF_HOUR, 2)
+            .optionalStart()
+            .appendLiteral('-')
+            .appendValue(SECOND_OF_MINUTE, 2)
+            .optionalStart()
+            .appendFraction(NANO_OF_SECOND, 0, 9, true)
+            .toFormatter(Locale.ROOT);
+
     /**
      * Resolves a timestamped sibling of the base path - {@code "{base_dir}/{base_name}_{tag}_{timestamp}.{base_ext}"}.
      * @param base Base path
@@ -15,7 +36,7 @@ public class PathUtil {
         LocalDateTime now = LocalDateTime.now();
         String backupName = base.getFileName().toString();
         backupName = backupName.substring(0, backupName.lastIndexOf('.') - 1);
-        backupName += "_" + tag + "_" + now.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) + ".json";
+        backupName += "_" + tag + "_" + now.format(ISO_LOCAL_DATE_TIME_SAFE) + ".json";
         return base.resolveSibling(backupName);
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/common/util/PathUtil.java
+++ b/src/main/java/me/jellysquid/mods/sodium/common/util/PathUtil.java
@@ -5,6 +5,12 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 public class PathUtil {
+    /**
+     * Resolves a timestamped sibling of the base path - {@code "{base_dir}/{base_name}_{tag}_{timestamp}.{base_ext}"}.
+     * @param base Base path
+     * @param tag Tag to add to sibling's name
+     * @return Sibling path
+     */
     public static Path resolveTimestampedSibling(Path base, String tag) {
         LocalDateTime now = LocalDateTime.now();
         String backupName = base.getFileName().toString();

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/SodiumMixinPlugin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/SodiumMixinPlugin.java
@@ -2,13 +2,13 @@ package me.jellysquid.mods.sodium.mixin;
 
 import me.jellysquid.mods.sodium.common.config.Option;
 import me.jellysquid.mods.sodium.common.config.SodiumConfig;
+import net.fabricmc.loader.api.FabricLoader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.objectweb.asm.tree.ClassNode;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
 import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 
-import java.io.File;
 import java.util.List;
 import java.util.Set;
 
@@ -22,9 +22,9 @@ public class SodiumMixinPlugin implements IMixinConfigPlugin {
     @Override
     public void onLoad(String mixinPackage) {
         try {
-            this.config = SodiumConfig.load(new File("./config/sodium-mixins.properties"));
+            this.config = SodiumConfig.load(FabricLoader.getInstance().getConfigDir().resolve("sodium-mixins.properties").normalize());
         } catch (Exception e) {
-            throw new RuntimeException("Could not load configuration file for Sodium", e);
+            logger.error("Could not load configuration file for Sodium", e);
         }
 
         this.logger.info("Loaded configuration file for Sodium: {} options available, {} override(s) found",


### PR DESCRIPTION
- Corrupt config files will be replaced with a copy of the default values.
  - The corrupt file will be backed up for inspection.
  - The game will still crash, just to give people a heads-up that their config's hosed and has been replaced.
- Changed the way in-game options are saved to the file. This *should* fix the "corrupt config" bug.
  - More specifically, the new file is written to a temporary file, and then that temporary file is moved into the original file's place.
- The `core` mixin package can no longer be disabled.
- I/O now uses NIO `Path`s, because they're cool