### PR TITLE
Add homepage for MultiMC

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -8,6 +8,7 @@
     "JellySquid"
   ],
   "contact": {
+    "homepage": "https://github.com/CaffeineMC/sodium-fabric",
     "sources": "https://github.com/CaffeineMC/sodium-fabric",
     "issues": "https://github.com/CaffeineMC/sodium-fabric/issues"
   },


### PR DESCRIPTION
Adds a homepage link to the mod config, which adds a clickable link in MultiMC to the Github page.