### PR TITLE
added extra file handling

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
@@ -13,6 +13,8 @@ public class SodiumClientMod implements ClientModInitializer {
 
     private static String MOD_VERSION;
 
+    public static boolean forcedReset = false;
+
     @Override
     public void onInitializeClient() {
         ModContainer mod = FabricLoader.getInstance()

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -49,7 +49,6 @@ public class SodiumGameOptions {
 
     public static class NotificationSettings {
         public boolean hideDonationButton = false;
-        public boolean forcedReset = false;
     }
 
     public enum ArenaMemoryAllocator implements TextProvider {

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -145,7 +145,6 @@ public class SodiumGameOptions {
         // Also use the PID to ensure no other instance of MC can write to the same tmp file
         long pid = ProcessHandle.current().pid();
         Path tempPath = this.configPath.resolveSibling(this.configPath.getFileName() + String.valueOf(pid) + ".tmp");
-        SodiumClientMod.logger().info(tempPath);
 
         // Write the file to our temporary location
         Files.writeString(tempPath, GSON.toJson(this));

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -3,6 +3,7 @@ package me.jellysquid.mods.sodium.client.gui;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
 import com.google.gson.stream.JsonReader;
 import me.jellysquid.mods.sodium.client.gui.options.TextProvider;
 import net.minecraft.client.option.GraphicsMode;
@@ -102,7 +103,7 @@ public class SodiumGameOptions {
         if (Files.exists(path)) {
             try (JsonReader reader = new JsonReader(new FileReader(path.toFile()))) {
                 config = GSON.fromJson(reader, SodiumGameOptions.class);
-            } catch (IOException e) {
+            } catch (IOException | JsonSyntaxException e) {
                 throw new RuntimeException("Could not parse config", e);
             }
         } else {

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -5,6 +5,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.stream.JsonReader;
+import me.jellysquid.mods.sodium.client.SodiumClientMod;
 import me.jellysquid.mods.sodium.client.gui.options.TextProvider;
 import net.minecraft.client.option.GraphicsMode;
 import net.minecraft.text.LiteralText;
@@ -104,7 +105,8 @@ public class SodiumGameOptions {
             try (JsonReader reader = new JsonReader(new FileReader(path.toFile()))) {
                 config = GSON.fromJson(reader, SodiumGameOptions.class);
             } catch (IOException | JsonSyntaxException e) {
-                throw new RuntimeException("Could not parse config", e);
+                SodiumClientMod.logger().warn("Could not parse config. Resetting config.");
+                config = new SodiumGameOptions();
             }
         } else {
             config = new SodiumGameOptions();

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -49,6 +49,7 @@ public class SodiumGameOptions {
 
     public static class NotificationSettings {
         public boolean hideDonationButton = false;
+        public boolean forcedReset = false;
     }
 
     public enum ArenaMemoryAllocator implements TextProvider {
@@ -70,6 +71,7 @@ public class SodiumGameOptions {
             return this.name;
         }
     }
+
 
     public enum GraphicsQuality implements TextProvider {
         DEFAULT("generator.default"),
@@ -107,9 +109,11 @@ public class SodiumGameOptions {
             } catch (IOException | JsonSyntaxException e) {
                 SodiumClientMod.logger().warn("Could not parse config. Resetting config.");
                 config = new SodiumGameOptions();
+                SodiumClientMod.forcedReset = true;
             }
         } else {
             config = new SodiumGameOptions();
+            SodiumClientMod.forcedReset = true;
         }
 
         config.configPath = path;

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -142,7 +142,10 @@ public class SodiumGameOptions {
         if (!file.canWrite() && file.exists()){throw new IOException("Sodium Config is read-only.");}
 
         // Use a temporary location next to the config's final destination
-        Path tempPath = this.configPath.resolveSibling(this.configPath.getFileName() + ".tmp");
+        // Also use the PID to ensure no other instance of MC can write to the same tmp file
+        long pid = ProcessHandle.current().pid();
+        Path tempPath = this.configPath.resolveSibling(this.configPath.getFileName() + String.valueOf(pid) + ".tmp");
+        SodiumClientMod.logger().info(tempPath);
 
         // Write the file to our temporary location
         Files.writeString(tempPath, GSON.toJson(this));

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -3,19 +3,20 @@ package me.jellysquid.mods.sodium.client.gui;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.stream.JsonReader;
 import me.jellysquid.mods.sodium.client.gui.options.TextProvider;
 import net.minecraft.client.option.GraphicsMode;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
 
+import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.lang.reflect.Modifier;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
 
 public class SodiumGameOptions {
     public final QualitySettings quality = new QualitySettings();
@@ -99,7 +100,7 @@ public class SodiumGameOptions {
         SodiumGameOptions config;
 
         if (Files.exists(path)) {
-            try (FileReader reader = new FileReader(path.toFile())) {
+            try (JsonReader reader = new JsonReader(new FileReader(path.toFile()))) {
                 config = GSON.fromJson(reader, SodiumGameOptions.class);
             } catch (IOException e) {
                 throw new RuntimeException("Could not parse config", e);
@@ -125,12 +126,14 @@ public class SodiumGameOptions {
 
     public void writeChanges() throws IOException {
         Path dir = this.configPath.getParent();
+        File file = new File(String.valueOf(this.configPath.resolveSibling(this.configPath.getFileName())));
 
         if (!Files.exists(dir)) {
             Files.createDirectories(dir);
         } else if (!Files.isDirectory(dir)) {
             throw new IOException("Not a directory: " + dir);
         }
+        if (!file.canWrite()){throw new IOException("Sodium Config is read-only.");}
 
         // Use a temporary location next to the config's final destination
         Path tempPath = this.configPath.resolveSibling(this.configPath.getFileName() + ".tmp");

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -134,7 +134,7 @@ public class SodiumGameOptions {
         } else if (!Files.isDirectory(dir)) {
             throw new IOException("Not a directory: " + dir);
         }
-        if (!file.canWrite()){throw new IOException("Sodium Config is read-only.");}
+        if (!file.canWrite() && file.exists()){throw new IOException("Sodium Config is read-only.");}
 
         // Use a temporary location next to the config's final destination
         Path tempPath = this.configPath.resolveSibling(this.configPath.getFileName() + ".tmp");

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumOptionsGUI.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumOptionsGUI.java
@@ -37,9 +37,11 @@ public class SodiumOptionsGUI extends Screen {
 
     private FlatButtonWidget applyButton, closeButton, undoButton;
     private FlatButtonWidget donateButton, hideDonateButton;
+    private FlatButtonWidget configResetButton;
 
     private boolean hasPendingChanges;
     private ControlElement<?> hoveredElement;
+
 
     public SodiumOptionsGUI(Screen prevScreen) {
         super(new TranslatableText("Sodium Options"));
@@ -84,11 +86,15 @@ public class SodiumOptionsGUI extends Screen {
         this.undoButton = new FlatButtonWidget(new Dim2i(this.width - 211, this.height - 30, 65, 20), new TranslatableText("sodium.options.buttons.undo"), this::undoChanges);
         this.applyButton = new FlatButtonWidget(new Dim2i(this.width - 142, this.height - 30, 65, 20), new TranslatableText("sodium.options.buttons.apply"), this::applyChanges);
         this.closeButton = new FlatButtonWidget(new Dim2i(this.width - 73, this.height - 30, 65, 20), new TranslatableText("sodium.options.buttons.close"), this::onClose);
+        this.configResetButton = new FlatButtonWidget(new Dim2i(this.width - 211, this.height - 55, 203, 20), new TranslatableText("sodium.options.buttons.config_error"),this::hideConfigReset);
         this.donateButton = new FlatButtonWidget(new Dim2i(this.width - 128, 6, 100, 20), new TranslatableText("sodium.options.buttons.donate"), this::openDonationPage);
         this.hideDonateButton = new FlatButtonWidget(new Dim2i(this.width - 26, 6, 20, 20), new LiteralText("x"), this::hideDonationButton);
 
         if (SodiumClientMod.options().notifications.hideDonationButton) {
             this.setDonationButtonVisibility(false);
+        }
+        if (!SodiumClientMod.forcedReset) {
+            this.configResetButton.setVisible(false);
         }
 
         this.addDrawableChild(this.undoButton);
@@ -96,11 +102,17 @@ public class SodiumOptionsGUI extends Screen {
         this.addDrawableChild(this.closeButton);
         this.addDrawableChild(this.donateButton);
         this.addDrawableChild(this.hideDonateButton);
+        this.addDrawableChild(this.configResetButton);
     }
 
     private void setDonationButtonVisibility(boolean value) {
         this.donateButton.setVisible(value);
         this.hideDonateButton.setVisible(value);
+    }
+
+    private void hideConfigReset(){
+        this.configResetButton.setVisible(false);
+        SodiumClientMod.forcedReset = false;
     }
 
     private void hideDonationButton() {

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/options/storage/SodiumOptionsStorage.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/options/storage/SodiumOptionsStorage.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 
 public class SodiumOptionsStorage implements OptionStorage<SodiumGameOptions> {
     private final SodiumGameOptions options;
+    public boolean forcedReset = false;
 
     public SodiumOptionsStorage() {
         this.options = SodiumClientMod.options();

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/widgets/FlatButtonWidget.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/widgets/FlatButtonWidget.java
@@ -20,6 +20,7 @@ public class FlatButtonWidget extends AbstractWidget implements Drawable {
         this.action = action;
     }
 
+
     @Override
     public void render(MatrixStack matrixStack, int mouseX, int mouseY, float delta) {
         if (!this.visible) {

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/widgets/FlatButtonWidget.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/widgets/FlatButtonWidget.java
@@ -19,7 +19,7 @@ public class FlatButtonWidget extends AbstractWidget implements Drawable {
         this.label = label;
         this.action = action;
     }
-    
+
     @Override
     public void render(MatrixStack matrixStack, int mouseX, int mouseY, float delta) {
         if (!this.visible) {

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/widgets/FlatButtonWidget.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/widgets/FlatButtonWidget.java
@@ -19,8 +19,7 @@ public class FlatButtonWidget extends AbstractWidget implements Drawable {
         this.label = label;
         this.action = action;
     }
-
-
+    
     @Override
     public void render(MatrixStack matrixStack, int mouseX, int mouseY, float delta) {
         if (!this.visible) {

--- a/src/main/resources/assets/sodium/lang/en_us.json
+++ b/src/main/resources/assets/sodium/lang/en_us.json
@@ -52,5 +52,6 @@
   "sodium.options.buttons.undo": "Undo",
   "sodium.options.buttons.apply": "Apply",
   "sodium.options.buttons.close": "Close",
-  "sodium.options.buttons.donate": "Buy us a coffee!"
+  "sodium.options.buttons.donate": "Buy us a coffee!",
+  "sodium.options.buttons.config_error": "§cConfig reset, unable to read at boot"
 }


### PR DESCRIPTION
`try (JsonReader reader = new JsonReader(new FileReader(path.toFile()))) {`

without using JsonReader could cause a MalformedJsonException if the file was corrupt


`if (!file.canWrite() && file.exists()){throw new IOException("Sodium Config is read-only.");}`

without checking if the config is readonly the Files.move will cause AccessDeniedException