### PR TITLE
Replace fragile Shadow with constructor inject

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/texture_tracking/MixinSpriteAnimation.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/texture_tracking/MixinSpriteAnimation.java
@@ -3,18 +3,27 @@ package me.jellysquid.mods.sodium.mixin.features.texture_tracking;
 import me.jellysquid.mods.sodium.client.SodiumClientMod;
 import me.jellysquid.mods.sodium.client.render.texture.SpriteExtended;
 import net.minecraft.client.texture.Sprite;
-import org.spongepowered.asm.mixin.Dynamic;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.List;
+
 @Mixin(Sprite.Animation.class)
 public class MixinSpriteAnimation {
-    @Shadow(aliases = "field_28469")
-    @Dynamic
+    @Unique
     private Sprite parent;
+
+    /**
+     * @author IMS
+     * @reason Replace fragile Shadow
+     */
+    @Inject(method = "<init>", at = @At("RETURN"))
+    public void assignParent(Sprite parent, List frames, int frameCount, Sprite.Interpolation interpolation, CallbackInfo ci) {
+        this.parent = parent;
+    }
 
     @Inject(method = "tick", at = @At("HEAD"), cancellable = true)
     private void preTick(CallbackInfo ci) {

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/texture_updates/MixinSpriteInterpolated.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/texture_updates/MixinSpriteInterpolated.java
@@ -4,10 +4,10 @@ import me.jellysquid.mods.sodium.client.util.color.ColorMixer;
 import net.minecraft.client.texture.NativeImage;
 import net.minecraft.client.texture.Sprite;
 import org.lwjgl.system.MemoryUtil;
-import org.spongepowered.asm.mixin.Final;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.*;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Sprite.Interpolation.class)
 public class MixinSpriteInterpolated {
@@ -15,10 +15,19 @@ public class MixinSpriteInterpolated {
     @Final
     private NativeImage[] images;
 
-    @Shadow(aliases = "field_21757")
+    @Unique
     private Sprite parent;
 
     private static final int STRIDE = 4;
+
+    /**
+     * @author IMS
+     * @reason Replace fragile Shadow
+     */
+    @Inject(method = "<init>", at = @At("RETURN"))
+    public void assignParent(Sprite parent, Sprite.Info info, int maxLevel, CallbackInfo ci) {
+        this.parent = parent;
+    }
 
     /**
      * @author JellySquid


### PR DESCRIPTION
The Shadow alias is known to break in many cases, most commonly when importing Sodium into an development environment.