### PR TITLE
fix: Allocate an extra vertex in ensureBufferCapacity to match vanilla

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/pipeline/MixinBufferBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/pipeline/MixinBufferBuilder.java
@@ -43,6 +43,8 @@ public abstract class MixinBufferBuilder implements VertexBufferView, VertexDrai
 
     @Override
     public boolean ensureBufferCapacity(int bytes) {
+        // Ensure that there is always space for 1 more vertex; see BufferBuilder.next()
+        bytes += format.getVertexSize();
         if (this.elementOffset + bytes <= this.buffer.capacity()) {
             return false;
         }

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/pipeline/MixinBufferBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/pipeline/MixinBufferBuilder.java
@@ -45,6 +45,7 @@ public abstract class MixinBufferBuilder implements VertexBufferView, VertexDrai
     public boolean ensureBufferCapacity(int bytes) {
         // Ensure that there is always space for 1 more vertex; see BufferBuilder.next()
         bytes += format.getVertexSize();
+
         if (this.elementOffset + bytes <= this.buffer.capacity()) {
             return false;
         }


### PR DESCRIPTION
Vanilla rendering code always ensures that there is space for 1 vertex left in vertex buffers, in `BufferBuilder.next()`, but Sodium VertexSinks do this growth check before appending vertices, without leaving space that may be necessary in code that uses VertexConsumers. This causes issues in places where buffers appended to by a Sodium VertexSink is later used by VertexConsumer code, especially with Sodium's intrinsics mixins (e.g. MixinGlyphRenderer).

This issue was first reported as #218. In this instance, a crash occurs when Sodium's glyph rendering optimisation interacts with the existing GlyphRenderer `drawRectangle` method. As the entity fallback vertex buffer that is being written into starts at a capacity of 1024 bytes, it only takes a few entity name tags to reach the limit of the buffer. In MixinGlyphRenderer, the draw `@Overwrite` mixin replaces the VertexConsumer calls used for glyph rendering with the following VertexSink calls:

```java
drain.ensureCapacity(4);
drain.writeGlyph(matrix, x1 + w1, h1, 0.0F, color, this.uMin, this.vMin, light);
drain.writeGlyph(matrix, x1 + w2, h2, 0.0F, color, this.uMin, this.vMax, light);
drain.writeGlyph(matrix, x2 + w2, h2, 0.0F, color, this.uMax, this.vMax, light);
drain.writeGlyph(matrix, x2 + w1, h1, 0.0F, color, this.uMax, this.vMin, light);
```

This allocates space for 4 vertices in the buffer. However, the next section of code that is run as part of the `drawRectangle` method in GlyphRenderer does not ensure capacity for vertices upfront, instead doing so for 1 vertex after writing a vertex - which leaves space for the next vertex:

```java
vertexConsumer.vertex(matrix, rectangle.xMin, rectangle.yMin, rectangle.zIndex).color(rectangle.red, rectangle.green, rectangle.blue, rectangle.alpha).texture(this.uMin, this.vMin).light(light)
	.next(); // Calls BufferBuilder.grow()
```

When there is *only* enough space for the glyph vertices, the VertexConsumer calls fail with an IndexOutOfBoundsException.

I felt like this should occur more often and in other parts of rendering code, as Sodium VertexSink calls usually use the same buffers as VertexConsumer calls! It turns out, there are several reasons as to why this is so rare:

1. Some rendering paths are completely overwritten by Sodium, so vanilla VertexConsumer code doesn't interact with it.
2. Many buffers start off quite large, and the first time `BufferBuilder.grow()` expands buffers they become ~2MB, so grows don't happen often.
3. Immediately drawn buffers using Tessellator are uploaded to the GPU long before reaching the buffer limit.
4. Once a buffer is grown, it stays that way for the entire runtime of the game, so the crash can depend on the order in which objects are rendered.

To determine if this issue also affects entity rendering (through the MixinModelPart optimisation), I developed a small proof of concept derived from the [Fabric Wiki Entity tutorial](https://fabricmc.net/wiki/tutorial:entity), with the CubeEntityModel `render` method replaced with the following:

```java
// Render a random square
vertices.vertex(0, 0, 0).color(red, green, blue, alpha).texture(0, 0).overlay(overlay).light(light).normal(0, 0, 0).next();
vertices.vertex(1, 0, 0).color(red, green, blue, alpha).texture(0, 0).overlay(overlay).light(light).normal(1, 0, 0).next();
vertices.vertex(1, 1, 0).color(red, green, blue, alpha).texture(0, 0).overlay(overlay).light(light).normal(1, 1, 0).next();
vertices.vertex(0, 1, 0).color(red, green, blue, alpha).texture(0, 0).overlay(overlay).light(light).normal(0, 1, 0).next();

// Render a cube
base.render(matrices, vertices, light, overlay);

// Try to render another square
vertices.vertex(0, 0, 0).color(red, green, blue, alpha)
	.texture(0, 0) // <-- Explodes here!
	.overlay(overlay).light(light).normal(0, 0, 0);
vertices.vertex(1, 0, 0).color(red, green, blue, alpha).texture(0, 0).overlay(overlay).light(light).normal(1, 0, 0).next();
vertices.vertex(1, 1, 0).color(red, green, blue, alpha).texture(0, 0).overlay(overlay).light(light).normal(1, 1, 0).next();
vertices.vertex(0, 1, 0).color(red, green, blue, alpha).texture(0, 0).overlay(overlay).light(light).normal(0, 1, 0).next();
```

For the reasons described above, this only causes a crash reliably when in a flat world with low render distance and after restarting the game, to ensure that it is the first entity being rendered into the buffer. The square rendered beforehand is necessary to ensure that the ModelPart is rendered close to the end of the 1024 byte buffer, otherwise the square afterwards will successfully grow the buffer.

My fix is simply to ensure that an extra vertex of space is allocated in `core.pipeline.MixinBufferBuilder`, which matches vanilla uses of BufferBuilder for Sodium's VertexSink abstraction. It may be preferable to change all uses of `ensureCapacity` instead, though this would also affect the VertexBufferBuilder used internally by Sodium and not touched by vanilla VertexConsumer code.

Fixes #218.