### PR TITLE
change: Allow overwrites to apply to access widened methods

### DIFF
--- a/src/main/resources/sodium.mixins.json
+++ b/src/main/resources/sodium.mixins.json
@@ -6,6 +6,9 @@
   "injectors": {
     "defaultRequire": 1
   },
+  "overwrites": {
+    "conformVisibility": true
+  },
   "client": [
     "core.frustum.MixinFrustum",
     "core.matrix.MixinMatrix3f",


### PR DESCRIPTION
Applies the accepted proposal in #445, which should occasionally help mod compatibility.
I've confirmed it fixed the crash with Fabrication 1.2.5, before the author worked around the issue. This type of crash has also been reported in #385 (with geckolib, which seems to have also worked around the issue by now).

I'm not aware of any mod currently affected by this, but it still seems sensible to apply the change.