### PR TITLE
Add jitpack.yml so that JitPack can build with the correct java version

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17


### PR DESCRIPTION
This allows projects like Iris to be able to use JitPack to compile against sodium development branches instead of needing a local jar file.