### PR TITLE
Fix building and running with Java 17

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/me/jellysquid/mods/sodium/client/util/rand/XoRoShiRoRandom.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/util/rand/XoRoShiRoRandom.java
@@ -61,7 +61,7 @@ public class XoRoShiRoRandom extends Random {
         return (int) this.nextLong(n);
     }
 
-    private long nextLong(final long n) {
+    public long nextLong(final long n) {
         if (n <= 0) {
             throw new IllegalArgumentException("illegal bound " + n + " (must be positive)");
         }


### PR DESCRIPTION
Alongside updating to the latest Gradle RC, this upgrades the visibility of the nextLong method to match 17's random and thus not error.