### PR TITLE
fix: Use auto GUI scale as GUI scale limit (#259)

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -68,7 +68,9 @@ public class SodiumGameOptionPages {
                         .setName("GUI Scale")
                         .setTooltip("Sets the maximum scale factor to be used for the user interface. If 'auto' is used, then the largest scale factor " +
                                 "will always be used.")
-                        .setControl(option -> new SliderControl(option, 0, 4, 1, ControlValueFormatter.guiScale()))
+                        .setControl(option -> new SliderControl(option, 0, MinecraftClient.getInstance().getWindow().
+                                calculateScaleFactor(0, MinecraftClient.getInstance().forcesUnicodeFont()), 1,
+                                ControlValueFormatter.guiScale()))
                         .setBinding((opts, value) -> {
                             opts.guiScale = value;
 


### PR DESCRIPTION
Instead of using a fixed value of 4 for the maximum GUI scale in the Sodium options page, the auto GUI scale (largest calculated size) will be used. 

Allowing the GUI scale to extend above 4 is helpful on high-dpi displays, where significantly larger GUI scales are necessary to match the physical size of equivalent low-dpi displays. 

This matches vanilla behavior and fixes #259.

Original work by @Bytzo (closed pr #390), updated for Sodium-next by @MeeniMc