### PR TITLE
fix: Ensure entities with outlines or nametags are always visible

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -319,6 +319,11 @@ public class SodiumWorldRenderer implements ChunkStatusListener {
             return true;
         }
 
+        // Ensure entities with outlines or nametags are always visible
+        if (this.client.hasOutline(entity) || entity.shouldRenderName()) {
+            return true;
+        }
+
         return this.isBoxVisible(box.minX, box.minY, box.minZ, box.maxX, box.maxY, box.maxZ);
     }
 

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/entity/cull/MixinEntityRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/entity/cull/MixinEntityRenderer.java
@@ -1,4 +1,4 @@
-package me.jellysquid.mods.sodium.mixin.features.entity.smooth_lighting;
+package me.jellysquid.mods.sodium.mixin.features.entity.cull;
 
 import me.jellysquid.mods.sodium.client.render.SodiumWorldRenderer;
 import net.minecraft.client.render.Frustum;

--- a/src/main/resources/sodium.mixins.json
+++ b/src/main/resources/sodium.mixins.json
@@ -35,7 +35,7 @@
     "features.debug.MixinDebugHud",
     "features.entity.fast_render.MixinCuboid",
     "features.entity.fast_render.MixinModelPart",
-    "features.entity.smooth_lighting.MixinEntityRenderer",
+    "features.entity.cull.MixinEntityRenderer",
     "features.fast_biome_colors.MixinBackgroundRenderer",
     "features.fast_biome_colors.MixinClientWorld",
     "features.gui.MixinDebugHud",


### PR DESCRIPTION
Currently, entities that can be seen through blocks (such as ones with the glowing effect or nametags) are not visible when in culled chunks. This is because Sodium culls entities in culled chunks.

This pull request adds an extra condition that marks entities as visible when they have the glowing effect or nametags, which should prevent them from being culled in culled chunks. This also repackages `me.jellysquid.mods.sodium.mixin.features.entity.smooth_lighting` to `me.jellysquid.mods.sodium.mixin.features.entity.cull`, since the Mixin has nothing to do with smooth lighting anymore.

This PR is the original implementation of #666, updated for 1.17. See #666 for more info and [this comment](https://github.com/CaffeineMC/sodium-fabric/pull/666#issuecomment-894066555) on why the more complex changes were dropped.