### PR TITLE
fix: Use default value when block state palette entry is missing

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
@@ -261,6 +261,9 @@ public class WorldSlice extends ReusableObject implements BlockRenderView, Biome
                         state = prevPaletteState;
                     } else {
                         state = palette.getByIndex(paletteId);
+                        if (state == null) {
+                            state = container.defaultValue;
+                        }
 
                         prevPaletteState = state;
                         prevPaletteId = paletteId;

--- a/src/main/resources/sodium.accesswidener
+++ b/src/main/resources/sodium.accesswidener
@@ -9,3 +9,4 @@ accessible method net/minecraft/client/render/Frustum isVisible (DDDDDD)Z
 
 accessible field net/minecraft/world/chunk/PalettedContainer data Lnet/minecraft/util/collection/PackedIntegerArray;
 accessible field net/minecraft/world/chunk/PalettedContainer palette Lnet/minecraft/world/chunk/Palette;
+accessible field net/minecraft/world/chunk/PalettedContainer defaultValue Ljava/lang/Object;


### PR DESCRIPTION
This mirrors vanilla behavior (see `PalettedContainer.get(index)`).

Fixes #565

Not entirely sure why the `paletteId` was invalid in the first place (in my case, playing on wynncraft.com, probably an artifact of multi-version support or other server-side shenanigans) but Vanilla (and Sodium 0.1.0) can deal with those just fine.
The freezing mentioned in the issue is because the main thread gets stuck waiting for important chunk updates after all chunk worker threads have died from NPEs in random places.