### PR TITLE
Center the option GUI

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumOptionsGUI.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumOptionsGUI.java
@@ -158,9 +158,12 @@ public class SodiumOptionsGUI extends Screen implements ScreenPromptable {
         this.rebuildGUIPages();
         this.rebuildGUIOptions();
 
-        this.undoButton = new FlatButtonWidget(new Dim2i(this.width - 211, this.height - 30, 65, 20), Text.translatable("sodium.options.buttons.undo"), this::undoChanges);
-        this.applyButton = new FlatButtonWidget(new Dim2i(this.width - 142, this.height - 30, 65, 20), Text.translatable("sodium.options.buttons.apply"), this::applyChanges);
-        this.closeButton = new FlatButtonWidget(new Dim2i(this.width - 73, this.height - 30, 65, 20), Text.translatable("gui.done"), this::close);
+        int x = Math.max(6, (this.width - 427) / 2) + 403;
+        int y = Math.min(this.height - 30, 28 + this.pages.get(1).getOptions().size() * 18 + this.pages.get(1).getGroups().size() * 4);
+
+        this.undoButton = new FlatButtonWidget(new Dim2i(x - 61 - 69 * 2, y, 61, 20), Text.translatable("sodium.options.buttons.undo"), this::undoChanges);
+        this.applyButton = new FlatButtonWidget(new Dim2i(x - 61 - 69, y, 61, 20), Text.translatable("sodium.options.buttons.apply"), this::applyChanges);
+        this.closeButton = new FlatButtonWidget(new Dim2i(x - 61, y, 61, 20), Text.translatable("gui.done"), this::close);
         this.donateButton = new FlatButtonWidget(new Dim2i(this.width - 128, 6, 100, 20), Text.translatable("sodium.options.buttons.donate"), this::openDonationPage);
         this.hideDonateButton = new FlatButtonWidget(new Dim2i(this.width - 26, 6, 20, 20), Text.literal("x"), this::hideDonationButton);
 
@@ -194,7 +197,7 @@ public class SodiumOptionsGUI extends Screen implements ScreenPromptable {
     }
 
     private void rebuildGUIPages() {
-        int x = 6;
+        int x = Math.max(6, (this.width - 427) / 2);
         int y = 6;
 
         for (OptionPage page : this.pages) {
@@ -210,7 +213,7 @@ public class SodiumOptionsGUI extends Screen implements ScreenPromptable {
     }
 
     private void rebuildGUIOptions() {
-        int x = 6;
+        int x = Math.max(6, (this.width - 427) / 2);
         int y = 28;
 
         for (OptionGroup group : this.currentPage.getGroups()) {
@@ -306,7 +309,7 @@ public class SodiumOptionsGUI extends Screen implements ScreenPromptable {
 
         int boxHeight = (tooltip.size() * 12) + boxPadding;
         int boxYLimit = boxY + boxHeight;
-        int boxYCutoff = this.height - 40;
+        int boxYCutoff = Math.min(this.height - 40, 28 + this.pages.get(1).getOptions().size() * 18 + this.pages.get(1).getGroups().size() * 4 - 4);
 
         // If the box is going to be cutoff on the Y-axis, move it back up the difference
         if (boxYLimit > boxYCutoff) {


### PR DESCRIPTION
MC GUI's are generally centered. Sodium options are departing from that model by being left adjusted.

This also reduces distance between the DONE button and the rest of the options.

This applies only when gui-scale is not set to AUTO, in AUTO it looks the same as before.

Signed-off-by: MeeniMc <68366846+MeeniMc@users.noreply.github.com>


## Some screens to illustrate: 

With patch, gui-scale=4x, 4K screen: center of the screen is occupied, less distance between the options and the 'apply/done' buttons
![2022-01-06_23 30 01](https://user-images.githubusercontent.com/68366846/148492029-494c6db2-9d4c-4f87-bc33-49320b04e385.png)
---

With patch: gui-scale=AUTO, pane 1: the layout has been verified to still prevent overlap between DONE/APPLY and the options in pane 1, and the option tooltips in pane 3 (this is the reason the DONE/APPLY have not been centered with this PR). 
![2022-01-06_23 30 27](https://user-images.githubusercontent.com/68366846/148492082-e8d76090-3b37-4d93-920d-1f69b740b36d.png)
---

<details> 
  <summary>For reference only, how it looks on 4k without this PR</summary>
Before, gui-scale=4x, 4K screen: lots of empty space in the center of the screen.
<img src="https://user-images.githubusercontent.com/68366846/148491959-9258a59c-4054-46c6-ad47-33468493f36a.png"/>
</details>




## Alternatives

This is an alternative to pr #41, except that it doesn't suffer from overlap of buttons in AUTO mode

## Related issues

Fixes issue #105 
