### PR TITLE
Fix memory leak in ChunkBuilder.

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuilder.java
@@ -80,7 +80,8 @@ public class ChunkBuilder {
     /**
      * Notifies all worker threads to stop and blocks until all workers terminate. After the workers have been shut
      * down, all tasks are cancelled and the pending queues are cleared. If the builder is already stopped, this
-     * method does nothing and exits.
+     * method does nothing and exits. This method implicitly calls {@link ChunkBuilder#doneStealingTasks()} on the
+     * calling thread.
      */
     public void stopWorkers() {
         if (!this.running.getAndSet(false)) {
@@ -122,6 +123,8 @@ public class ChunkBuilder {
         this.buildQueue.clear();
 
         this.world = null;
+        
+        this.doneStealingTasks();
     }
 
     public CompletableFuture<ChunkBuildResult> schedule(ChunkRenderBuildTask task) {
@@ -191,6 +194,15 @@ public class ChunkBuilder {
 
     public Iterator<ChunkBuildResult> createDeferredBuildResultDrain() {
         return new QueueDrainingIterator<>(this.deferredResultQueue);
+    }
+    
+    /**
+     * Cleans up resources allocated on the currently calling thread for the {@link ChunkBuilder#stealTask()} method.
+     * This method should be called on a thread that has stolen tasks when it is done stealing to prevent resource
+     * leaks.
+     */
+    public void doneStealingTasks() {
+        this.localContexts.remove();
     }
 
     /**


### PR DESCRIPTION
This PR fixes a memory leak that I could reproduce after going through multiple nether portals with a high render distance. This leak appears to be caused by the fact that ChunkBuilder.localContexts#remove() is never called by the main thread. Even though the ThreadLocal object itself is garbage collected when all references to a ChunkBuilder disappear, the main thread maintains a strong reference to the value held by the localContexts ThreadLocal, preventing the value from ever being garbage collected since the main thread never dies. This fixes that issue by ensuring that ChunkBuilder.localContexts#remove() is called by the main thread when the ChunkBuilder is being removed (e.g.  when a player goes through a nether portal).