### PR TITLE
[This is not to be used] Tests on AMD drivers with vertex pulling. breaks other drivers

### DIFF
--- a/src/main/resources/assets/sodium/shaders/blocks/base.vsh
+++ b/src/main/resources/assets/sodium/shaders/blocks/base.vsh
@@ -35,11 +35,17 @@ uint _get_vertex_index() {
 }
 
 uint _get_instance_index() {
-    return ((uint(gl_VertexID)+1u) & 0xFF000000u) >> 24u;
-    // AMD drivers issue for devices on windows and above polaris. shifting vertexID normally by 24u causes corrupt, anyother value
-    // is broken but not garbage. adding 1u makes the world render pretty well, except for the crate at x-65 z106 seed:5457330753028660597
-    // shifting right by 1 on the mask had similar behaviour but some chunks were erratic
-    // i do not know why either of these worked
+    return (uint(uint(gl_VertexID)) & uint(0xFF000000u)) << uint(1u) >> uint(25u);
+    // return (uint(double(gl_VertexID)) & uint(0xFF000000u)) >> uint(24u);
+    // seems to be logically identical to above
+    // return (uint(uint(gl_VertexID)+1u) & uint(0xFF000000u)) >> uint(24u);
+    // totally diffrent, less glitchy/erratic, dont exactly get why tho and surely this has other issues
+
+    // im guessing theres two issues. shifting by 24 seems to corrupt the instance id, if i was to guess, maybe a padding issue?
+    // as casting gl vertex to double also fixes this the same way as shifting so im assume the cast adds bits on the right
+    // amd using floats for gl_VertexID seems to also corrupt certian ids as i assume multiple vertecies
+    // can share the same ID https://www.reddit.com/r/GraphicsProgramming/comments/igosn8/gl_vertexid_skips_id_8388608_223/
+    // just adding 1 to vertex id gave best results only a hand full of chunks are corrupt and dont render
 }
 
 #import <sodium:include/fog.glsl>

--- a/src/main/resources/assets/sodium/shaders/blocks/base.vsh
+++ b/src/main/resources/assets/sodium/shaders/blocks/base.vsh
@@ -35,8 +35,11 @@ uint _get_vertex_index() {
 }
 
 uint _get_instance_index() {
-    return (uint(gl_VertexID) & 0xFF000000u >> 1) >> 24u;
-    // AMD drivers for devices past polaris want the mask shifted by 1. or it will just corrupt everything
+    return ((uint(gl_VertexID)+1u) & 0xFF000000u) >> 24u;
+    // AMD drivers issue for devices on windows and above polaris. shifting vertexID normally by 24u causes corrupt, anyother value
+    // is broken but not garbage. adding 1u makes the world render pretty well, except for the crate at x-65 z106 seed:5457330753028660597
+    // shifting right by 1 on the mask had similar behaviour but some chunks were erratic
+    // i do not know why either of these worked
 }
 
 #import <sodium:include/fog.glsl>

--- a/src/main/resources/assets/sodium/shaders/blocks/base.vsh
+++ b/src/main/resources/assets/sodium/shaders/blocks/base.vsh
@@ -35,7 +35,8 @@ uint _get_vertex_index() {
 }
 
 uint _get_instance_index() {
-    return (uint(gl_VertexID) & 0xFF000000u) >> 24u;
+    return (uint(gl_VertexID) & 0xFF000000u >> 1) >> 24u;
+    // AMD drivers for devices past polaris want the mask shifted by 1. or it will just corrupt everything
 }
 
 #import <sodium:include/fog.glsl>


### PR DESCRIPTION
Original: 
![2021-12-22_03 32 17](https://user-images.githubusercontent.com/19439141/147031084-70d9227d-11eb-41c9-a01d-316c8337b19b.png)

First Commit: `(uint(gl_VertexID) & 0xFF000000u >> 1) >> 24u;` found this by luck while reverting other changes not sure why it works as the shifted result would be wrong
![2021-12-21_09 50 55](https://user-images.githubusercontent.com/19439141/146909256-19313b41-907c-418e-93c1-66203e341f28.png)

Second Commit: `((uint(gl_VertexID)+1u) & 0xFF000000u) >> 24u;` seemed to be better but the change is strange to me, i dont understand how or why amd drivers render mostly correct by doing this
![2021-12-21_11 22 40](https://user-images.githubusercontent.com/19439141/146923996-66af909c-cc06-48a8-b6ee-22d463a2a911.png)
the chunk hole is not consistent between reboots, it is consistent between reloads

Third Commit: https://www.reddit.com/r/GraphicsProgramming/comments/igosn8/gl_vertexid_skips_id_8388608_223/ suggested casting to double fixes it at massive performance hit. however with sodium this did not fully fix the issue. another thing to note is it acted identical to ` (uint(uint(gl_VertexID)) & uint(0xFF000000u)) << uint(1u) >> uint(25u)` with only some chunks flickering in the wrong location
![2021-12-22_03 30 17](https://user-images.githubusercontent.com/19439141/147031033-208c053b-2173-4840-80ab-5d0196debf49.png)

[RenderdocsCommit3.zip](https://github.com/CaffeineMC/sodium-fabric/files/7759855/RenderdocsCommit3.zip)
[RenderdocsOrigin.zip](https://github.com/CaffeineMC/sodium-fabric/files/7759863/RenderdocsOrigin.zip)

All 3 versions broke Nvidia Drivers latest drivers for a 970. nvidia seemed to break in the same way as AMD with these changes, with 1&3 having erratic chunks and 2 having world holes.

a question i have is why does nvidia break with commit 3? i expect 1 & 2 to be bad but nvidia seems to drop to a crawl with commit 3 and my assumption is that the shift stuff would be logically identical to << 24u yet its not. ~~currently asserting this in python. my guess is opengl handles some of those ops diffrently or the drivers interpret it in some weird way causing some corruption.~~ it does and python was a mistake, c++ handled it diffrently but to the extent im not sure how it was rendering at all.. for `<<1u >> 25u` and im not sure why C&D break nvidia when the bit(s) set are never used.