### PR TITLE
Make VertexBufferBuilder allocate on creation

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/render/vertex/buffer/VertexBufferBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/render/vertex/buffer/VertexBufferBuilder.java
@@ -16,8 +16,7 @@ public class VertexBufferBuilder implements VertexBufferView {
 
     public VertexBufferBuilder(BufferVertexFormat vertexFormat, int initialCapacity) {
         this.vertexFormat = vertexFormat;
-
-        this.buffer = null;
+        this.buffer = MemoryUtil.memAlloc(initialCapacity);
         this.capacity = initialCapacity;
         this.writerOffset = 0;
         this.initialCapacity = initialCapacity;


### PR DESCRIPTION
This doesn't fix anything currently, but it can cause problems if other classes use it and expect `initialCapacity` to be correct