### PR TITLE
Fix mistake with #892 using static water sprite for invisible blocks

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/FluidRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/FluidRenderer.java
@@ -19,6 +19,7 @@ import me.jellysquid.mods.sodium.client.util.color.ColorABGR;
 import me.jellysquid.mods.sodium.common.util.DirectionUtil;
 import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandler;
 import net.fabricmc.fabric.impl.client.rendering.fluid.FluidRenderHandlerRegistryImpl;
+import net.minecraft.block.BlockRenderType;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.SideShapeType;
 import net.minecraft.client.MinecraftClient;
@@ -321,10 +322,10 @@ public class FluidRenderer {
                     BlockPos adjPos = this.scratchPos.set(adjX, adjY, adjZ);
                     BlockState adjBlock = world.getBlockState(adjPos);
 
-                    if (!adjBlock.isOpaque() && !adjBlock.isAir()) {
-                        // ice, glass, stained glass, tinted glass
+                    if (!adjBlock.isOpaque() && adjBlock.getRenderType() != BlockRenderType.INVISIBLE) {
+                        // should ignore invisible blocks, barriers, light blocks
+                        // use static water when adjacent block is ice, glass, stained glass, tinted glass
                         sprite = this.waterOverlaySprite;
-
                     }
                 }
 


### PR DESCRIPTION
small fix for #991 single line change

`(!adjBlock.isOpaque() && adjBlock.getRenderType() != BlockRenderType.INVISIBLE)`

without water will render with the static sprite when barrier or light blocks are placed next to it. with the water will render with the animated sprite