### PR TITLE
fix: Don't use potentially outdated occlusion data for chunk rebuilds

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager.java
@@ -477,8 +477,14 @@ public class ChunkRenderManager implements ChunkStatusListener {
             // Nearby chunks are always rendered immediately
             important = important || this.isChunkPrioritized(render);
 
-            // Only enqueue chunks for updates during the next frame if it is visible and wasn't already dirty
-            if (render.scheduleRebuild(important) && this.culler.isSectionVisible(render.getId())) {
+            // Only enqueue chunks for updates if they aren't already enqueued for an update
+            //
+            // We should avoid rebuilding chunks that aren't visible by using data from the occlusion culler, however
+            // that is not currently feasible because occlusion culling data is only ever updated when chunks are
+            // rebuilt. Computation of occlusion data needs to be isolated from chunk rebuilds for that to be feasible.
+            //
+            // TODO: Avoid rebuilding chunks that aren't visible to the player
+            if (render.scheduleRebuild(important)) {
                 (render.needsImportantRebuild() ? this.importantRebuildQueue : this.rebuildQueue)
                         .enqueue(render);
             }


### PR DESCRIPTION
Previously, Sodium would attempt to avoid rebuilding chunks if the occlusion culler determined that they were not visible. However, when it is time to rebuild a chunk, the occlusion data is out of date.

Occlusion data is only updated through chunk rebuilds, meaning that if a chunk is never scheduled for a rebuild, it will never become visible according to the culler. For an optimization like this to work, the computation of occlusion data would need to be separated from chunk rebuilds in some way, or the rebuild logic would need to be smart enough to know when to trust the existing data and when to ignore it.

For now, it is best to remove this problematic optimization for the sake of correctness, and once there has been a chance to implement the optimization in a correct way, it can be restored.

Though the commit de545a500a31f96b5caf7f698a38902945e70f2e makes this issue far more severe, it is still present in earlier commits. However, for whatever reason, affected chunks are eventually rebuilt in these previous versions, so they still pop in, just with some noticeable delay.

Fixes #605 according to my own testing, but testing from others is appreciated as well.