### PR TITLE
Scale the debug pie with the rest of the GUI

### DIFF
--- a/src/main/java/net/caffeinemc/sodium/config/mixin/MixinConfig.java
+++ b/src/main/java/net/caffeinemc/sodium/config/mixin/MixinConfig.java
@@ -41,6 +41,7 @@ public class MixinConfig {
         this.addMixinRule("features.gui", true);
         this.addMixinRule("features.gui.fast_loading_screen", true);
         this.addMixinRule("features.gui.font", true);
+        this.addMixinRule("features.gui.scale_debug_pie", true);
         this.addMixinRule("features.item", true);
         this.addMixinRule("features.matrix_stack", true);
         this.addMixinRule("features.model", true);

--- a/src/main/java/net/caffeinemc/sodium/mixin/features/gui/scale_debug_pie/MixinMinecraftClient.java
+++ b/src/main/java/net/caffeinemc/sodium/mixin/features/gui/scale_debug_pie/MixinMinecraftClient.java
@@ -1,0 +1,39 @@
+package net.caffeinemc.sodium.mixin.features.gui.scale_debug_pie;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.util.Window;
+import org.joml.Matrix4f;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(MinecraftClient.class)
+public class MixinMinecraftClient {
+    @Shadow
+    @Final
+    private Window window;
+
+    @Redirect(method = "drawProfilerResults", at = @At(value = "INVOKE", target = "Lorg/joml/Matrix4f;setOrtho(FFFFFF)Lorg/joml/Matrix4f;"))
+    private Matrix4f getScaledPosition(Matrix4f instance, float left, float right, float bottom, float top, float zNear, float zFar) {
+        return instance.setOrtho(
+                left,
+                (float) (window.getFramebufferWidth() / (window.getScaleFactor() / 2)),
+                (float) (window.getFramebufferHeight() / (window.getScaleFactor() / 2)),
+                top,
+                zNear,
+                zFar
+        );
+    }
+
+    @Redirect(method = "drawProfilerResults", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/util/Window;getFramebufferWidth()I", ordinal = 1))
+    private int getScaledWidth(Window instance) {
+        return (int) (window.getFramebufferWidth() / (window.getScaleFactor() / 2));
+    }
+
+    @Redirect(method = "drawProfilerResults", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/util/Window;getFramebufferHeight()I", ordinal = 1))
+    private int getScaledHeight(Window instance) {
+        return (int) (window.getFramebufferHeight() / (window.getScaleFactor() / 2));
+    }
+}

--- a/src/main/resources/sodium.mixins.json
+++ b/src/main/resources/sodium.mixins.json
@@ -43,6 +43,7 @@
     "features.gui.MixinDebugHud",
     "features.gui.fast_loading_screen.MixinLevelLoadingScreen",
     "features.gui.font.MixinGlyphRenderer",
+    "features.gui.scale_debug_pie.MixinMinecraftClient",
     "features.item.MixinItemRenderer",
     "features.matrix_stack.MixinVertexConsumer",
     "features.model.MixinMultipartBakedModel",


### PR DESCRIPTION
On Hi-DPI displays the Debug pie is nearly unreadable
![image](https://user-images.githubusercontent.com/48024900/200341453-d43fda80-9bfc-4572-b168-d98d658262da.png)

This is a vanilla issue, but I feel that this bug fix would fit well in Sodium.

Preview of the fix:
![image](https://user-images.githubusercontent.com/48024900/200341973-3be8eb08-be1f-4cf5-be95-2258b74355f3.png)

The commit could likely be cherry-picked onto 1.19.x/dev