### PR TITLE
Fix Sodium Icon not showing up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Project icon](https://git-assets.jellysquid.me/hotlink-ok/sodium/icon-rounded-128px.png)
+![Project icon](https://github.com/CaffeineMC/sodium-fabric/blob/1.16.x/next/src/main/resources/assets/sodium/icon.png)
 
 # Sodium (for Fabric)
 ![GitHub license](https://img.shields.io/github/license/CaffeineMC/sodium-fabric.svg)


### PR DESCRIPTION
Fixes the sodium icon not showing up when visiting the sodium repository 