### PR TITLE
Block lighting fixes and optimizations II

### DIFF
--- a/src/main/java/net/caffeinemc/sodium/render/terrain/BlockRenderer.java
+++ b/src/main/java/net/caffeinemc/sodium/render/terrain/BlockRenderer.java
@@ -66,7 +66,7 @@ public class BlockRenderer {
             }
 
             if (!cull || this.occlusionCache.shouldDrawSide(state, world, pos, dir)) {
-                this.renderQuadList(world, state, pos, origin, lighter, offset, buffers, sided, ChunkMeshFace.fromDirection(dir));
+                this.renderQuadList(world, state, pos, origin, lighter, offset, buffers, sided, dir);
 
                 rendered = true;
             }
@@ -77,7 +77,7 @@ public class BlockRenderer {
         List<BakedQuad> all = model.getQuads(state, null, this.random);
 
         if (!all.isEmpty()) {
-            this.renderQuadList(world, state, pos, origin, lighter, offset, buffers, all, ChunkMeshFace.UNASSIGNED);
+            this.renderQuadList(world, state, pos, origin, lighter, offset, buffers, all, null);
 
             rendered = true;
         }
@@ -86,7 +86,8 @@ public class BlockRenderer {
     }
 
     private void renderQuadList(BlockRenderView world, BlockState state, BlockPos pos, BlockPos origin, LightPipeline lighter, Vec3d offset,
-                                ChunkMeshBuilder buffers, List<BakedQuad> quads, ChunkMeshFace facing) {
+                                ChunkMeshBuilder buffers, List<BakedQuad> quads, Direction cullFace) {
+        ChunkMeshFace facing = cullFace == null ? ChunkMeshFace.UNASSIGNED : ChunkMeshFace.fromDirection(cullFace);
         ColorSampler<BlockState> colorizer = null;
 
         TerrainVertexSink vertices = buffers.getVertexSink(facing);
@@ -98,7 +99,7 @@ public class BlockRenderer {
             BakedQuad quad = quads.get(i);
 
             QuadLightData light = this.cachedQuadLightData;
-            lighter.calculate((ModelQuadView) quad, pos, light, quad.getFace(), quad.hasShade());
+            lighter.calculate((ModelQuadView) quad, pos, light, cullFace, quad.getFace(), quad.hasShade());
 
             if (quad.hasColor() && colorizer == null) {
                 colorizer = this.blockColors.getColorProvider(state);

--- a/src/main/java/net/caffeinemc/sodium/render/terrain/FluidRenderer.java
+++ b/src/main/java/net/caffeinemc/sodium/render/terrain/FluidRenderer.java
@@ -257,7 +257,7 @@ public class FluidRenderer {
             rendered = true;
         }
 
-        this.quad.setFlags(ModelQuadFlags.IS_ALIGNED);
+        quad.setFlags(ModelQuadFlags.IS_ALIGNED);
 
         for (Direction dir : DirectionUtil.HORIZONTAL_DIRECTIONS) {
             float c1;
@@ -384,7 +384,7 @@ public class FluidRenderer {
     private void calculateQuadColors(ModelQuadView quad, BlockRenderView world, BlockPos pos, LightPipeline lighter, Direction dir, float brightness,
                                      ColorSampler<FluidState> colorSampler, FluidState fluidState) {
         QuadLightData light = this.quadLightData;
-        lighter.calculate(quad, pos, light, dir, false);
+        lighter.calculate(quad, pos, light, null, dir, false);
 
         int[] biomeColors = this.colorBlender.getColors(world, pos, quad, colorSampler, fluidState);
 

--- a/src/main/java/net/caffeinemc/sodium/render/terrain/light/LightPipeline.java
+++ b/src/main/java/net/caffeinemc/sodium/render/terrain/light/LightPipeline.java
@@ -15,8 +15,9 @@ public interface LightPipeline {
      * @param quad The block model quad
      * @param pos The block position of the model this quad belongs to
      * @param out The data arrays which will store the calculated light data results
+     * @param cullFace The cull face of the quad
      * @param face The pre-computed facing vector of the quad
      * @param shade True if the block is shaded by ambient occlusion
      */
-    void calculate(ModelQuadView quad, BlockPos pos, QuadLightData out, Direction face, boolean shade);
+    void calculate(ModelQuadView quad, BlockPos pos, QuadLightData out, Direction cullFace, Direction face, boolean shade);
 }

--- a/src/main/java/net/caffeinemc/sodium/render/terrain/light/flat/FlatLightPipeline.java
+++ b/src/main/java/net/caffeinemc/sodium/render/terrain/light/flat/FlatLightPipeline.java
@@ -25,14 +25,24 @@ public class FlatLightPipeline implements LightPipeline {
     }
 
     @Override
-    public void calculate(ModelQuadView quad, BlockPos pos, QuadLightData out, Direction face, boolean shade) {
-        // If the face is aligned, use the light data above it
-        if ((quad.getFlags() & ModelQuadFlags.IS_ALIGNED) != 0 && !this.lightCache.getWorld().getBlockState(pos).hasEmissiveLighting(this.lightCache.getWorld(), pos)) {
-            Arrays.fill(out.lm, LightDataAccess.unpackLM(this.lightCache.get(pos, face)));
+    public void calculate(ModelQuadView quad, BlockPos pos, QuadLightData out, Direction cullFace, Direction face, boolean shade) {
+        int lightmap;
+
+        // To match vanilla behavior, use the cull face if it exists/is available
+        if (cullFace != null) {
+            lightmap = LightDataAccess.unpackLM(this.lightCache.get(pos, cullFace));
         } else {
-            Arrays.fill(out.lm, LightDataAccess.unpackLM(this.lightCache.get(pos)));
+            int flags = quad.getFlags();
+            // If the face is aligned, use the light data above it
+            // To match vanilla behavior, also treat the face as aligned if it is parallel and the block state is a full cube
+            if ((flags & ModelQuadFlags.IS_ALIGNED) != 0 || ((flags & ModelQuadFlags.IS_PARALLEL) != 0 && LightDataAccess.unpackFC(this.lightCache.get(pos)))) {
+                lightmap = LightDataAccess.unpackLM(this.lightCache.get(pos, face));
+            } else {
+                lightmap = LightDataAccess.unpackLM(this.lightCache.get(pos));
+            }
         }
 
+        Arrays.fill(out.lm, lightmap);
         Arrays.fill(out.br, this.lightCache.getWorld().getBrightness(face, shade));
     }
 }

--- a/src/main/java/net/caffeinemc/sodium/render/terrain/quad/properties/ModelQuadFlags.java
+++ b/src/main/java/net/caffeinemc/sodium/render/terrain/quad/properties/ModelQuadFlags.java
@@ -6,14 +6,20 @@ import net.minecraft.util.math.Direction;
 
 public class ModelQuadFlags {
     /**
-     * Indicates that the quad is aligned to the block grid.
-     */
-    public static final int IS_ALIGNED = 0b01;
-
-    /**
      * Indicates that the quad does not fully cover the given face for the model.
      */
-    public static final int IS_PARTIAL = 0b10;
+    public static final int IS_PARTIAL = 0b001;
+
+    /**
+     * Indicates that the quad is parallel to its light face.
+     */
+    public static final int IS_PARALLEL = 0b010;
+
+    /**
+     * Indicates that the quad is aligned to the block grid.
+     * This flag is only set if {@link #IS_PARALLEL} is set.
+     */
+    public static final int IS_ALIGNED = 0b100;
 
     /**
      * @return True if the bit-flag of {@link ModelQuadFlags} contains the given flag
@@ -51,25 +57,35 @@ public class ModelQuadFlags {
             maxZ = Math.max(maxZ, z);
         }
 
-        boolean aligned = switch (face) {
-            case DOWN -> minY == maxY && minY < 0.0001f;
-            case UP -> minY == maxY && maxY > 0.9999F;
-            case NORTH -> minZ == maxZ && minZ < 0.0001f;
-            case SOUTH -> minZ == maxZ && maxZ > 0.9999F;
-            case WEST -> minX == maxX && minX < 0.0001f;
-            case EAST -> minX == maxX && maxX > 0.9999F;
-        };
-
         boolean partial = switch (face.getAxis()) {
             case X -> minY >= 0.0001f || minZ >= 0.0001f || maxY <= 0.9999F || maxZ <= 0.9999F;
             case Y -> minX >= 0.0001f || minZ >= 0.0001f || maxX <= 0.9999F || maxZ <= 0.9999F;
             case Z -> minX >= 0.0001f || minY >= 0.0001f || maxX <= 0.9999F || maxY <= 0.9999F;
         };
 
+        boolean parallel = switch(face.getAxis()) {
+            case X -> minX == maxX;
+            case Y -> minY == maxY;
+            case Z -> minZ == maxZ;
+        };
+
+        boolean aligned = parallel && switch (face) {
+            case DOWN -> minY < 0.0001f;
+            case UP -> maxY > 0.9999F;
+            case NORTH -> minZ < 0.0001f;
+            case SOUTH -> maxZ > 0.9999F;
+            case WEST -> minX < 0.0001f;
+            case EAST -> maxX > 0.9999F;
+        };
+
         int flags = 0;
 
         if (partial) {
             flags |= IS_PARTIAL;
+        }
+
+        if (parallel) {
+            flags |= IS_PARALLEL;
         }
 
         if (aligned) {

--- a/src/main/java/net/caffeinemc/sodium/render/terrain/quad/properties/ModelQuadFlags.java
+++ b/src/main/java/net/caffeinemc/sodium/render/terrain/quad/properties/ModelQuadFlags.java
@@ -58,23 +58,23 @@ public class ModelQuadFlags {
         }
 
         boolean partial = switch (face.getAxis()) {
-            case X -> minY >= 0.0001f || minZ >= 0.0001f || maxY <= 0.9999F || maxZ <= 0.9999F;
-            case Y -> minX >= 0.0001f || minZ >= 0.0001f || maxX <= 0.9999F || maxZ <= 0.9999F;
-            case Z -> minX >= 0.0001f || minY >= 0.0001f || maxX <= 0.9999F || maxY <= 0.9999F;
+            case X -> minY >= 0.0001F || minZ >= 0.0001F || maxY <= 0.9999F || maxZ <= 0.9999F;
+            case Y -> minX >= 0.0001F || minZ >= 0.0001F || maxX <= 0.9999F || maxZ <= 0.9999F;
+            case Z -> minX >= 0.0001F || minY >= 0.0001F || maxX <= 0.9999F || maxY <= 0.9999F;
         };
 
-        boolean parallel = switch(face.getAxis()) {
+        boolean parallel = switch (face.getAxis()) {
             case X -> minX == maxX;
             case Y -> minY == maxY;
             case Z -> minZ == maxZ;
         };
 
         boolean aligned = parallel && switch (face) {
-            case DOWN -> minY < 0.0001f;
+            case DOWN -> minY < 0.0001F;
             case UP -> maxY > 0.9999F;
-            case NORTH -> minZ < 0.0001f;
+            case NORTH -> minZ < 0.0001F;
             case SOUTH -> maxZ > 0.9999F;
-            case WEST -> minX < 0.0001f;
+            case WEST -> minX < 0.0001F;
             case EAST -> maxX > 0.9999F;
         };
 


### PR DESCRIPTION
- Fix flat lighting on inset quads on blocks that do not emit light and are not emissive
- Fix dark quads on light-emitting blocks behind tinted glass
- Restructure SmoothLightPipeline to use the fastest code path possible
- Add some vanilla checks for better parity
- Add IS_PARALLEL quad flag
- Add FC (full cube) to light cache words