### PR TITLE
Allocate matrix buffer via malloc instead of calloc

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gl/shader/uniform/GlUniformMatrix4f.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gl/shader/uniform/GlUniformMatrix4f.java
@@ -14,10 +14,7 @@ public class GlUniformMatrix4f extends GlUniform<Matrix4f>  {
     @Override
     public void set(Matrix4f value) {
         try (MemoryStack stack = MemoryStack.stackPush()) {
-            FloatBuffer buf = stack.callocFloat(16);
-            value.get(buf);
-
-            GL30C.glUniformMatrix4fv(this.index, false, buf);
+            GL30C.glUniformMatrix4fv(this.index, false, value.get(stack.mallocFloat(16)));
         }
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/util/math/JomlHelper.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/util/math/JomlHelper.java
@@ -8,7 +8,7 @@ import java.nio.FloatBuffer;
 public class JomlHelper {
     public static void set(Matrix4f dst, net.minecraft.util.math.Matrix4f src) {
         try (MemoryStack stack = MemoryStack.stackPush()) {
-            FloatBuffer buffer = stack.callocFloat(16);
+            FloatBuffer buffer = stack.mallocFloat(16);
             src.writeColumnMajor(buffer);
 
             dst.set(buffer);


### PR DESCRIPTION
We don't need zeroing of the allocated memory.