### PR TITLE
Handle DashLoaders use of Unsafe.allocateInstance()

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/model/MixinMultipartBakedModel.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/model/MixinMultipartBakedModel.java
@@ -36,7 +36,9 @@ public class MixinMultipartBakedModel {
         }
 
         // DashLoader fix as its using Unsafe.allocateInstance()
-        if(stateCacheFast == null) stateCacheFast = STATE_CACHE_CREATOR.get();
+        if(this.stateCacheFast == null)  {
+            this.stateCacheFast = STATE_CACHE_CREATOR.get();
+        }
 
         List<BakedModel> models;
 

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/shader/MixinShader.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/shader/MixinShader.java
@@ -8,16 +8,23 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+import java.util.function.Supplier;
+
 @Mixin(Shader.class)
 public class MixinShader {
-    private final Object2IntMap<CharSequence> uniformLocationCache = new Object2IntOpenHashMap<>();
+    private static final Supplier<Object2IntMap<CharSequence>> UNIFORM_CACHE_CREATOR = () -> {
+        Object2IntMap<CharSequence> out = new Object2IntOpenHashMap<>();
+        out.defaultReturnValue(-1);
+        return out;
+    };
 
-    public MixinShader() {
-        this.uniformLocationCache.defaultReturnValue(-1);
-    }
+    private Object2IntMap<CharSequence> uniformLocationCache = UNIFORM_CACHE_CREATOR.get();
 
     @Redirect(method = "upload", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gl/GlUniform;getUniformLocation(ILjava/lang/CharSequence;)I"))
     private int redirectGetUniformLocation(int program, CharSequence name) {
+        // DashLoader fix as its using Unsafe.allocateInstance()
+        if(uniformLocationCache == null) uniformLocationCache = UNIFORM_CACHE_CREATOR.get();
+
         int id = this.uniformLocationCache.computeIfAbsent(name, (key) -> GlUniform.getUniformLocation(program, key));
 
         if (id < 0) {

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/shader/MixinShader.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/shader/MixinShader.java
@@ -23,7 +23,9 @@ public class MixinShader {
     @Redirect(method = "upload", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gl/GlUniform;getUniformLocation(ILjava/lang/CharSequence;)I"))
     private int redirectGetUniformLocation(int program, CharSequence name) {
         // DashLoader fix as its using Unsafe.allocateInstance()
-        if(uniformLocationCache == null) uniformLocationCache = UNIFORM_CACHE_CREATOR.get();
+        if(this.uniformLocationCache == null) {
+            this.uniformLocationCache = UNIFORM_CACHE_CREATOR.get();
+        }
 
         int id = this.uniformLocationCache.computeIfAbsent(name, (key) -> GlUniform.getUniformLocation(program, key));
 


### PR DESCRIPTION
DashLoader uses Unsafe.allocateInstance in spots where we cannot use the constructor as we have cached all of the fields to save computation on initialization. Sodium has a couple of conflicts were in the past DashLoader needed to disable a couple of important Sodium features to stay compatible. This pr solves all of the important conflicts.