### PR TITLE
Fix dirty issue by ignoring macOS files (like .DS_Store)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ bin/
 # fabric
 
 run/
+
+# macOS
+
+.DS_Store
+.AppleDouble
+.LSOverride


### PR DESCRIPTION
macOS generates `.DS_Store` and other files automatically in many folders when Finder is used. Ignoring them in gitignore resolves the issue where builds on macOS are considered dirty. (Running `git status` will reveal the presence of an untracked `.DS_Store`)