### PR TITLE
Upgrade to Gradle 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     //to change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-    modCompile "net.fabricmc:fabric-loader:${project.loader_version}"
+    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 }
 
 if (project.use_third_party_mods) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,5 @@
 pluginManagement {
     repositories {
-        jcenter()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'


### PR DESCRIPTION
* The JCenter repository ([which will stop serving packages on February 1, 2022](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/)) is deprecated in Gradle 7, so it is removed in 0aa7275. I did not replace this with another repoistory (e.g. `mavenCentral()`) since there seem to be no dependencies that relied on it.
* `modCompile` is deprecated in Gradle 7, so it is replaced with `modImplementation` in c67d506.
* Gradle wrapper is updated to 7.0 in 3299a4f.

Personal testing showed that the command `gradlew clean build --warning-mode all --no-daemon` resulted in no real performance difference between 6.8.3 and 7.0 (37s and 38s). In best case scenario, [performance should increase for incremental builds](https://docs.gradle.org/7.0/release-notes.html#performance-improvements).

The built JAR runs fine on Minecraft 1.16.5 on my end.

I am open to any suggestions to improve this PR.

Environment:
* Windows 10 Enterprise (20H2)
* Intel® Core™ i7-8565U