### PR TITLE
fix: Make boxes outside of the world height always visible

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -326,18 +326,12 @@ public class SodiumWorldRenderer {
             return true;
         }
 
-        Box box = entity.getVisibilityBoundingBox();
-
-        // Entities outside the valid world height will never map to a rendered chunk
-        // Always render these entities or they'll be culled incorrectly!
-        if (box.maxY < 0.5D || box.minY > 255.5D) {
-            return true;
-        }
-
         // Ensure entities with outlines or nametags are always visible
         if (this.client.hasOutline(entity) || entity.shouldRenderName()) {
             return true;
         }
+
+        Box box = entity.getVisibilityBoundingBox();
 
         return this.isBoxVisible(box.minX, box.minY, box.minZ, box.maxX, box.maxY, box.maxZ);
     }
@@ -347,13 +341,19 @@ public class SodiumWorldRenderer {
     }
 
     public boolean isBoxVisible(double x1, double y1, double z1, double x2, double y2, double z2) {
-        int minX = MathHelper.floor(x1 - 0.5D) >> 4;
-        int minY = MathHelper.floor(y1 - 0.5D) >> 4;
-        int minZ = MathHelper.floor(z1 - 0.5D) >> 4;
+        // Boxes outside the valid world height will never map to a rendered chunk
+        // Always render these boxes or they'll be culled incorrectly!
+        if (y2 < this.world.getBottomY() + 0.5D || y1 > this.world.getTopY() - 0.5D) {
+            return true;
+        }
 
-        int maxX = MathHelper.floor(x2 + 0.5D) >> 4;
-        int maxY = MathHelper.floor(y2 + 0.5D) >> 4;
-        int maxZ = MathHelper.floor(z2 + 0.5D) >> 4;
+        int minX = ChunkSectionPos.getSectionCoord(x1 - 0.5D);
+        int minY = ChunkSectionPos.getSectionCoord(y1 - 0.5D);
+        int minZ = ChunkSectionPos.getSectionCoord(z1 - 0.5D);
+
+        int maxX = ChunkSectionPos.getSectionCoord(x2 + 0.5D);
+        int maxY = ChunkSectionPos.getSectionCoord(y2 + 0.5D);
+        int maxZ = ChunkSectionPos.getSectionCoord(z2 + 0.5D);
 
         for (int x = minX; x <= maxX; x++) {
             for (int z = minZ; z <= maxZ; z++) {


### PR DESCRIPTION
### Summary

This pull request changes the [`isBoxVisible()`](https://github.com/CaffeineMC/sodium-fabric/blob/d50338a9a6c01614f5f941bebbcd4b47e61939fd/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java#L349) method to first check if the specified box is outside the world height. If it is, the method will return `true`. This fixes #1081.

### Details

Currently, `isBoxVisible()` always returns `false` for boxes above or below the world height, since no visible chunk sections exist there. This can cause issues with Sodium's entity and particle culling, since they both use this value to determine if something should be culled or not. If using this value directly, entities and particles above or below the world height will always be culled, even if the player can see them.

Although a workaround for this issue already exists for entities (see 885222a476b7054ae428031d72c0b47fa579872a), particles still have the issue of being incorrectly culled (see #1081). The workaround for entities checks if an entity is above or below the world height, then avoids culling it if so. While the same kind of logic could be implemented with particle culling, it might make more sense to instead implement the logic within the `isBoxVisible()` method. This way, the result of `isBoxVisible()` is more true to its name and a special condition does not need to be added with its every use.

### Additional notes

This pull request changes the conversion of block to chunk coordinates within `isBoxVisible()` to use `ChunkSectionPos.getSectionCoord()` for readability.

By making these changes, an issue where entities below 0 or above 255 are never culled is fixed.