### PR TITLE
Remove `vendor` property from build.gradle, allowing sodium to be bui…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,6 @@ java {
 
     toolchain {
         languageVersion = JavaLanguageVersion.of(8)
-        vendor = JvmVendorSpec.ADOPTOPENJDK
     }
 }
 


### PR DESCRIPTION
…lt with jdk's other than those from Adoptopenjdk