### PR TITLE
Fixing static water again

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/FluidRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/pipeline/FluidRenderer.java
@@ -20,7 +20,9 @@ import me.jellysquid.mods.sodium.common.util.DirectionUtil;
 import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandler;
 import net.fabricmc.fabric.impl.client.rendering.fluid.FluidRenderHandlerRegistryImpl;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.LeavesBlock;
 import net.minecraft.block.SideShapeType;
+import net.minecraft.block.TransparentBlock;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.model.ModelLoader;
 import net.minecraft.client.texture.Sprite;
@@ -321,10 +323,10 @@ public class FluidRenderer {
                     BlockPos adjPos = this.scratchPos.set(adjX, adjY, adjZ);
                     BlockState adjBlock = world.getBlockState(adjPos);
 
-                    if (!adjBlock.isOpaque() && !adjBlock.isAir()) {
-                        // ice, glass, stained glass, tinted glass
+                    if (adjBlock.getBlock() instanceof TransparentBlock || adjBlock.getBlock() instanceof LeavesBlock){
+                        // From testing static water seems to only be used on transparent blocks or leaves.
+                        // The texture change is subtle. use a resource pack with modified water_overlay.png to confirm behaviour.
                         sprite = this.waterOverlaySprite;
-
                     }
                 }
 


### PR DESCRIPTION
Okay, not good, third attempt. 

the original way by checking block state values was really bad. hard to tell what was going on and what wouldnt or would be matched. 

it was still broken against blocks like plant blocks, chorus flower blocks, brewing stands and would apply the overlay when it shouldnt.

not sure why i didnt in the first place but now just check if the block is an instance of transparentBlock or Leaves as these seem to be the only ones that actually use this texture (but i could be wrong again).

ill include a resource pack that ive used to change the colour of the water overlay as without its quite hard to spot any difference
[testwater.zip](https://github.com/CaffeineMC/sodium-fabric/files/7721925/testwater.zip)

 