### PR TITLE
Fix to allow block face culling to be disabled

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RegionChunkRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RegionChunkRenderer.java
@@ -1,6 +1,7 @@
 package me.jellysquid.mods.sodium.client.render.chunk;
 
 import com.google.common.collect.Lists;
+import me.jellysquid.mods.sodium.client.SodiumClientMod;
 import me.jellysquid.mods.sodium.client.gl.attribute.GlVertexAttributeBinding;
 import me.jellysquid.mods.sodium.client.gl.buffer.GlBufferUsage;
 import me.jellysquid.mods.sodium.client.gl.buffer.GlMutableBuffer;
@@ -135,30 +136,39 @@ public class RegionChunkRenderer extends ShaderChunkRenderer {
             int baseVertex = (int) state.getVertexSegment()
                     .getOffset();
 
-            this.addDrawCall(state.getModelPart(ModelQuadFacing.UNASSIGNED), indexOffset, baseVertex);
+            if (SodiumClientMod.options().advanced.useBlockFaceCulling) {
 
-            if (camera.posY > bounds.y1) {
-                this.addDrawCall(state.getModelPart(ModelQuadFacing.UP), indexOffset, baseVertex);
+                this.addDrawCall(state.getModelPart(ModelQuadFacing.UNASSIGNED), indexOffset, baseVertex);
+
+                if (camera.posY > bounds.y1) {
+                    this.addDrawCall(state.getModelPart(ModelQuadFacing.UP), indexOffset, baseVertex);
+                }
+
+                if (camera.posY < bounds.y2) {
+                    this.addDrawCall(state.getModelPart(ModelQuadFacing.DOWN), indexOffset, baseVertex);
+                }
+
+                if (camera.posX > bounds.x1) {
+                    this.addDrawCall(state.getModelPart(ModelQuadFacing.EAST), indexOffset, baseVertex);
+                }
+
+                if (camera.posX < bounds.x2) {
+                    this.addDrawCall(state.getModelPart(ModelQuadFacing.WEST), indexOffset, baseVertex);
+                }
+
+                if (camera.posZ > bounds.z1) {
+                    this.addDrawCall(state.getModelPart(ModelQuadFacing.SOUTH), indexOffset, baseVertex);
+                }
+
+                if (camera.posZ < bounds.z2) {
+                    this.addDrawCall(state.getModelPart(ModelQuadFacing.NORTH), indexOffset, baseVertex);
+                }
             }
+            else {
+                for (ModelQuadFacing modelFace : ModelQuadFacing.values()){
+                    this.addDrawCall(state.getModelPart(modelFace), indexOffset, baseVertex);
+                }
 
-            if (camera.posY < bounds.y2) {
-                this.addDrawCall(state.getModelPart(ModelQuadFacing.DOWN), indexOffset, baseVertex);
-            }
-
-            if (camera.posX > bounds.x1) {
-                this.addDrawCall(state.getModelPart(ModelQuadFacing.EAST), indexOffset, baseVertex);
-            }
-
-            if (camera.posX < bounds.x2) {
-                this.addDrawCall(state.getModelPart(ModelQuadFacing.WEST), indexOffset, baseVertex);
-            }
-
-            if (camera.posZ > bounds.z1) {
-                this.addDrawCall(state.getModelPart(ModelQuadFacing.SOUTH), indexOffset, baseVertex);
-            }
-
-            if (camera.posZ < bounds.z2) {
-                this.addDrawCall(state.getModelPart(ModelQuadFacing.NORTH), indexOffset, baseVertex);
             }
         }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RegionChunkRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RegionChunkRenderer.java
@@ -34,7 +34,7 @@ import java.util.Map;
 public class RegionChunkRenderer extends ShaderChunkRenderer {
     private final MultiDrawBatch[] batches;
     private final GlVertexAttributeBinding[] vertexAttributeBindings;
-    private final boolean enableBlockFaceCull = SodiumClientMod.options().advanced.useBlockFaceCulling;
+    private final boolean enableBlockFaceCulling = SodiumClientMod.options().advanced.useBlockFaceCulling;
 
     private final GlMutableBuffer chunkInfoBuffer;
 
@@ -135,7 +135,7 @@ public class RegionChunkRenderer extends ShaderChunkRenderer {
             int baseVertex = (int) state.getVertexSegment()
                     .getOffset();
 
-            if (this.enableBlockFaceCull) {
+            if (this.enableBlockFaceCulling) {
 
                 ChunkRenderBounds bounds = render.getBounds();
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RegionChunkRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RegionChunkRenderer.java
@@ -128,8 +128,6 @@ public class RegionChunkRenderer extends ShaderChunkRenderer {
                 continue;
             }
 
-            ChunkRenderBounds bounds = render.getBounds();
-
             long indexOffset = state.getIndexSegment()
                     .getOffset();
 
@@ -137,6 +135,8 @@ public class RegionChunkRenderer extends ShaderChunkRenderer {
                     .getOffset();
 
             if (SodiumClientMod.options().advanced.useBlockFaceCulling) {
+                
+                ChunkRenderBounds bounds = render.getBounds();
 
                 this.addDrawCall(state.getModelPart(ModelQuadFacing.UNASSIGNED), indexOffset, baseVertex);
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RegionChunkRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RegionChunkRenderer.java
@@ -34,6 +34,7 @@ import java.util.Map;
 public class RegionChunkRenderer extends ShaderChunkRenderer {
     private final MultiDrawBatch[] batches;
     private final GlVertexAttributeBinding[] vertexAttributeBindings;
+    private final boolean enableBlockFaceCull = SodiumClientMod.options().advanced.useBlockFaceCulling;
 
     private final GlMutableBuffer chunkInfoBuffer;
 
@@ -134,8 +135,8 @@ public class RegionChunkRenderer extends ShaderChunkRenderer {
             int baseVertex = (int) state.getVertexSegment()
                     .getOffset();
 
-            if (SodiumClientMod.options().advanced.useBlockFaceCulling) {
-                
+            if (this.enableBlockFaceCull) {
+
                 ChunkRenderBounds bounds = render.getBounds();
 
                 this.addDrawCall(state.getModelPart(ModelQuadFacing.UNASSIGNED), indexOffset, baseVertex);

--- a/src/main/java/me/jellysquid/mods/sodium/common/config/SodiumConfig.java
+++ b/src/main/java/me/jellysquid/mods/sodium/common/config/SodiumConfig.java
@@ -55,6 +55,7 @@ public class SodiumConfig {
         this.addMixinRule("features.world_ticking", true);
         this.addMixinRule("features.fast_biome_colors", true);
         this.addMixinRule("features.shader", true);
+        this.addMixinRule("features.fast_leaf_culling", true);
     }
 
     /**

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/fast_leaf_culling/MixinLeavesBlock.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/fast_leaf_culling/MixinLeavesBlock.java
@@ -1,0 +1,30 @@
+package me.jellysquid.mods.sodium.mixin.features.fast_leaf_culling;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.LeavesBlock;
+import net.minecraft.block.Material;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.option.GraphicsMode;
+import net.minecraft.util.math.Direction;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(LeavesBlock.class)
+public class MixinLeavesBlock extends Block {
+    public MixinLeavesBlock() {
+        super(Settings.of(Material.AIR));
+        throw new AssertionError("Mixin constructor called!");
+    }
+
+    @Override
+    public boolean isSideInvisible(BlockState state, BlockState stateFrom, Direction direction) {
+        if (FabricLoader.getInstance().getEnvironmentType() == EnvType.CLIENT) {
+            if (MinecraftClient.getInstance().options.graphicsMode == GraphicsMode.FAST) {
+                return stateFrom.getBlock() instanceof LeavesBlock || super.isSideInvisible(state, stateFrom, direction);
+            }
+        }
+        return super.isSideInvisible(state, stateFrom, direction);
+    }
+}

--- a/src/main/resources/sodium.mixins.json
+++ b/src/main/resources/sodium.mixins.json
@@ -38,6 +38,7 @@
     "features.entity.smooth_lighting.MixinEntityRenderer",
     "features.fast_biome_colors.MixinBackgroundRenderer",
     "features.fast_biome_colors.MixinClientWorld",
+    "features.fast_leaf_culling.MixinLeavesBlock",
     "features.gui.MixinDebugHud",
     "features.gui.fast_loading_screen.MixinLevelLoadingScreen",
     "features.gui.font.MixinGlyphRenderer",


### PR DESCRIPTION
sodium had an option to toggle block face culling but it was never used in sodium 0.3. disabling block face culling is required for resource packs that use models

#817
#732