### PR TITLE
Apply mod overrides when generating config (#915)

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/common/config/SodiumConfig.java
+++ b/src/main/java/me/jellysquid/mods/sodium/common/config/SodiumConfig.java
@@ -188,7 +188,10 @@ public class SodiumConfig {
                 LOGGER.warn("Could not write default configuration file", e);
             }
 
-            return new SodiumConfig();
+            SodiumConfig config = new SodiumConfig();
+            config.applyModOverrides();
+
+            return config;
         }
 
         Properties props = new Properties();


### PR DESCRIPTION
Ensures that mod overrides are applied when a config files is not found and needs to be generated for the first time.
Closes #915 

As a note, this is my first time contributing to an open source Java project so please let me know if there are any issues with how I have setup my pull request. I have attempted to follow the CONTRIBUTING.md guidelines, however it is entirely possible I missed something.