### PR TITLE
Update Loom Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.5.28'
+    id 'fabric-loom' version '0.6-SNAPSHOT'
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
Mods don't seem to build anymore on loom 0.5, so I updated it to 0.6. PRs coming on Lithium, Phosphor and Hydrogen soon™️.