### PR TITLE
fix: Propagate exceptions from chunk build tasks to the main thread

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuilder.java
@@ -343,20 +343,18 @@ public class ChunkBuilder {
                 }
 
                 ChunkBuildResult result;
+
                 try {
                     // Perform the build task with this worker's local resources and obtain the result
                     result = job.task.performBuild(this.pipeline, this.bufferCache, job);
                 } catch (Exception e) {
-                    // Release resources attached to the failed task
-                    job.task.releaseResources();
-
                     // Propagate any exception from chunk building
                     job.future.completeExceptionally(e);
                     continue;
+                } finally {
+                    // After the task has executed, it's safe to release any resources attached to the task
+                    job.task.releaseResources();
                 }
-
-                // After the result has been obtained, it's safe to release any resources attached to the task
-                job.task.releaseResources();
 
                 // The result can be null if the task is cancelled
                 if (result != null) {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuilder.java
@@ -342,8 +342,18 @@ public class ChunkBuilder {
                     continue;
                 }
 
-                // Perform the build task with this worker's local resources and obtain the result
-                ChunkBuildResult result = job.task.performBuild(this.pipeline, this.bufferCache, job);
+                ChunkBuildResult result;
+                try {
+                    // Perform the build task with this worker's local resources and obtain the result
+                    result = job.task.performBuild(this.pipeline, this.bufferCache, job);
+                } catch (Exception e) {
+                    // Release resources attached to the failed task
+                    job.task.releaseResources();
+
+                    // Propagate any exception from chunk building
+                    job.future.completeExceptionally(e);
+                    continue;
+                }
 
                 // After the result has been obtained, it's safe to release any resources attached to the task
                 job.task.releaseResources();


### PR DESCRIPTION
Chunk build tasks in Sodium can throw due to issues with mods or bugs in chunk building, so exceptions from these cause the chunk task threads to exit. This causes the main thread to hang in `ChunkRenderManager.updateChunks` waiting for completed build tasks, without creating a crash report for the user to submit.

This change adds a catch-all exception handler around chunk build task execution, which propagates the exception so that it is re-thrown in `FutureDequeDrain.next()` and generates a crash report on the main thread.