### PR TITLE
Updated 1.17 workflows to java 16

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,10 +8,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 8
+    - name: Set up JDK 16
       uses: actions/setup-java@v1
       with:
-        java-version: 8
+        java-version: 16
     - name: Build artifacts
       run: ./gradlew build
     - name: Upload build artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Set up JDK 16
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 16
       - name: Build artifacts
         run: ./gradlew build
       - name: Upload assets to GitHub


### PR DESCRIPTION
Self explanatory. Set the workflows to java 16 so that githubs build thing doesn't error.