### PR TITLE
fix: Fix copy consolidation on arena buffer resize (0.4-experiments)

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/render/chunk/arena/AsyncBufferArena.java
+++ b/src/main/java/me/jellysquid/mods/sodium/render/chunk/arena/AsyncBufferArena.java
@@ -79,7 +79,7 @@ public class AsyncBufferArena implements GlBufferArena {
         for (int i = 0; i < usedSegments.size(); i++) {
             GlBufferSegment s = usedSegments.get(i);
 
-            if (currentCopyCommand == null || currentCopyCommand.writeOffset + currentCopyCommand.length != s.getOffset() || !s.isUploaded()) {
+            if (currentCopyCommand == null || currentCopyCommand.readOffset + currentCopyCommand.length != s.getOffset() || !s.isUploaded()) {
                 if (currentCopyCommand != null) {
                     pendingCopies.add(currentCopyCommand);
                 }


### PR DESCRIPTION
**Before:**
No copy commands were merged in `AsyncBufferArena` during resizing. This could sometimes generate hundreds of copy commands, which, according to RenderDoc, would take up around 1/4 of the frame time and cause performance dips.

Copy commands were merged naively in `MappedStagingBuffer`, only merging if two sequential copies shared a border.

**After:**
In `AsyncBufferArena`, we know that no copies will intersect, but only border each other. This makes it much simpler to merge perfectly, so it is implemented with these assumptions to improve performance. This typically removes ~90% of copy calls.

In `MappedStagingBuffer`, copies that don't share a border can still be merged as long as they intersect at all. Also, situations where a portion of a buffer is written to multiple times are eliminated in all cases (I think). This wasn't as much of a benefit as the first, but it still removed ~20% of copy calls.

I'm not sure if this is able to be merged into dev, but if possible, I will open a new PR that applies the changes to it. They weren't exact 1:1 scenarios, but they should give an idea of the changes.

**Comparison:**
Both were captured while flying at full speed in spectator mode to make sure RenderDoc would pick up both copy events.

Before:
![before-changes-comparison](https://user-images.githubusercontent.com/30326913/137553476-59b82856-ef24-4375-9022-e3e2f5330760.png)


After:
![after-changes-comparison](https://user-images.githubusercontent.com/30326913/137553496-bcf95115-f68a-46d6-8d58-1349c0897918.png)
