### PR TITLE
Fix marker armorstand lighting

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/model/light/EntityLighter.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/model/light/EntityLighter.java
@@ -1,5 +1,6 @@
 package me.jellysquid.mods.sodium.client.model.light;
 
+import me.jellysquid.mods.sodium.client.render.entity.EntityExtended;
 import me.jellysquid.mods.sodium.client.render.entity.EntityLightSampler;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
@@ -23,8 +24,8 @@ public class EntityLighter {
         // Bounding boxes with no volume cause issues, ensure they're non-zero
         // Notably, armor stands in "Marker" mode decide this is a cute thing to do
         // https://github.com/jellysquid3/sodium-fabric/issues/60
-        double width = Math.max(entity.getWidth(), MIN_BOX_SIZE);
-        double height = Math.max(entity.getHeight(), MIN_BOX_SIZE);
+        double width = Math.max(((EntityExtended) entity).getLitWidth(), MIN_BOX_SIZE);
+        double height = Math.max(((EntityExtended) entity).getLitHeight(), MIN_BOX_SIZE);
 
         double x2 = x1 + width;
         double y2 = y1 + height;

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/entity/EntityExtended.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/entity/EntityExtended.java
@@ -1,0 +1,7 @@
+package me.jellysquid.mods.sodium.client.render.entity;
+
+public interface EntityExtended {
+    float getLitWidth();
+
+    float getLitHeight();
+}

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/entity/smooth_lighting/MixinArmorStandEntity.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/entity/smooth_lighting/MixinArmorStandEntity.java
@@ -1,0 +1,34 @@
+package me.jellysquid.mods.sodium.mixin.features.entity.smooth_lighting;
+
+import me.jellysquid.mods.sodium.client.render.entity.EntityExtended;
+import net.minecraft.entity.EntityDimensions;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.decoration.ArmorStandEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ArmorStandEntity.class)
+public abstract class MixinArmorStandEntity implements EntityExtended {
+    private EntityDimensions nonMarkerDimensions = EntityType.ARMOR_STAND.getDimensions();
+
+    @Shadow
+    protected abstract EntityDimensions method_31168(boolean marker);
+
+    @Inject(method = "calculateDimensions", at = @At("TAIL"))
+    public void postCalculateDimensions(CallbackInfo ci) {
+        this.nonMarkerDimensions = this.method_31168(false);
+    }
+
+    @Override
+    public float getLitWidth() {
+        return this.nonMarkerDimensions.width;
+    }
+
+    @Override
+    public float getLitHeight() {
+        return this.nonMarkerDimensions.height;
+    }
+}

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/entity/smooth_lighting/MixinEntity.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/entity/smooth_lighting/MixinEntity.java
@@ -1,0 +1,25 @@
+package me.jellysquid.mods.sodium.mixin.features.entity.smooth_lighting;
+
+import me.jellysquid.mods.sodium.client.render.entity.EntityExtended;
+import net.minecraft.entity.Entity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(Entity.class)
+public abstract class MixinEntity implements EntityExtended {
+    @Shadow
+    protected abstract float getWidth();
+
+    @Shadow
+    protected abstract float getHeight();
+
+    @Override
+    public float getLitWidth() {
+        return this.getWidth();
+    }
+
+    @Override
+    public float getLitHeight() {
+        return this.getHeight();
+    }
+}

--- a/src/main/resources/sodium.mixins.json
+++ b/src/main/resources/sodium.mixins.json
@@ -32,6 +32,8 @@
     "features.debug.MixinDebugHud",
     "features.entity.fast_render.MixinCuboid",
     "features.entity.fast_render.MixinModelPart",
+    "features.entity.smooth_lighting.MixinArmorStandEntity",
+    "features.entity.smooth_lighting.MixinEntity",
     "features.entity.smooth_lighting.MixinEntityRenderer",
     "features.entity.smooth_lighting.MixinPaintingEntityRenderer",
     "features.gui.MixinDebugHud",


### PR DESCRIPTION
This PR resolves #68 by correcting the entity dimensions used for the smooth lighting computation done for marker armor stands.

Normally, armor stands use their non-marker equivalent dimensions and select the greatest light value, however smooth entity lighting (i.e. [EntityLighter](https://github.com/CaffeineMC/sodium-fabric/blob/2fb1d28aa61680170e44a138c296f3b5534314e0/src/main/java/me/jellysquid/mods/sodium/client/model/light/EntityLighter.java)) foregoes entity-specific logic. To account for this special case the light value interpolation has been left as is to maintain smooth lighting however, done so over the proper blocks.