### PR TITLE
new: API to block until all dirty chunks have been updated (#351) 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,10 @@
+import net.fabricmc.loom.task.RemapJarTask
+import net.fabricmc.loom.task.RemapSourcesJarTask
+
 plugins {
-    id 'fabric-loom' version '0.6-SNAPSHOT'
+    id 'fabric-loom' version '0.7-SNAPSHOT'
     id 'org.ajoberstar.grgit' version '4.1.0'
+    id 'maven-publish'
 }
 
 archivesBaseName = "${project.archives_base_name}-mc${project.minecraft_version}"
@@ -10,6 +14,21 @@ group = project.maven_group
 minecraft {
     refmapName = "mixins.sodium.refmap.json"
     accessWidener = file("src/main/resources/sodium.accesswidener")
+}
+
+sourceSets {
+    api {
+        java {
+            compileClasspath += main.compileClasspath
+        }
+    }
+
+    main {
+        java {
+            compileClasspath += api.output
+            runtimeClasspath += api.output
+        }
+    }
 }
 
 dependencies {
@@ -56,8 +75,53 @@ java {
     }
 }
 
-jar {
+tasks.withType(Jar) {
     from "LICENSE.txt"
+}
+
+jar {
+    from(sourceSets.api.output) {
+        exclude "fabric.mod.json" // dummy json so loom knows to remap the api jar, the real jar has a proper one
+    }
+}
+
+tasks.register("apiJar", Jar) {
+    classifier "api-dev"
+    from sourceSets.api.output
+}
+
+def remapApiJar = tasks.register("remapApiJar", RemapJarTask) {
+    classifier "api"
+    input = apiJar.archiveFile
+    addNestedDependencies = false
+}
+build.dependsOn remapApiJar
+
+tasks.register("apiSourcesJar", Jar) {
+    classifier "api-sources-dev"
+    from sourceSets.api.allSource
+}
+
+def remapApiSourcesJar = tasks.register("remapApiSourcesJar", RemapSourcesJarTask) {
+    dependsOn apiSourcesJar
+    input = apiSourcesJar.archiveFile
+    output = apiSourcesJar.destinationDirectory.file(apiSourcesJar.archiveFileName.map { it.replace("-dev", "") })
+}
+build.dependsOn remapApiSourcesJar
+
+publishing {
+    publications {
+        main (MavenPublication) {
+            artifactId "sodium"
+            artifact(remapJar)
+        }
+
+        api (MavenPublication) {
+            artifactId "sodium-api"
+            artifact source: remapApiJar, classifier: ""
+            artifact source: remapApiSourcesJar.map { it.output }, classifier: "sources"
+        }
+    }
 }
 
 def getVersionMetadata() {

--- a/src/api/java/me/jellysquid/mods/sodium/api/SodiumApi.java
+++ b/src/api/java/me/jellysquid/mods/sodium/api/SodiumApi.java
@@ -1,9 +1,21 @@
 package me.jellysquid.mods.sodium.api;
 
+import me.jellysquid.mods.sodium.api.world.ISodiumWorldRenderer;
+import net.minecraft.client.render.WorldRenderer;
+
 public interface SodiumApi {
     static SodiumApi get() {
         return Impl.instance;
     }
+
+    /**
+     * Provides access to the implementation of {@link ISodiumWorldRenderer} for the given vanilla renderer.
+     *
+     * @param worldRenderer The vanilla renderer
+     * @return The current instance
+     * @throws IllegalStateException If the renderer has not yet been created
+     */
+    ISodiumWorldRenderer getWorldRenderer(WorldRenderer worldRenderer) throws IllegalStateException;
 
     final class Impl {
         static SodiumApi instance;

--- a/src/api/java/me/jellysquid/mods/sodium/api/SodiumApi.java
+++ b/src/api/java/me/jellysquid/mods/sodium/api/SodiumApi.java
@@ -1,0 +1,12 @@
+package me.jellysquid.mods.sodium.api;
+
+public interface SodiumApi {
+    static SodiumApi get() {
+        return Impl.instance;
+    }
+
+    final class Impl {
+        static SodiumApi instance;
+        private Impl() {}
+    }
+}

--- a/src/api/java/me/jellysquid/mods/sodium/api/world/ISodiumWorldRenderer.java
+++ b/src/api/java/me/jellysquid/mods/sodium/api/world/ISodiumWorldRenderer.java
@@ -1,0 +1,22 @@
+package me.jellysquid.mods.sodium.api.world;
+
+import net.minecraft.client.render.WorldRenderer;
+
+/**
+ * Provides an extension to vanilla's {@link WorldRenderer}.
+ */
+public interface ISodiumWorldRenderer {
+    /**
+     * Blocks until all dirty chunks have been fully (re)built and uploaded.
+     * Must be called from the main thread.
+     *
+     * Primary use case being "screenshot" mods which want to force all chunks to be loaded before taking a picture.
+     *
+     * For maximum effect, this should be called between terrain setup (setupTerrain) and rendering. Also note that
+     * new chunk may become visible as a result of this call but these will not be marked dirty and as such might not
+     * be updated until setupTerrain is called again.
+     *
+     * @return True if any work was done. This can serve as an indication that new chunks may have become visible.
+     */
+    boolean updateAllDirtyChunks();
+}

--- a/src/api/resources/fabric.mod.json
+++ b/src/api/resources/fabric.mod.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 1,
+  "id": "sodium-api",
+  "version": ""
+}

--- a/src/main/java/me/jellysquid/mods/sodium/api/SodiumApiImpl.java
+++ b/src/main/java/me/jellysquid/mods/sodium/api/SodiumApiImpl.java
@@ -1,0 +1,7 @@
+package me.jellysquid.mods.sodium.api;
+
+public class SodiumApiImpl implements SodiumApi {
+    public static void install() {
+        SodiumApi.Impl.instance = new SodiumApiImpl();
+    }
+}

--- a/src/main/java/me/jellysquid/mods/sodium/api/SodiumApiImpl.java
+++ b/src/main/java/me/jellysquid/mods/sodium/api/SodiumApiImpl.java
@@ -1,7 +1,15 @@
 package me.jellysquid.mods.sodium.api;
 
+import me.jellysquid.mods.sodium.api.world.ISodiumWorldRenderer;
+import me.jellysquid.mods.sodium.client.render.SodiumWorldRenderer;
+import net.minecraft.client.render.WorldRenderer;
+
 public class SodiumApiImpl implements SodiumApi {
     public static void install() {
         SodiumApi.Impl.instance = new SodiumApiImpl();
+    }
+
+    public ISodiumWorldRenderer getWorldRenderer(WorldRenderer worldRenderer) {
+        return SodiumWorldRenderer.getInstance().getApiImpl();
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
@@ -1,5 +1,6 @@
 package me.jellysquid.mods.sodium.client;
 
+import me.jellysquid.mods.sodium.api.SodiumApiImpl;
 import me.jellysquid.mods.sodium.client.gui.SodiumGameOptions;
 import me.jellysquid.mods.sodium.client.util.UnsafeUtil;
 import net.fabricmc.api.ClientModInitializer;
@@ -25,6 +26,8 @@ public class SodiumClientMod implements ClientModInitializer {
         MOD_VERSION = mod.getMetadata()
                 .getVersion()
                 .getFriendlyString();
+
+        SodiumApiImpl.install();
     }
 
     public static SodiumGameOptions options() {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -5,6 +5,7 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import me.jellysquid.mods.sodium.api.world.ISodiumWorldRenderer;
 import me.jellysquid.mods.sodium.client.SodiumClientMod;
 import me.jellysquid.mods.sodium.client.gl.device.RenderDevice;
 import me.jellysquid.mods.sodium.client.gui.SodiumGameOptions;
@@ -44,6 +45,7 @@ public class SodiumWorldRenderer implements ChunkStatusListener {
     private static SodiumWorldRenderer instance;
 
     private final MinecraftClient client;
+    private final ApiImpl apiImpl = new ApiImpl();
 
     private ClientWorld world;
     private int renderDistance;
@@ -426,5 +428,22 @@ public class SodiumWorldRenderer implements ChunkStatusListener {
 
     public ChunkRenderBackend<?> getChunkRenderer() {
         return this.chunkRenderBackend;
+    }
+
+    public ISodiumWorldRenderer getApiImpl() {
+        return this.apiImpl;
+    }
+
+    private class ApiImpl implements ISodiumWorldRenderer {
+        @Override
+        public boolean updateAllDirtyChunks() {
+            RenderDevice.enterManagedCode();
+            try {
+                SodiumWorldRenderer.this.chunkRenderManager.updateChunksNow();
+                return SodiumWorldRenderer.this.chunkRenderManager.isDirty();
+            } finally {
+                RenderDevice.exitManagedCode();
+            }
+        }
     }
 }


### PR DESCRIPTION
Split into two parts because I'm a lot less certain about the way the api framework should look than actually implementing the functionality.

# new: Framework to provide an API to third party mods

The API is separated into its own source set and we build a dedicated jar from that, so mods can depend on it without
depending on the entirety of Sodium (less to download/remap and no accidentally using the implementation classes):
```
dependencies {
    def sodiumVersion = "0.2.0+rev.972c7c1-dirty"
    modCompileOnly "me.jellysquid.mods:sodium-api:${sodiumVersion}"
    if (project.ext.use_sodium_in_dev) {
        modRuntime "me.jellysquid.mods:sodium:${sodiumVersion}"
    }
}
```
For the api jar to be properly remapped, we need to include a dummy fabric.mod.json. Mods should not include the API jar
at runtime (would be weird to have a sodium-api mod present without sodium, and picking the most recent one via the
version will not work for snapshot versions), so that json really is only used for loom.

Not sure what the best way to implement `SodiumApi.get()` is because the api source set cannot reference impl classes
and interfaces cannot contain mutable fields. The best I could come up with is having a semi-internal inner Impl class
with the mutable field.
The API implementation classes are generally (more noticeable in the following commit) separated from other
implementation classes because they - much like the Mixin classes - represent an interface to the outer world, and need
to notify the thingl RenderDevice about entering/leaveing the managed code, i.e. should not be called from other
internal code.

Bumps fabric-loom to 0.7 because 0.6 does not support the Gradle 7 + maven-publish combination (see
FabricMC/fabric-loom@9873153). Not going straight to 0.8
because that requires Java 16 to run.

#  new: API to block until all dirty chunks have been updated (#351) 

For background as to what this is for, see https://github.com/ReplayMod/ReplayMod/issues/150#issuecomment-623741826 and the reply.
I would expect this to be fairly uncontroversial, only real downside is that it's adding a bit of code which needs to be maintained but I'll gladly do that given the alternative is to hack into internals from the other mod via mixins.
The only change to behavior which applies even when the API is not in use, is the small addition of a `idleThreads` counter which is incremented/decremented before/after a worker thread goes to wait on the `jobNotifier`. This is required to make sure there are no more tasks currently being processed (cause those will neither be in the `buildQueue` nor the `uploadQueue`).

# Unrelated but noteworthy

Not included in or directly related to this PR (because it introduces a non-trivial change to existing behavior) but something I noticed while adding the `idleThreads` counter: The existing `isBuildQueueEmpty` method is used to replace a vanilla method which afaict is supposed to return whether all processing is done (i.e. the same thing which the new `isIdle` method returns), so `isBuildQueueEmpty` should probably be replaced with `isIdle` to more closely resemble the behavior of the vanilla method.

Also not included but something I noticed: There is a super tiny race condition in `getNextJob` where another job is added to the queue and a notify is sent, both after it is polled but before the wait. Rather easy to fix by just checking the queue a second time after entering the synchronized block before going to sleep, I just haven't opened a PR for it because that's guaranteed to conflict with this one.