### PR TITLE
fix #686: Clear cloud framebuffer when render distance changed on Fabulous graphics

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -35,7 +35,16 @@ public class SodiumGameOptionPages {
                         .setTooltip("The view distance controls how far away terrain will be rendered. Lower distances mean that less terrain will be " +
                                 "rendered, improving frame rates.")
                         .setControl(option -> new SliderControl(option, 2, 32, 1, ControlValueFormatter.quantity("Chunks")))
-                        .setBinding((options, value) -> options.viewDistance = value, options -> options.viewDistance)
+                        .setBinding((options, value) -> {
+                                options.viewDistance = value;
+
+                                if (MinecraftClient.isFabulousGraphicsOrBetter()) {
+                                    Framebuffer framebuffer = MinecraftClient.getInstance().worldRenderer.getCloudsFramebuffer();
+                                    if (framebuffer != null) {
+                                        framebuffer.clear(MinecraftClient.IS_SYSTEM_MAC);
+                                    }
+                                }
+                            }, options -> options.viewDistance)
                         .setImpact(OptionImpact.HIGH)
                         .build())
                 .add(OptionImpl.createBuilder(int.class, vanillaOpts)


### PR DESCRIPTION
This same issue appeared when the user would disable clouds on Fabulous graphics (#79) and was fixed in pull #80 by LucilleTea. Applying the same code to whenever a user changed their render distance resolves #686.