### PR TITLE
fix: Validate chunk section Y axis upon retrieving ChunkRenderContainer

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderColumn.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderColumn.java
@@ -30,6 +30,9 @@ public class ChunkRenderColumn {
     }
 
     public ChunkRenderContainer getRender(int y) {
+        if (y < 0 || y >= this.renders.length) {
+            return null;
+        }
         return this.renders[y];
     }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager.java
@@ -227,10 +227,6 @@ public class ChunkRenderManager implements ChunkStatusListener {
     }
 
     public ChunkRenderContainer getRender(int x, int y, int z) {
-        if (y < 0 || y >= 16) {
-            return null;
-        }
-
         ChunkRenderColumn column = this.columns.get(ChunkPos.toLong(x, z));
 
         if (column == null) {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager.java
@@ -227,6 +227,10 @@ public class ChunkRenderManager implements ChunkStatusListener {
     }
 
     public ChunkRenderContainer getRender(int x, int y, int z) {
+        if (y < 0 || y >= 16) {
+            return null;
+        }
+
         ChunkRenderColumn column = this.columns.get(ChunkPos.toLong(x, z));
 
         if (column == null) {
@@ -471,10 +475,6 @@ public class ChunkRenderManager implements ChunkStatusListener {
     }
 
     public void scheduleRebuild(int x, int y, int z, boolean important) {
-        if (y < 0 || y >= 16) {
-            return;
-        }
-
         ChunkRenderContainer render = this.getRender(x, y, z);
 
         if (render != null) {


### PR DESCRIPTION
Fixes #587, the issue was present on https://github.com/CaffeineMC/sodium-fabric/commit/de545a500a31f96b5caf7f698a38902945e70f2e. The `ChunkRenderManager#isChunkVisible` was modified using the new `ChunkGraphCuller#isSectionVisible`  requiring a ChunkRenderContainer ID. Upon retrieving the `ChunkRenderContainer` with `ChunkRenderManager#getRender`, Sodium does not verify chunk section Y axis.