### PR TITLE
fix: Buffer overflow in `UnsafeChunkDrawCallVector`

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/multidraw/ChunkDrawParamsVector.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/multidraw/ChunkDrawParamsVector.java
@@ -72,7 +72,7 @@ public abstract class ChunkDrawParamsVector extends StructBuffer {
 
         private void updatePointers(long offset) {
             this.writeBase = MemoryUtil.memAddress(this.buffer);
-            this.writeEnd = this.writePointer + this.buffer.capacity();
+            this.writeEnd = this.writeBase + this.buffer.capacity();
 
             this.writePointer = this.writeBase + offset;
         }


### PR DESCRIPTION
The `writeEnd` variable used to be set relative to the write pointer, not relative start of the buffer.
This resulted in a `writeEnd` value which was far too large, allowing the buffer to overflow beyond its allocated space
and into random memory, corrupting everything in its way with all the unpredictable doom one would expect from that.

Spent about five hours tracking this down. Really didn't help that in my case it appears that the thing being corrupted was Mesa / the userland part of amdgpu, leading to reliable GPU lockups (requiring an X server restart and in rare cases a hard reboot).

<details>
<summary>Notes I took while tracking this down, in case anyone cares about the exact symptoms I got</summary>

- Bisected to de545a5 
- Occurs at around 16600+-200 sections being rendered: https://i.johni0702.de/faJ9C.png
- Same with compact vertex format: https://i.johni0702.de/XEO4r.png
- Same when FOV is larger (so it's not just a distant chunk triggering it): https://i.johni0702.de/3QVKM.png
- Same when looking in different direction; for last few frames, new (?) chunks appear at the wrong location: https://i.johni0702.de/ZU9y9.png
- When slowly turning, can get the sections loaded to far above 16k and the sections rendered significantly above as well; also note that some of the most distant chunks are only CUTOUT, i.e. SOLID is probably as above: https://i.johni0702.de/IT240.png
- Same with chunk region size decreased to 1x1x1: https://i.johni0702.de/7G0jo.png
- Does not happen with oneshot (GL3) renderer.
- Does not happen when removing glMultiDrawArraysIndirect call.
- Only rendering the first section in each region either fixes or significantly delays the issue: https://i.johni0702.de/WjlZn.png
- Truncating chunk buffer to be empty (`BufferSlice.unpackLength(part)` -> `0`) still triggers issue: https://i.johni0702.de/W8ogm.png
- Same when rendering with first, count, baseInstance and instanceCount all set to 0: https://i.johni0702.de/65bAM.png
- Does not happen with "Use Memory Intrinsics" disabled.

</details>