### PR TITLE
fix: Mark tripwire as translucent so that it is rendered back-to-front

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/passes/BlockRenderPass.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/passes/BlockRenderPass.java
@@ -8,7 +8,7 @@ public enum BlockRenderPass {
     CUTOUT(RenderLayer.getCutout(), false),
     CUTOUT_MIPPED(RenderLayer.getCutoutMipped(), false),
     TRANSLUCENT(RenderLayer.getTranslucent(), true),
-    TRIPWIRE(RenderLayer.getTripwire(), false);
+    TRIPWIRE(RenderLayer.getTripwire(), true);
 
     public static final BlockRenderPass[] VALUES = BlockRenderPass.values();
     public static final int COUNT = VALUES.length;


### PR DESCRIPTION
Both the `TRANSLUCENT` and `TRIPWIRE` render layers are rendered with translucency, however Sodium treats the `TRIPWIRE` render layer as if it were opaque for the purposes of determining whether chunks should be sorted back to front or front to back.

Viewing non-overlapping tripwire across chunks before & after this change (correct rendering):

![Viewing non-overlapping tripwire across chunks before & after this change (correct rendering)](https://user-images.githubusercontent.com/22420959/114250381-61ac9380-9952-11eb-919f-9348b24f71ba.png)

Viewing overlapping tripwire across chunks before this change (notice that instead of being blended, the farther away tripwire is occluded):

![Viewing overlapping tripwire across chunks before this change (notice that instead of being blended, the farther away tripwire is occluded)](https://user-images.githubusercontent.com/22420959/114250393-6d985580-9952-11eb-8405-76bf7e33f0d3.png)

Viewing overlapping tripwire across chunks after this change (notice the correct blending):

![Viewing overlapping tripwire across chunks after this change (notice the correct blending)](https://user-images.githubusercontent.com/22420959/114250473-afc19700-9952-11eb-9bcf-20718e035284.png)
