### PR TITLE
Make issue templates use new label names, as well as S-needs-triage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,8 @@
 name: Bug report
-description: ' Use this template if you''re running into bugs or other issues '
-labels: bug
+description: "Use this template if you're running into bugs or other issues"
+labels:
+  - T-bug
+  - S-needs-triage
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yml
@@ -1,6 +1,8 @@
 name: Crash report
 description: Use this template if your game is crashing or failing to start correctly
-labels: crash
+labels:
+  - T-crash
+  - S-needs-triage
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-labels: enhancement
-assignees: ''
-
+labels: T-enhancement, S-needs-triage
 ---
 
 **Is your feature request related to a problem? Please describe.**


### PR DESCRIPTION
I also renamed `crash-report.yml` to `crash_report.yml` for consistency, and removed a few unused yaml fields from `feature_request.md`