### PR TITLE
fix: `capacity` not updated after `ChunkDrawParamsVector.growBuffer`

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/multidraw/ChunkDrawParamsVector.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/multidraw/ChunkDrawParamsVector.java
@@ -103,6 +103,13 @@ public abstract class ChunkDrawParamsVector extends StructBuffer {
         }
 
         @Override
+        protected void growBuffer() {
+            super.growBuffer();
+
+            this.onBufferChanged();
+        }
+
+        @Override
         public void reset() {
             this.writeOffset = 0;
         }


### PR DESCRIPTION
In `pushChunkDrawParams` the need to grow the buffer is determined by comparing the write offset to the `capacity`
field. But after the buffer had been grown, the `capacity` field had been left unchanged, thereby triggering another
grow on each call to `pushChunkDrawParams`, quickly running out of memory.

Looks like this was just forgotten about cause `onBufferChanged` already exists and `growBuffer` is already overwritten in the Unsafe version (which I'd guess most people are using).

I ran across this when disabling `Use Memory Intrinsics` (so it'll use NIO rather than Unsafe) at high render distance (so the initial buffer is too small), while trying to track down another issue.