### PR TITLE
Clean up simple compiler warnings: Unused imports, untyped generic.

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gl/buffer/GlBufferMapping.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gl/buffer/GlBufferMapping.java
@@ -2,7 +2,6 @@ package me.jellysquid.mods.sodium.client.gl.buffer;
 
 import org.lwjgl.system.MemoryUtil;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 public class GlBufferMapping {

--- a/src/main/java/me/jellysquid/mods/sodium/client/gl/buffer/GlBufferTarget.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gl/buffer/GlBufferTarget.java
@@ -2,7 +2,6 @@ package me.jellysquid.mods.sodium.client.gl.buffer;
 
 import org.lwjgl.opengl.GL20C;
 import org.lwjgl.opengl.GL31C;
-import org.lwjgl.opengl.GL40C;
 
 public enum GlBufferTarget {
     ARRAY_BUFFER(GL20C.GL_ARRAY_BUFFER, GL20C.GL_ARRAY_BUFFER_BINDING),

--- a/src/main/java/me/jellysquid/mods/sodium/client/gl/shader/GlProgram.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gl/shader/GlProgram.java
@@ -4,7 +4,6 @@ import com.mojang.blaze3d.platform.GlStateManager;
 import me.jellysquid.mods.sodium.client.gl.GlObject;
 import me.jellysquid.mods.sodium.client.gl.shader.uniform.GlUniform;
 import me.jellysquid.mods.sodium.client.gl.shader.uniform.GlUniformBlock;
-import me.jellysquid.mods.sodium.client.render.chunk.shader.ChunkShaderInterface;
 import me.jellysquid.mods.sodium.client.render.chunk.shader.ShaderBindingContext;
 import net.minecraft.util.Identifier;
 import org.apache.logging.log4j.LogManager;
@@ -130,7 +129,7 @@ public class GlProgram<T> extends GlObject implements ShaderBindingContext {
         }
     }
 
-    public interface ProgramFactory<P extends GlProgram> {
+    public interface ProgramFactory<P extends GlProgram<?>> {
         P create(int handle);
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/gl/shader/uniform/GlUniformBlock.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gl/shader/uniform/GlUniformBlock.java
@@ -1,7 +1,6 @@
 package me.jellysquid.mods.sodium.client.gl.shader.uniform;
 
 import me.jellysquid.mods.sodium.client.gl.buffer.GlBuffer;
-import me.jellysquid.mods.sodium.client.gl.shader.GlProgram;
 import org.lwjgl.opengl.GL32C;
 
 public class GlUniformBlock {

--- a/src/main/java/me/jellysquid/mods/sodium/client/gl/sync/GlFence.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gl/sync/GlFence.java
@@ -1,7 +1,5 @@
 package me.jellysquid.mods.sodium.client.gl.sync;
 
-import me.jellysquid.mods.sodium.client.gl.GlObject;
-import org.lwjgl.opengl.GL30C;
 import org.lwjgl.opengl.GL32C;
 import org.lwjgl.system.MemoryStack;
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/gl/tessellation/GlAbstractTessellation.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gl/tessellation/GlAbstractTessellation.java
@@ -1,8 +1,6 @@
 package me.jellysquid.mods.sodium.client.gl.tessellation;
 
 import me.jellysquid.mods.sodium.client.gl.attribute.GlVertexAttributeBinding;
-import me.jellysquid.mods.sodium.client.gl.buffer.GlBuffer;
-import me.jellysquid.mods.sodium.client.gl.buffer.GlBufferTarget;
 import me.jellysquid.mods.sodium.client.gl.device.CommandList;
 import org.lwjgl.opengl.GL20C;
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/gl/tessellation/GlVertexArrayTessellation.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gl/tessellation/GlVertexArrayTessellation.java
@@ -1,7 +1,6 @@
 package me.jellysquid.mods.sodium.client.gl.tessellation;
 
 import me.jellysquid.mods.sodium.client.gl.array.GlVertexArray;
-import me.jellysquid.mods.sodium.client.gl.buffer.GlBuffer;
 import me.jellysquid.mods.sodium.client.gl.device.CommandList;
 
 public class GlVertexArrayTessellation extends GlAbstractTessellation {

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/ControlElement.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/ControlElement.java
@@ -4,7 +4,6 @@ import me.jellysquid.mods.sodium.client.gui.options.Option;
 import me.jellysquid.mods.sodium.client.gui.widgets.AbstractWidget;
 import me.jellysquid.mods.sodium.client.util.Dim2i;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 
 public class ControlElement<T> extends AbstractWidget {

--- a/src/main/java/me/jellysquid/mods/sodium/client/model/IndexBufferBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/model/IndexBufferBuilder.java
@@ -1,12 +1,9 @@
 package me.jellysquid.mods.sodium.client.model;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import it.unimi.dsi.fastutil.ints.IntArrays;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import me.jellysquid.mods.sodium.client.gl.tessellation.GlIndexType;
-import me.jellysquid.mods.sodium.client.gl.util.ElementRange;
 import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadWinding;
-import me.jellysquid.mods.sodium.client.model.vertex.buffer.VertexBufferBuilder;
 
 import java.nio.ByteBuffer;
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkGraphicsState.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkGraphicsState.java
@@ -1,7 +1,6 @@
 package me.jellysquid.mods.sodium.client.render.chunk;
 
 import me.jellysquid.mods.sodium.client.gl.arena.GlBufferSegment;
-import me.jellysquid.mods.sodium.client.gl.tessellation.GlIndexType;
 import me.jellysquid.mods.sodium.client.gl.util.ElementRange;
 import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadFacing;
 import me.jellysquid.mods.sodium.client.render.chunk.data.ChunkMeshData;

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RegionChunkRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RegionChunkRenderer.java
@@ -15,7 +15,6 @@ import me.jellysquid.mods.sodium.client.gl.tessellation.GlTessellation;
 import me.jellysquid.mods.sodium.client.gl.tessellation.TessellationBinding;
 import me.jellysquid.mods.sodium.client.gl.util.ElementRange;
 import me.jellysquid.mods.sodium.client.gl.util.MultiDrawBatch;
-import me.jellysquid.mods.sodium.client.model.quad.ModelQuad;
 import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadFacing;
 import me.jellysquid.mods.sodium.client.model.vertex.type.ChunkVertexType;
 import me.jellysquid.mods.sodium.client.render.chunk.data.ChunkRenderBounds;

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildBuffers.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildBuffers.java
@@ -15,7 +15,6 @@ import me.jellysquid.mods.sodium.client.render.chunk.passes.BlockRenderPass;
 import me.jellysquid.mods.sodium.client.render.chunk.passes.BlockRenderPassManager;
 import me.jellysquid.mods.sodium.client.util.NativeBuffer;
 import net.minecraft.client.render.RenderLayer;
-import net.minecraft.util.math.Vec3i;
 
 import java.util.Arrays;
 import java.util.EnumMap;

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildResult.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildResult.java
@@ -1,6 +1,5 @@
 package me.jellysquid.mods.sodium.client.render.chunk.compile;
 
-import me.jellysquid.mods.sodium.client.gl.tessellation.GlIndexType;
 import me.jellysquid.mods.sodium.client.render.chunk.RenderSection;
 import me.jellysquid.mods.sodium.client.render.chunk.data.ChunkMeshData;
 import me.jellysquid.mods.sodium.client.render.chunk.data.ChunkRenderData;

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/buffers/BakedChunkModelBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/buffers/BakedChunkModelBuilder.java
@@ -2,13 +2,9 @@ package me.jellysquid.mods.sodium.client.render.chunk.compile.buffers;
 
 import me.jellysquid.mods.sodium.client.model.IndexBufferBuilder;
 import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadFacing;
-import me.jellysquid.mods.sodium.client.render.chunk.RegionChunkRenderer;
-import me.jellysquid.mods.sodium.client.render.chunk.RenderSection;
 import me.jellysquid.mods.sodium.client.render.chunk.data.ChunkRenderData;
 import me.jellysquid.mods.sodium.client.render.chunk.format.ModelVertexSink;
-import me.jellysquid.mods.sodium.client.render.chunk.region.RenderRegion;
 import net.minecraft.client.texture.Sprite;
-import net.minecraft.util.math.Vec3i;
 
 public class BakedChunkModelBuilder implements ChunkModelBuilder {
     private final ModelVertexSink vertexSink;

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/region/RenderRegion.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/region/RenderRegion.java
@@ -8,7 +8,6 @@ import me.jellysquid.mods.sodium.client.gl.arena.SwapBufferArena;
 import me.jellysquid.mods.sodium.client.gl.arena.staging.StagingBuffer;
 import me.jellysquid.mods.sodium.client.gl.device.CommandList;
 import me.jellysquid.mods.sodium.client.gl.tessellation.GlTessellation;
-import me.jellysquid.mods.sodium.client.render.chunk.ChunkRenderer;
 import me.jellysquid.mods.sodium.client.render.chunk.RenderSection;
 import me.jellysquid.mods.sodium.client.render.chunk.format.ChunkModelVertexFormats;
 import me.jellysquid.mods.sodium.client.render.chunk.passes.BlockRenderPass;

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/shader/ChunkShaderInterface.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/shader/ChunkShaderInterface.java
@@ -2,8 +2,6 @@ package me.jellysquid.mods.sodium.client.render.chunk.shader;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import me.jellysquid.mods.sodium.client.gl.buffer.GlMutableBuffer;
-import me.jellysquid.mods.sodium.client.gl.shader.GlProgram;
-import me.jellysquid.mods.sodium.client.gl.device.RenderDevice;
 import me.jellysquid.mods.sodium.client.gl.shader.uniform.GlUniformBlock;
 import me.jellysquid.mods.sodium.client.gl.shader.uniform.GlUniformFloat;
 import me.jellysquid.mods.sodium.client.gl.shader.uniform.GlUniformInt;

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/tasks/ChunkRenderRebuildTask.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/tasks/ChunkRenderRebuildTask.java
@@ -7,7 +7,6 @@ import me.jellysquid.mods.sodium.client.render.chunk.data.ChunkMeshData;
 import me.jellysquid.mods.sodium.client.render.chunk.data.ChunkRenderBounds;
 import me.jellysquid.mods.sodium.client.render.chunk.data.ChunkRenderData;
 import me.jellysquid.mods.sodium.client.render.chunk.passes.BlockRenderPass;
-import me.jellysquid.mods.sodium.client.render.chunk.region.RenderRegion;
 import me.jellysquid.mods.sodium.client.render.pipeline.context.ChunkRenderCacheLocal;
 import me.jellysquid.mods.sodium.client.util.task.CancellationSource;
 import me.jellysquid.mods.sodium.client.world.WorldSlice;
@@ -23,7 +22,6 @@ import net.minecraft.client.render.chunk.ChunkOcclusionDataBuilder;
 import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Vec3i;
 
 import java.util.EnumMap;
 import java.util.Map;

--- a/src/main/java/me/jellysquid/mods/sodium/client/util/NativeBuffer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/util/NativeBuffer.java
@@ -4,7 +4,6 @@ import it.unimi.dsi.fastutil.objects.Reference2ReferenceMap;
 import it.unimi.dsi.fastutil.objects.Reference2ReferenceMaps;
 import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
 import me.jellysquid.mods.sodium.client.SodiumClientMod;
-import me.jellysquid.mods.sodium.client.gui.SodiumGameOptions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.lwjgl.system.MemoryUtil;


### PR DESCRIPTION
Was just poking around and noticed these warnings.  There were a few "resource leak" warnings I didn't touch.