### PR TITLE
Add back vanilla shader color bug fix

### DIFF
--- a/src/main/java/net/caffeinemc/sodium/mixin/features/chunk_rendering/MixinWorldRenderer.java
+++ b/src/main/java/net/caffeinemc/sodium/mixin/features/chunk_rendering/MixinWorldRenderer.java
@@ -1,5 +1,6 @@
 package net.caffeinemc.sodium.mixin.features.chunk_rendering;
 
+import com.mojang.blaze3d.systems.RenderSystem;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import net.caffeinemc.sodium.render.SodiumWorldRenderer;
 import net.caffeinemc.sodium.interop.vanilla.math.frustum.FrustumAdapter;
@@ -86,6 +87,11 @@ public abstract class MixinWorldRenderer implements WorldRendererHolder {
     @Overwrite
     private void renderLayer(RenderLayer renderLayer, MatrixStack matrices, double x, double y, double z, Matrix4f matrix) {
         this.renderer.drawChunkLayer(renderLayer, matrices);
+
+        // VANILLA BUG: Binding a RenderLayer for chunk rendering will result in setShaderColor being called,
+        // which is accidentally depended on by tile entity rendering. Since we don't bind a render layer, we need
+        // to set this back to the expected state, or colors will be corrupted.
+        RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f);
     }
 
     /**


### PR DESCRIPTION
This adds back a previously included bug fix which fixes color corruption noticeable in beacon beams and block breaking.