### PR TITLE
Non-Inclusive Fabric API Compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,10 +16,12 @@ minecraft {
 }
 
 configurations {
-    modIncludeImplementation
+    modFAPI
 
-    include.extendsFrom modIncludeImplementation
-    modImplementation.extendsFrom modIncludeImplementation
+    if (project.use_fapi)
+        modImplementation.extendsFrom modFAPI
+    else
+        modCompileOnly.extendsFrom modFAPI
 }
 
 dependencies {
@@ -29,9 +31,9 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
     // Fabric API
-    modIncludeImplementation(fabricApi.module("fabric-api-base", project.fabric_version))
-    modIncludeImplementation(fabricApi.module("fabric-rendering-fluids-v1", project.fabric_version))
-    modIncludeImplementation(fabricApi.module("fabric-rendering-data-attachment-v1", project.fabric_version))
+    modFAPI(fabricApi.module("fabric-api-base", project.fabric_version))
+    modFAPI(fabricApi.module("fabric-rendering-fluids-v1", project.fabric_version))
+    modFAPI(fabricApi.module("fabric-rendering-data-attachment-v1", project.fabric_version))
 }
 
 if (project.use_third_party_mods) {

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ minecraft {
 configurations {
     modFAPI
 
-    if (project.use_fapi)
+    if (project.use_fabric_at_runtime)
         modImplementation.extendsFrom modFAPI
     else
         modCompileOnly.extendsFrom modFAPI

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,6 @@ plugins {
     id 'org.ajoberstar.grgit' version '4.1.0'
 }
 
-sourceCompatibility = "1.8"
-targetCompatibility = "1.8"
-
 archivesBaseName = "${project.archives_base_name}-mc${project.minecraft_version}"
 version = "${project.mod_version}+${getVersionMetadata()}"
 group = project.maven_group

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,10 @@ mod_version=0.3.0
 maven_group=me.jellysquid.mods
 archives_base_name=sodium-fabric
 
+# If true, Fabric API will be loaded during runtime in the developer run configurations
+# Use this to test Fabric API compatibility
+use_fapi = false
+
 # If true, third-party mods will be loaded during runtime in the developer run configurations
 use_third_party_mods = true
 databreaker_version = 0.2.7

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,6 @@ org.gradle.jvmargs=-Xmx1G
 minecraft_version=1.17
 yarn_mappings=1.17+build.1
 loader_version=0.11.3
-fabric_version=0.34.9+1.17
 
 # Mod Properties
 mod_version=0.3.0
@@ -16,6 +15,7 @@ archives_base_name=sodium-fabric
 # If true, Fabric API will be loaded during runtime in the developer run configurations
 # Use this to test Fabric API compatibility
 use_fapi = false
+fabric_version=0.34.9+1.17
 
 # If true, third-party mods will be loaded during runtime in the developer run configurations
 use_third_party_mods = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,8 +14,8 @@ archives_base_name=sodium-fabric
 
 # If true, Fabric API will be loaded during runtime in the developer run configurations
 # Use this to test Fabric API compatibility
-use_fapi = false
-fabric_version=0.34.9+1.17
+use_fabric_at_runtime = true
+fabric_version = 0.34.9+1.17
 
 # If true, third-party mods will be loaded during runtime in the developer run configurations
 use_third_party_mods = true

--- a/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
@@ -1,5 +1,6 @@
 package me.jellysquid.mods.sodium.client;
 
+import me.jellysquid.mods.sodium.client.compat.CompatHolder;
 import me.jellysquid.mods.sodium.client.gui.SodiumGameOptions;
 import me.jellysquid.mods.sodium.client.util.UnsafeUtil;
 import net.fabricmc.api.ClientModInitializer;
@@ -23,6 +24,8 @@ public class SodiumClientMod implements ClientModInitializer {
         MOD_VERSION = mod.getMetadata()
                 .getVersion()
                 .getFriendlyString();
+
+        CompatHolder.init();
     }
 
     public static SodiumGameOptions options() {

--- a/src/main/java/me/jellysquid/mods/sodium/client/compat/CompatHolder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/compat/CompatHolder.java
@@ -1,5 +1,29 @@
 package me.jellysquid.mods.sodium.client.compat;
 
+import me.jellysquid.mods.sodium.client.world.WorldSlice;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.NotNull;
+
 public final class CompatHolder {
     private CompatHolder() { }
+
+    public static void init() { }
+
+    public static @NotNull WorldSlice createWorldSlice(@NotNull World world) {
+        return WORLD_SLICE_FACTORY.create(world);
+    }
+
+    private static boolean isModLoaded(@NotNull String id) {
+        return FabricLoader.getInstance().isModLoaded(id);
+    }
+
+    private static final WorldSliceFactory WORLD_SLICE_FACTORY = createWorldSliceFactory();
+
+    private static @NotNull WorldSliceFactory createWorldSliceFactory() {
+        if (isModLoaded("fabric-rendering-data-attachment-v1"))
+            return RenderAttachedWorldSlice::new;
+        else
+            return WorldSlice::new;
+    }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/compat/CompatHolder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/compat/CompatHolder.java
@@ -1,9 +1,17 @@
 package me.jellysquid.mods.sodium.client.compat;
 
+import it.unimi.dsi.fastutil.objects.Object2ReferenceOpenHashMap;
 import me.jellysquid.mods.sodium.client.world.WorldSlice;
+import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandlerRegistry;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.client.texture.Sprite;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.fluid.FluidState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.BlockRenderView;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public final class CompatHolder {
     private CompatHolder() { }
@@ -14,16 +22,54 @@ public final class CompatHolder {
         return WORLD_SLICE_FACTORY.create(world);
     }
 
+    public static @NotNull FluidRenderHandler getFluidRenderHandler(@NotNull Fluid fluid) {
+        return FLUID_RENDER_HANDLER_PROVIDER.get(fluid);
+    }
+
+    public static void onFluidResourceReload(Sprite[] waterSprites, Sprite[] lavaSprites) {
+        FLUID_RENDER_HANDLER_PROVIDER.onResourceReload(waterSprites, lavaSprites);
+    }
+
     private static boolean isModLoaded(@NotNull String id) {
         return FabricLoader.getInstance().isModLoaded(id);
     }
 
     private static final WorldSliceFactory WORLD_SLICE_FACTORY = createWorldSliceFactory();
+    private static final FluidRenderHandlerProvider FLUID_RENDER_HANDLER_PROVIDER = createFluidRendererOverrideProvider();
 
     private static @NotNull WorldSliceFactory createWorldSliceFactory() {
         if (isModLoaded("fabric-rendering-data-attachment-v1"))
             return RenderAttachedWorldSlice::new;
         else
             return WorldSlice::new;
+    }
+
+    private static @NotNull FluidRenderHandlerProvider createFluidRendererOverrideProvider() {
+        if (isModLoaded("fabric-rendering-fluids-v1"))
+            return new FluidRenderHandlerProvider() {
+                private final Object2ReferenceOpenHashMap<Fluid, FluidRenderHandler> cache
+                        = new Object2ReferenceOpenHashMap<>();
+
+                @Override
+                public @NotNull FluidRenderHandler get(@NotNull Fluid fluid) {
+                    return cache.computeIfAbsent(fluid, fluid1 -> {
+                        net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandler delegate
+                                = FluidRenderHandlerRegistry.INSTANCE.get(fluid);
+                        return new FluidRenderHandler() {
+                            @Override
+                            public Sprite[] getFluidSprites(@Nullable BlockRenderView view, @Nullable BlockPos pos, FluidState state) {
+                                return delegate.getFluidSprites(view, pos, state);
+                            }
+
+                            @Override
+                            public int getFluidColor(@Nullable BlockRenderView view, @Nullable BlockPos pos, FluidState state) {
+                                return delegate.getFluidColor(view, pos, state);
+                            }
+                        };
+                    });
+                }
+            };
+        else
+            return new VanillaFluidRenderHandlerProvider();
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/compat/CompatHolder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/compat/CompatHolder.java
@@ -46,7 +46,7 @@ public final class CompatHolder {
                 public @NotNull FluidRenderHandler get(@NotNull Fluid fluid) {
                     return cache.computeIfAbsent(fluid, fluid1 -> {
                         net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandler delegate
-                                = FluidRenderHandlerRegistry.INSTANCE.get(fluid);
+                                = FluidRenderHandlerRegistry.INSTANCE.get(fluid1);
                         return new FluidRenderHandler() {
                             @Override
                             public Sprite[] getFluidSprites(@Nullable BlockRenderView view, @Nullable BlockPos pos, FluidState state) {

--- a/src/main/java/me/jellysquid/mods/sodium/client/compat/CompatHolder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/compat/CompatHolder.java
@@ -60,6 +60,12 @@ public final class CompatHolder {
                         };
                     });
                 }
+
+                @Override
+                public void onResourceReload(Sprite[] waterSprites, Sprite[] lavaSprites) {
+                    // clear cache, since sprites could have changed
+                    cache.clear();
+                }
             };
         else
             return new VanillaFluidRenderHandlerProvider();

--- a/src/main/java/me/jellysquid/mods/sodium/client/compat/CompatHolder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/compat/CompatHolder.java
@@ -9,33 +9,25 @@ import net.minecraft.fluid.Fluid;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockRenderView;
-import net.minecraft.world.World;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Holds compatibility-related class/interface instances.
+ */
+@ApiStatus.Internal
 public final class CompatHolder {
     private CompatHolder() { }
 
-    public static void init() { }
-
-    public static @NotNull WorldSlice createWorldSlice(@NotNull World world) {
-        return WORLD_SLICE_FACTORY.create(world);
-    }
-
-    public static @NotNull FluidRenderHandler getFluidRenderHandler(@NotNull Fluid fluid) {
-        return FLUID_RENDER_HANDLER_PROVIDER.get(fluid);
-    }
-
-    public static void onFluidResourceReload(Sprite[] waterSprites, Sprite[] lavaSprites) {
-        FLUID_RENDER_HANDLER_PROVIDER.onResourceReload(waterSprites, lavaSprites);
-    }
+    public static void init() { /* <clinit> */ }
 
     private static boolean isModLoaded(@NotNull String id) {
         return FabricLoader.getInstance().isModLoaded(id);
     }
 
-    private static final WorldSliceFactory WORLD_SLICE_FACTORY = createWorldSliceFactory();
-    private static final FluidRenderHandlerProvider FLUID_RENDER_HANDLER_PROVIDER = createFluidRendererOverrideProvider();
+    public static final WorldSliceFactory WORLD_SLICE_FACTORY = createWorldSliceFactory();
+    public static final FluidRenderHandlerProvider FLUID_RENDER_HANDLER_PROVIDER = createFluidRenderHandlerProvider();
 
     private static @NotNull WorldSliceFactory createWorldSliceFactory() {
         if (isModLoaded("fabric-rendering-data-attachment-v1"))
@@ -44,7 +36,7 @@ public final class CompatHolder {
             return WorldSlice::new;
     }
 
-    private static @NotNull FluidRenderHandlerProvider createFluidRendererOverrideProvider() {
+    private static @NotNull FluidRenderHandlerProvider createFluidRenderHandlerProvider() {
         if (isModLoaded("fabric-rendering-fluids-v1"))
             return new FluidRenderHandlerProvider() {
                 private final Object2ReferenceOpenHashMap<Fluid, FluidRenderHandler> cache

--- a/src/main/java/me/jellysquid/mods/sodium/client/compat/CompatHolder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/compat/CompatHolder.java
@@ -1,0 +1,5 @@
+package me.jellysquid.mods.sodium.client.compat;
+
+public final class CompatHolder {
+    private CompatHolder() { }
+}

--- a/src/main/java/me/jellysquid/mods/sodium/client/compat/FluidRenderHandler.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/compat/FluidRenderHandler.java
@@ -1,12 +1,18 @@
 package me.jellysquid.mods.sodium.client.compat;
 
+import me.jellysquid.mods.sodium.client.model.quad.ModelQuadColorProvider;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockRenderView;
 import org.jetbrains.annotations.Nullable;
 
-public interface FluidRenderHandler {
+public interface FluidRenderHandler extends ModelQuadColorProvider<FluidState> {
     Sprite[] getFluidSprites(@Nullable BlockRenderView view, @Nullable BlockPos pos, FluidState state);
     int getFluidColor(@Nullable BlockRenderView view, @Nullable BlockPos pos, FluidState state);
+
+    @Override
+    default int getColor(FluidState state, @Nullable BlockRenderView world, @Nullable BlockPos pos, int tintIndex) {
+        return getFluidColor(world, pos, state);
+    }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/compat/FluidRenderHandler.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/compat/FluidRenderHandler.java
@@ -1,0 +1,12 @@
+package me.jellysquid.mods.sodium.client.compat;
+
+import net.minecraft.client.texture.Sprite;
+import net.minecraft.fluid.FluidState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.BlockRenderView;
+import org.jetbrains.annotations.Nullable;
+
+public interface FluidRenderHandler {
+    Sprite[] getFluidSprites(@Nullable BlockRenderView view, @Nullable BlockPos pos, FluidState state);
+    int getFluidColor(@Nullable BlockRenderView view, @Nullable BlockPos pos, FluidState state);
+}

--- a/src/main/java/me/jellysquid/mods/sodium/client/compat/FluidRenderHandlerProvider.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/compat/FluidRenderHandlerProvider.java
@@ -5,7 +5,7 @@ import net.minecraft.fluid.Fluid;
 import org.jetbrains.annotations.NotNull;
 
 @FunctionalInterface
-interface FluidRenderHandlerProvider {
+public interface FluidRenderHandlerProvider {
     @NotNull FluidRenderHandler get(@NotNull Fluid fluid);
 
     default void onResourceReload(Sprite[] waterSprites, Sprite[] lavaSprites) { }

--- a/src/main/java/me/jellysquid/mods/sodium/client/compat/FluidRenderHandlerProvider.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/compat/FluidRenderHandlerProvider.java
@@ -1,0 +1,12 @@
+package me.jellysquid.mods.sodium.client.compat;
+
+import net.minecraft.client.texture.Sprite;
+import net.minecraft.fluid.Fluid;
+import org.jetbrains.annotations.NotNull;
+
+@FunctionalInterface
+interface FluidRenderHandlerProvider {
+    @NotNull FluidRenderHandler get(@NotNull Fluid fluid);
+
+    default void onResourceReload(Sprite[] waterSprites, Sprite[] lavaSprites) { }
+}

--- a/src/main/java/me/jellysquid/mods/sodium/client/compat/FluidRenderHandlerProvider.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/compat/FluidRenderHandlerProvider.java
@@ -4,9 +4,7 @@ import net.minecraft.client.texture.Sprite;
 import net.minecraft.fluid.Fluid;
 import org.jetbrains.annotations.NotNull;
 
-@FunctionalInterface
 public interface FluidRenderHandlerProvider {
     @NotNull FluidRenderHandler get(@NotNull Fluid fluid);
-
-    default void onResourceReload(Sprite[] waterSprites, Sprite[] lavaSprites) { }
+    void onResourceReload(Sprite[] waterSprites, Sprite[] lavaSprites);
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/compat/RenderAttachedWorldSlice.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/compat/RenderAttachedWorldSlice.java
@@ -1,0 +1,23 @@
+package me.jellysquid.mods.sodium.client.compat;
+
+import me.jellysquid.mods.sodium.client.world.WorldSlice;
+import net.fabricmc.fabric.api.rendering.data.v1.RenderAttachedBlockView;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.Nullable;
+
+class RenderAttachedWorldSlice extends WorldSlice implements RenderAttachedBlockView {
+    public RenderAttachedWorldSlice(World world) {
+        super(world);
+    }
+
+    @Override
+    public @Nullable Object getBlockEntityRenderAttachment(BlockPos pos) {
+        int relX = pos.getX() - this.baseX;
+        int relY = pos.getY() - this.baseY;
+        int relZ = pos.getZ() - this.baseZ;
+
+        return this.sections[WorldSlice.getLocalSectionIndex(relX >> 4, relY >> 4, relZ >> 4)]
+                .getBlockEntityRenderAttachment(relX & 15, relY & 15, relZ & 15);
+    }
+}

--- a/src/main/java/me/jellysquid/mods/sodium/client/compat/VanillaFluidRenderHandlerProvider.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/compat/VanillaFluidRenderHandlerProvider.java
@@ -1,0 +1,64 @@
+package me.jellysquid.mods.sodium.client.compat;
+
+import it.unimi.dsi.fastutil.objects.Object2ReferenceArrayMap;
+import net.minecraft.client.color.world.BiomeColors;
+import net.minecraft.client.texture.Sprite;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.fluid.FluidState;
+import net.minecraft.fluid.Fluids;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.registry.BuiltinRegistries;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.world.BlockRenderView;
+import net.minecraft.world.biome.BiomeKeys;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+final class VanillaFluidRenderHandlerProvider implements FluidRenderHandlerProvider {
+    private static final int DEFAULT_WATER_COLOR
+            = Objects.requireNonNull(BuiltinRegistries.BIOME.get(BiomeKeys.OCEAN)).getWaterColor();
+    private final Object2ReferenceArrayMap<Fluid, FluidRenderHandler> handlers = new Object2ReferenceArrayMap<>();
+
+    @Override
+    public @NotNull FluidRenderHandler get(@NotNull Fluid fluid) {
+        FluidRenderHandler handler = handlers.get(fluid);
+        if (handler == null)
+            throw new RuntimeException("Unhandled fluid " + Registry.FLUID.getKey(fluid) + "!");
+        return handler;
+    }
+
+    @Override
+    public void onResourceReload(Sprite[] waterSprites, Sprite[] lavaSprites) {
+        FluidRenderHandler waterHandler = new FluidRenderHandler() {
+            @Override
+            public Sprite[] getFluidSprites(@Nullable BlockRenderView view, @Nullable BlockPos pos, FluidState state) {
+                return waterSprites;
+            }
+
+            @Override
+            public int getFluidColor(@Nullable BlockRenderView view, @Nullable BlockPos pos, FluidState state) {
+                if (view == null)
+                    return DEFAULT_WATER_COLOR;
+                return BiomeColors.getWaterColor(view, pos);
+            }
+        };
+        FluidRenderHandler lavaHandler = new FluidRenderHandler() {
+            @Override
+            public Sprite[] getFluidSprites(@Nullable BlockRenderView view, @Nullable BlockPos pos, FluidState state) {
+                return lavaSprites;
+            }
+
+            @Override
+            public int getFluidColor(@Nullable BlockRenderView view, @Nullable BlockPos pos, FluidState state) {
+                return -1;
+            }
+        };
+
+        handlers.put(Fluids.WATER, waterHandler);
+        handlers.put(Fluids.FLOWING_WATER, waterHandler);
+        handlers.put(Fluids.LAVA, lavaHandler);
+        handlers.put(Fluids.FLOWING_LAVA, lavaHandler);
+    }
+}

--- a/src/main/java/me/jellysquid/mods/sodium/client/compat/WorldSliceFactory.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/compat/WorldSliceFactory.java
@@ -1,0 +1,10 @@
+package me.jellysquid.mods.sodium.client.compat;
+
+import me.jellysquid.mods.sodium.client.world.WorldSlice;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.NotNull;
+
+@FunctionalInterface
+interface WorldSliceFactory {
+    @NotNull WorldSlice create(@NotNull World world);
+}

--- a/src/main/java/me/jellysquid/mods/sodium/client/compat/WorldSliceFactory.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/compat/WorldSliceFactory.java
@@ -5,6 +5,6 @@ import net.minecraft.world.World;
 import org.jetbrains.annotations.NotNull;
 
 @FunctionalInterface
-interface WorldSliceFactory {
+public interface WorldSliceFactory {
     @NotNull WorldSlice create(@NotNull World world);
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/FluidRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/FluidRenderer.java
@@ -36,8 +36,13 @@ import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.BlockRenderView;
+import org.jetbrains.annotations.NotNull;
 
 public class FluidRenderer {
+    public static @NotNull FluidRenderHandler getRenderHandler(@NotNull Fluid fluid) {
+        return CompatHolder.FLUID_RENDER_HANDLER_PROVIDER.get(fluid);
+    }
+
     // TODO: allow this to be changed by vertex format
     // TODO: move fluid rendering to a separate render pass and control glPolygonOffset and glDepthFunc to fix this properly
     private static final float EPSILON = 0.001f;
@@ -116,7 +121,7 @@ public class FluidRenderer {
 
         boolean isWater = fluidState.isIn(FluidTags.WATER);
 
-        FluidRenderHandler handler = CompatHolder.getFluidRenderHandler(fluidState.getFluid());
+        FluidRenderHandler handler = getRenderHandler(fluidState.getFluid());
 
         Sprite[] sprites = handler.getFluidSprites(world, pos, fluidState);
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/FluidRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/FluidRenderer.java
@@ -1,5 +1,7 @@
 package me.jellysquid.mods.sodium.client.render.pipeline;
 
+import me.jellysquid.mods.sodium.client.compat.CompatHolder;
+import me.jellysquid.mods.sodium.client.compat.FluidRenderHandler;
 import me.jellysquid.mods.sodium.client.model.light.LightMode;
 import me.jellysquid.mods.sodium.client.model.light.LightPipeline;
 import me.jellysquid.mods.sodium.client.model.light.LightPipelineProvider;
@@ -17,8 +19,6 @@ import me.jellysquid.mods.sodium.client.render.chunk.format.ModelVertexSink;
 import me.jellysquid.mods.sodium.client.util.Norm3b;
 import me.jellysquid.mods.sodium.client.util.color.ColorABGR;
 import me.jellysquid.mods.sodium.common.util.DirectionUtil;
-import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandler;
-import net.fabricmc.fabric.impl.client.rendering.fluid.FluidRenderHandlerRegistryImpl;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
@@ -120,7 +120,7 @@ public class FluidRenderer {
 
         boolean isWater = fluidState.isIn(FluidTags.WATER);
 
-        FluidRenderHandler handler = FluidRenderHandlerRegistryImpl.INSTANCE.getOverride(fluidState.getFluid());
+        FluidRenderHandler handler = CompatHolder.getFluidRenderHandler(fluidState.getFluid());
         ModelQuadColorProvider<FluidState> colorizer = this.createColorProviderAdapter(handler);
 
         Sprite[] sprites = handler.getFluidSprites(world, pos, fluidState);

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/context/ChunkRenderCacheLocal.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/context/ChunkRenderCacheLocal.java
@@ -1,5 +1,6 @@
 package me.jellysquid.mods.sodium.client.render.pipeline.context;
 
+import me.jellysquid.mods.sodium.client.compat.CompatHolder;
 import me.jellysquid.mods.sodium.client.model.light.LightPipelineProvider;
 import me.jellysquid.mods.sodium.client.model.light.cache.ArrayLightDataCache;
 import me.jellysquid.mods.sodium.client.model.quad.blender.BiomeColorBlender;
@@ -22,7 +23,7 @@ public class ChunkRenderCacheLocal extends ChunkRenderCache {
     private final WorldSlice worldSlice;
 
     public ChunkRenderCacheLocal(MinecraftClient client, World world) {
-        this.worldSlice = new WorldSlice(world);
+        this.worldSlice = CompatHolder.createWorldSlice(world);
         this.lightDataCache = new ArrayLightDataCache(this.worldSlice);
 
         LightPipelineProvider lightPipelineProvider = new LightPipelineProvider(this.lightDataCache);

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/context/ChunkRenderCacheLocal.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/context/ChunkRenderCacheLocal.java
@@ -1,6 +1,5 @@
 package me.jellysquid.mods.sodium.client.render.pipeline.context;
 
-import me.jellysquid.mods.sodium.client.compat.CompatHolder;
 import me.jellysquid.mods.sodium.client.model.light.LightPipelineProvider;
 import me.jellysquid.mods.sodium.client.model.light.cache.ArrayLightDataCache;
 import me.jellysquid.mods.sodium.client.model.quad.blender.BiomeColorBlender;
@@ -23,7 +22,7 @@ public class ChunkRenderCacheLocal extends ChunkRenderCache {
     private final WorldSlice worldSlice;
 
     public ChunkRenderCacheLocal(MinecraftClient client, World world) {
-        this.worldSlice = CompatHolder.createWorldSlice(world);
+        this.worldSlice = WorldSlice.create(world);
         this.lightDataCache = new ArrayLightDataCache(this.worldSlice);
 
         LightPipelineProvider lightPipelineProvider = new LightPipelineProvider(this.lightDataCache);

--- a/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
@@ -1,6 +1,7 @@
 package me.jellysquid.mods.sodium.client.world;
 
 import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
+import me.jellysquid.mods.sodium.client.compat.CompatHolder;
 import me.jellysquid.mods.sodium.client.world.cloned.PackedIntegerArrayExtended;
 import me.jellysquid.mods.sodium.client.world.biome.BiomeCache;
 import me.jellysquid.mods.sodium.client.world.biome.BiomeColorCache;
@@ -22,6 +23,8 @@ import net.minecraft.world.biome.source.BiomeAccess;
 import net.minecraft.world.chunk.*;
 import net.minecraft.world.chunk.light.LightingProvider;
 import net.minecraft.world.level.ColorResolver;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
@@ -132,6 +135,12 @@ public class WorldSlice implements BlockRenderView, BiomeAccess.Storage {
         return new ChunkRenderContext(origin, sections, volume);
     }
 
+    public static @NotNull WorldSlice create(@NotNull World world) {
+        return CompatHolder.WORLD_SLICE_FACTORY.create(world);
+    }
+
+    // don't use this directly, use WorldSlice.create instead
+    @ApiStatus.Internal
     public WorldSlice(World world) {
         this.world = world;
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
@@ -36,7 +36,7 @@ import java.util.Map;
  *
  * Object pooling should be used to avoid huge allocations as this class contains many large arrays.
  */
-public class WorldSlice implements BlockRenderView, BiomeAccess.Storage, RenderAttachedBlockView {
+public class WorldSlice implements BlockRenderView, BiomeAccess.Storage {
     // The number of blocks on each axis in a section.
     private static final int SECTION_BLOCK_LENGTH = 16;
 
@@ -69,7 +69,7 @@ public class WorldSlice implements BlockRenderView, BiomeAccess.Storage, RenderA
     private final BlockState[][] blockStatesArrays;
 
     // Local section copies. Read-only.
-    private ClonedChunkSection[] sections;
+    protected ClonedChunkSection[] sections;
 
     // Biome caches for each chunk section
     private BiomeCache[] biomeCaches;
@@ -86,7 +86,7 @@ public class WorldSlice implements BlockRenderView, BiomeAccess.Storage, RenderA
     private BiomeColorCache prevColorCache;
 
     // The starting point from which this slice captures blocks
-    private int baseX, baseY, baseZ;
+    protected int baseX, baseY, baseZ;
 
     // The chunk origin of this slice
     private ChunkSectionPos origin;
@@ -359,15 +359,5 @@ public class WorldSlice implements BlockRenderView, BiomeAccess.Storage, RenderA
     @Override
     public int getBottomY() {
         return this.world.getBottomY();
-    }
-
-    @Override
-    public @Nullable Object getBlockEntityRenderAttachment(BlockPos pos) {
-        int relX = pos.getX() - this.baseX;
-        int relY = pos.getY() - this.baseY;
-        int relZ = pos.getZ() - this.baseZ;
-
-        return this.sections[WorldSlice.getLocalSectionIndex(relX >> 4, relY >> 4, relZ >> 4)]
-                .getBlockEntityRenderAttachment(relX & 15, relY & 15, relZ & 15);
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/common/config/SodiumConfig.java
+++ b/src/main/java/me/jellysquid/mods/sodium/common/config/SodiumConfig.java
@@ -34,6 +34,7 @@ public class SodiumConfig {
         this.addMixinRule("features.buffer_builder.fast_sort", true);
         this.addMixinRule("features.buffer_builder.intrinsics", true);
         this.addMixinRule("features.chunk_rendering", true);
+        this.addMixinRule("features.compat", true);
         this.addMixinRule("features.debug", true);
         this.addMixinRule("features.entity", true);
         this.addMixinRule("features.entity.fast_render", true);

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/compat/MixinFluidRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/compat/MixinFluidRenderer.java
@@ -21,6 +21,6 @@ public class MixinFluidRenderer {
 
     @Inject(method = "onResourceReload", at = @At("RETURN"))
     public void onResourceReload(CallbackInfo ci) {
-        CompatHolder.onFluidResourceReload(waterSprites, lavaSprites);
+        CompatHolder.FLUID_RENDER_HANDLER_PROVIDER.onResourceReload(waterSprites, lavaSprites);
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/compat/MixinFluidRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/compat/MixinFluidRenderer.java
@@ -1,0 +1,26 @@
+package me.jellysquid.mods.sodium.mixin.features.compat;
+
+import me.jellysquid.mods.sodium.client.compat.CompatHolder;
+import net.minecraft.client.render.block.FluidRenderer;
+import net.minecraft.client.texture.Sprite;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(FluidRenderer.class)
+public class MixinFluidRenderer {
+    @Shadow
+    @Final
+    private Sprite[] waterSprites;
+    @Shadow
+    @Final
+    private Sprite[] lavaSprites;
+
+    @Inject(method = "onResourceReload", at = @At("RETURN"))
+    public void onResourceReload(CallbackInfo ci) {
+        CompatHolder.onFluidResourceReload(waterSprites, lavaSprites);
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,9 +27,7 @@
     "sodium.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.8.0",
-    "fabric-rendering-data-attachment-v1": ">=0.1",
-    "fabric-rendering-fluids-v1": ">=0.1"
+    "fabricloader": ">=0.8.0"
   },
   "breaks": {
     "optifabric": "*",

--- a/src/main/resources/sodium.mixins.json
+++ b/src/main/resources/sodium.mixins.json
@@ -32,6 +32,7 @@
     "features.chunk_rendering.MixinPackedIntegerArray",
     "features.chunk_rendering.MixinPalettedContainer",
     "features.chunk_rendering.MixinWorldRenderer",
+    "features.compat.MixinFluidRenderer",
     "features.debug.MixinDebugHud",
     "features.entity.fast_render.MixinCuboid",
     "features.entity.fast_render.MixinModelPart",


### PR DESCRIPTION
Ignore the kinda iffy name, this PR _should_ allow FAPI compatibility without actually including any FAPI modules ~~and getting the speedrunning community in a tizzy.~~

Currently supported:
- `fabric-rendering-fluids-v1`
- `fabric-rendering-data-attachment-v1`