### PR TITLE
Culling optimizations

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -756,7 +756,7 @@ public class RenderSectionManager {
         int id = state.getIndex(chunkX, chunkY, chunkZ);
         byte shift = (byte) ((id&3)<<1);
         byte cache = state.frustumCache[id>>2];
-        int res = (cache>>3)&3;
+        int res = (cache>>shift)&3;
         if (res!=0) {
             return res;
         }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -79,7 +79,7 @@ public class RenderSectionManager {
     private static class State {
         private static final long DEFAULT_VISIBILITY_DATA = calculateVisibilityData(ChunkRenderData.EMPTY.getOcclusionData());
 
-        private final int offsetZ, offsetX;
+        private final int offsetZ, offsetY;
         private final int maskXZ, maskY;
 
         public final RenderSection[] sections;
@@ -100,8 +100,8 @@ public class RenderSectionManager {
             this.maskXZ = sizeXZ - 1;
             this.maskY = sizeY - 1;
 
-            this.offsetZ = Integer.numberOfTrailingZeros(sizeY);
-            this.offsetX = this.offsetZ + Integer.numberOfTrailingZeros(sizeXZ);
+            this.offsetZ = Integer.numberOfTrailingZeros(sizeXZ);
+            this.offsetY = this.offsetZ * 2;
 
             int arraySize = sizeXZ * sizeY * sizeXZ;
 
@@ -126,7 +126,7 @@ public class RenderSectionManager {
         }
 
         public int getIndex(int x, int y, int z) {
-            return ((x & this.maskXZ) << (this.offsetX)) | ((z & this.maskXZ) << this.offsetZ) | (y & this.maskY);
+            return ((y & this.maskY) << this.offsetY) |((z & this.maskXZ) << (this.offsetZ)) | (x & this.maskXZ);
         }
     }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/util/frustum/Frustum.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/util/frustum/Frustum.java
@@ -4,7 +4,7 @@ public interface Frustum {
     /**
      * @return The visibility of an axis-aligned box within the frustum
      */
-    Visibility testBox(float minX, float minY, float minZ, float maxX, float maxY, float maxZ);
+    int testBox(float minX, float minY, float minZ, float maxX, float maxY, float maxZ);
 
     /**
      * @return true if the axis-aligned box is visible within the frustum, otherwise false
@@ -13,20 +13,20 @@ public interface Frustum {
         return this.testBox(minX, minY, minZ, maxX, maxY, maxZ) != Visibility.OUTSIDE;
     }
 
-    enum Visibility {
+    public static final class Visibility {
         /**
          * The object is fully outside the frustum and is not visible.
          */
-        OUTSIDE,
+        public static final int OUTSIDE = 1;
 
         /**
          * The object intersects with a plane of the frustum and is visible.
          */
-        INTERSECT,
+        public static final int INTERSECT = 2;
 
         /**
          * The object is fully contained within the frustum and is visible.
          */
-        INSIDE
+        public static final int INSIDE = 3;
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/util/frustum/JomlFrustum.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/util/frustum/JomlFrustum.java
@@ -21,7 +21,7 @@ public class JomlFrustum implements Frustum {
     }
 
     @Override
-    public Visibility testBox(float minX, float minY, float minZ, float maxX, float maxY, float maxZ) {
+    public int testBox(float minX, float minY, float minZ, float maxX, float maxY, float maxZ) {
         return switch (this.intersection.intersectAab(minX - this.offset.x, minY - this.offset.y, minZ - this.offset.z,
                 maxX - this.offset.x, maxY - this.offset.y, maxZ - this.offset.z)) {
             case FrustumIntersection.INTERSECT -> Visibility.INTERSECT;

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/MixinFrustum.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/MixinFrustum.java
@@ -28,7 +28,7 @@ public class MixinFrustum implements FrustumAdapter, me.jellysquid.mods.sodium.c
     }
 
     @Override
-    public Visibility testBox(float minX, float minY, float minZ, float maxX, float maxY, float maxZ) {
+    public int testBox(float minX, float minY, float minZ, float maxX, float maxY, float maxZ) {
         return switch (this.frustumIntersection.intersectAab(minX - (float) this.x, minY - (float) this.y, minZ - (float) this.z,
                 maxX - (float) this.x, maxY - (float) this.y, maxZ - (float) this.z)) {
             case FrustumIntersection.INTERSECT -> Visibility.INTERSECT;


### PR DESCRIPTION
Increases performance by including a frustum result cache and moving raycasting to instantly skip entire chunk sections