### PR TITLE
new: Implement FREX Flawless Frames API (#351) (1.16)

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
@@ -1,6 +1,7 @@
 package me.jellysquid.mods.sodium.client;
 
 import me.jellysquid.mods.sodium.client.gui.SodiumGameOptions;
+import me.jellysquid.mods.sodium.client.util.FlawlessFrames;
 import me.jellysquid.mods.sodium.client.util.UnsafeUtil;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.loader.api.FabricLoader;
@@ -25,6 +26,8 @@ public class SodiumClientMod implements ClientModInitializer {
         MOD_VERSION = mod.getMetadata()
                 .getVersion()
                 .getFriendlyString();
+
+        FlawlessFrames.onClientInitialization();
     }
 
     public static SodiumGameOptions options() {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -427,4 +427,8 @@ public class SodiumWorldRenderer implements ChunkStatusListener {
     public ChunkRenderBackend<?> getChunkRenderer() {
         return this.chunkRenderBackend;
     }
+
+    public ChunkRenderManager<?> getChunkRenderManager() {
+        return this.chunkRenderManager;
+    }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager.java
@@ -454,6 +454,31 @@ public class ChunkRenderManager<T extends ChunkGraphicsState> implements ChunkSt
         }
     }
 
+    public void updateAllChunksNow() {
+        Deque<CompletableFuture<ChunkBuildResult<T>>> futures = new ArrayDeque<>();
+
+        // Schedule all pending rebuilds
+        while (!this.importantRebuildQueue.isEmpty()) {
+            futures.add(this.builder.scheduleRebuildTaskAsync(this.importantRebuildQueue.dequeue()));
+        }
+
+        while (!this.rebuildQueue.isEmpty()) {
+            futures.add(this.builder.scheduleRebuildTaskAsync(this.rebuildQueue.dequeue()));
+        }
+
+        // Try to complete some other work on the main thread while we wait for rebuilds to complete
+        this.dirty |= this.builder.performPendingUploads();
+
+        if (!futures.isEmpty()) {
+            // Now wait for all of our rebuilds to complete
+            this.backend.upload(RenderDevice.INSTANCE.createCommandList(), new FutureDequeDrain<>(futures));
+            this.dirty = true;
+        }
+
+        // Finally wait for any rebuilds which had already been scheduled before this method was called
+        this.dirty |= this.builder.performAllUploads();
+    }
+
     public void markDirty() {
         this.dirty = true;
     }

--- a/src/main/java/me/jellysquid/mods/sodium/client/util/FlawlessFrames.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/util/FlawlessFrames.java
@@ -1,0 +1,43 @@
+package me.jellysquid.mods.sodium.client.util;
+
+import net.fabricmc.loader.api.FabricLoader;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Implements the "Flawless Frames" FREX feature using which third-party mods can instruct Sodium to sacrifice
+ * performance (even beyond the point where it can no longer achieve interactive frame rates) in exchange for
+ * a noticeable boost to quality.
+ *
+ * In Sodium's case, this means waiting for all chunks to be fully updated and ready for rendering before each frame.
+ *
+ * See https://github.com/grondag/frex/pull/9
+ */
+public class FlawlessFrames {
+    private static final Set<Object> ACTIVE = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    @SuppressWarnings("unchecked")
+    public static void onClientInitialization() {
+        Function<String, Consumer<Boolean>> provider = name -> {
+            Object token = new Object();
+            return active -> {
+                if (active) {
+                    ACTIVE.add(token);
+                } else {
+                    ACTIVE.remove(token);
+                }
+            };
+        };
+        FabricLoader.getInstance()
+                .getEntrypoints("frex_flawless_frames", Consumer.class)
+                .forEach(api -> api.accept(provider));
+    }
+
+    public static boolean isActive() {
+        return !ACTIVE.isEmpty();
+    }
+}


### PR DESCRIPTION
 > Implements the "Flawless Frames" FREX feature using which third-party mods can instruct Sodium to sacrifice
 > performance (even beyond the point where it can no longer achieve interactive frame rates) in exchange for
 > a noticeable boost to quality.
 >
 > In Sodium's case, this means waiting for all chunks to be fully updated and ready for rendering before each frame.
 >
 > See https://github.com/grondag/frex/pull/9

Supersedes https://github.com/CaffeineMC/sodium-fabric/pull/676.

Implementation of the blocking update is identical to the old PR but the whole API part has been replaced with [this FREX one](https://github.com/grondag/frex/pull/9) (doesn't actually require FREX, it's just defined there as a standard which multiple mods can implement) which is much simpler, nicer and more general at the same time.

Unlike the previous API, this one requires that all visible chunks be fully updated (the previous one only required all **pending** ones to be updated, and the caller would have to loop until the full chunk graph is visible). So the looping is now done in Sodium (see `MixinWorldRenderer`). This loop isn't ideal (we re-setup many thing which could not have changed) but it's good enough to get the whole thing working and performance is secondary for Flawless Frames.