### PR TITLE
new: Mipmap fixes from Iris

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/passes/BlockRenderPass.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/passes/BlockRenderPass.java
@@ -6,7 +6,7 @@ import net.minecraft.client.render.RenderLayer;
 public enum BlockRenderPass {
     SOLID(RenderLayer.getSolid(), false, 0.0f),
     CUTOUT(RenderLayer.getCutout(), false, 0.1f),
-    CUTOUT_MIPPED(RenderLayer.getCutoutMipped(), false, 0.5f),
+    CUTOUT_MIPPED(RenderLayer.getCutoutMipped(), false, 0.1f),
     TRANSLUCENT(RenderLayer.getTranslucent(), true, 0.0f),
     TRIPWIRE(RenderLayer.getTripwire(), true, 0.1f);
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/util/color/ColorSRGB.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/util/color/ColorSRGB.java
@@ -1,0 +1,31 @@
+package me.jellysquid.mods.sodium.client.util.color;
+
+import net.caffeinemc.mods.sodium.api.util.ColorARGB;
+import org.spongepowered.asm.mixin.Unique;
+
+public class ColorSRGB {
+    private static final double SRGB_CONVERSION_COMPONENT = 1.0 / 2.2;
+
+    // Generate some color tables for gamma correction.
+    private static final float[] SRGB_TO_LINEAR = new float[256];
+
+    static {
+        for (int i = 0; i < 256; i++) {
+            SRGB_TO_LINEAR[i] = (float) Math.pow(i / 255.0, 2.2);
+        }
+    }
+
+    public static float convertToSRGB(int linear) {
+        return SRGB_TO_LINEAR[linear];
+    }
+
+    // Packs 3 color components and a linear alpha into sRGB from linear color space.
+    @Unique
+    public static int convertToPackedLinear(float r, float g, float b, int a) {
+        int srgbR = (int) (Math.pow(r, SRGB_CONVERSION_COMPONENT) * 255.0);
+        int srgbG = (int) (Math.pow(g, SRGB_CONVERSION_COMPONENT) * 255.0);
+        int srgbB = (int) (Math.pow(b, SRGB_CONVERSION_COMPONENT) * 255.0);
+
+        return ColorARGB.pack(srgbR, srgbG, srgbB, a);
+    }
+}

--- a/src/main/java/me/jellysquid/mods/sodium/common/config/SodiumConfig.java
+++ b/src/main/java/me/jellysquid/mods/sodium/common/config/SodiumConfig.java
@@ -43,6 +43,7 @@ public class SodiumConfig {
         this.addMixinRule("features.gui.font", true);
         this.addMixinRule("features.item", true);
         this.addMixinRule("features.matrix_stack", true);
+        this.addMixinRule("features.mipmaps", true);
         this.addMixinRule("features.model", true);
         this.addMixinRule("features.options", true);
         this.addMixinRule("features.particle", true);

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/mipmaps/MixinMipmapHelper.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/mipmaps/MixinMipmapHelper.java
@@ -1,0 +1,127 @@
+package me.jellysquid.mods.sodium.mixin.features.mipmaps;
+
+import net.minecraft.client.texture.MipmapHelper;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Unique;
+
+/**
+ * Implements a significantly enhanced mipmap downsampling filter.
+ *
+ * <p>This algorithm combines ideas from vanilla Minecraft -- using linear color spaces instead of sRGB for blending) --
+ * with ideas from OptiFine -- using the alpha values for weighting in downsampling -- to produce a novel downsampling
+ * algorithm for mipmapping that produces minimal visual artifacts.</p>
+ *
+ * <p>This implementation fixes a number of issues with other implementations:</p>
+ *
+ * <li>
+ *     <ul>OptiFine blends in sRGB space, resulting in brightness losses.</ul>
+ *     <ul>Vanilla applies gamma correction to alpha values, which has weird results when alpha values aren't the same.</ul>
+ *     <ul>Vanilla computes a simple average of the 4 pixels, disregarding the relative alpha values of pixels. In
+ *         cutout textures, this results in a lot of pixels with high alpha values and dark colors, causing visual
+ *         artifacts.</ul>
+ * </li>
+ *
+ * This Mixin is ported from Iris at <a href="https://github.com/IrisShaders/Iris/blob/41095ac23ea0add664afd1b85c414d1f1ed94066/src/main/java/net/coderbot/iris/mixin/bettermipmaps/MixinMipmapGenerator.java">MixinMipmapGenerator</a>.
+ */
+@Mixin(MipmapHelper.class)
+public class MixinMipmapHelper {
+    // Generate some color tables for gamma correction.
+    private static final float[] SRGB_TO_LINEAR = new float[256];
+
+    static {
+        for (int i = 0; i < 256; i++) {
+            SRGB_TO_LINEAR[i] = (float) Math.pow(i / 255.0, 2.2);
+        }
+    }
+
+    /**
+     * @author coderbot
+     * @reason replace the vanilla blending function with our improved function
+     */
+    @Overwrite
+    private static int blend(int one, int two, int three, int four, boolean checkAlpha) {
+        // First blend horizontally, then blend vertically.
+        //
+        // This works well for the case where our change is the most impactful (grass side overlays)
+        return weightedAverageColor(weightedAverageColor(one, two), weightedAverageColor(three, four));
+    }
+
+    @Unique
+    private static int unpackAlpha(int color) {
+        return (color >>> 24) & 255;
+    }
+
+    @Unique
+    private static int weightedAverageColor(int one, int two) {
+        int alphaOne = unpackAlpha(one);
+        int alphaTwo = unpackAlpha(two);
+
+        // In the case where the alpha values of the same, we can get by with an unweighted average.
+        if (alphaOne == alphaTwo) {
+            return averageRgb(one, two, alphaOne);
+        }
+
+        // If one of our pixels is fully transparent, ignore it.
+        // We just take the value of the other pixel as-is. To compensate for not changing the color value, we
+        // divide the alpha value by 4 instead of 2.
+        if (alphaOne == 0) {
+            return (two & 0x00FFFFFF) | ((alphaTwo / 4) << 24);
+        }
+
+        if (alphaTwo == 0) {
+            return (one & 0x00FFFFFF) | ((alphaOne / 4) << 24);
+        }
+
+        // Use the alpha values to compute relative weights of each color.
+        float scale = 1.0f / (alphaOne + alphaTwo);
+        float relativeWeightOne = alphaOne * scale;
+        float relativeWeightTwo = alphaTwo * scale;
+
+        // Convert the color components into linear space, then multiply the corresponding weight.
+        float oneR = unpackLinearComponent(one, 0) * relativeWeightOne;
+        float oneG = unpackLinearComponent(one, 8) * relativeWeightOne;
+        float oneB = unpackLinearComponent(one, 16) * relativeWeightOne;
+        float twoR = unpackLinearComponent(two, 0) * relativeWeightTwo;
+        float twoG = unpackLinearComponent(two, 8) * relativeWeightTwo;
+        float twoB = unpackLinearComponent(two, 16) * relativeWeightTwo;
+
+        // Combine the color components of each color
+        float linearR = oneR + twoR;
+        float linearG = oneG + twoG;
+        float linearB = oneB + twoB;
+
+        // Take the average alpha of both pixels
+        int averageAlpha = (alphaOne + alphaTwo) / 2;
+
+        // Convert to sRGB and pack the colors back into an integer.
+        return packLinearToSrgb(linearR, linearG, linearB, averageAlpha);
+    }
+
+    @Unique
+    private static float unpackLinearComponent(int color, int shift) {
+        return SRGB_TO_LINEAR[(color >> shift) & 255];
+    }
+
+    @Unique
+    private static int packLinearToSrgb(float r, float g, float b, int a) {
+        int srgbR = (int) (Math.pow(r, 1.0 / 2.2) * 255.0);
+        int srgbG = (int) (Math.pow(g, 1.0 / 2.2) * 255.0);
+        int srgbB = (int) (Math.pow(b, 1.0 / 2.2) * 255.0);
+
+        return (a << 24) | (srgbB << 16) | (srgbG << 8) | srgbR;
+    }
+
+    // Computes a non-weighted average of the two sRGB colors in linear space, avoiding brightness losses.
+    @Unique
+    private static int averageRgb(int a, int b, int alpha) {
+        float ar = unpackLinearComponent(a, 0);
+        float ag = unpackLinearComponent(a, 8);
+        float ab = unpackLinearComponent(a, 16);
+        float br = unpackLinearComponent(b, 0);
+        float bg = unpackLinearComponent(b, 8);
+        float bb = unpackLinearComponent(b, 16);
+
+        return packLinearToSrgb((ar + br) / 2.0f, (ag + bg) / 2.0f, (ab + bb) / 2.0f, alpha);
+    }
+}

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/mipmaps/MixinSpriteContents.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/mipmaps/MixinSpriteContents.java
@@ -1,0 +1,138 @@
+package me.jellysquid.mods.sodium.mixin.features.mipmaps;
+
+import net.minecraft.client.texture.NativeImage;
+import net.minecraft.client.texture.SpriteContents;
+import net.minecraft.util.Identifier;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+/**
+ * This Mixin is ported from Iris at <a href="https://github.com/IrisShaders/Iris/blob/41095ac23ea0add664afd1b85c414d1f1ed94066/src/main/java/net/coderbot/iris/mixin/bettermipmaps/MixinTextureAtlasSprite.java">MixinTextureAtlasSprite</a>.
+ */
+@Mixin(SpriteContents.class)
+public class MixinSpriteContents {
+    @Mutable
+    @Shadow
+    @Final
+    private NativeImage image;
+    // Generate some color tables for gamma correction.
+    private static final float[] SRGB_TO_LINEAR = new float[256];
+
+    static {
+        for (int i = 0; i < 256; i++) {
+            SRGB_TO_LINEAR[i] = (float) Math.pow(i / 255.0, 2.2);
+        }
+    }
+
+    // While Fabric allows us to @Inject into the constructor here, that's just a specific detail of FabricMC's mixin
+    // fork. Upstream Mixin doesn't allow arbitrary @Inject usage in constructor. However, we can use @ModifyVariable
+    // just fine, in a way that hopefully doesn't conflict with other mods.
+    //
+    // By doing this, we can work with upstream Mixin as well, as is used on Forge. While we don't officially
+    // support Forge, since this works well on Fabric too, it's fine to ensure that the diff between Fabric and Forge
+    // can remain minimal. Being less dependent on specific details of Fabric is good, since it means we can be more
+    // cross-platform.
+    @Redirect(method = "<init>", at = @At(value = "FIELD", target = "Lnet/minecraft/client/texture/SpriteContents;image:Lnet/minecraft/client/texture/NativeImage;", opcode = Opcodes.PUTFIELD))
+    private void iris$beforeGenerateMipLevels(SpriteContents instance, NativeImage nativeImage, Identifier identifier) {
+        // We're injecting after the "info" field has been set, so this is safe even though we're in a constructor.
+        if (identifier.getPath().contains("leaves")) {
+            // Don't ruin the textures of leaves on fast graphics, since they're supposed to have black pixels
+            // apparently.
+            this.image = nativeImage;
+            return;
+        }
+
+
+        iris$fillInTransparentPixelColors(nativeImage);
+
+        this.image = nativeImage;
+    }
+
+    /**
+     * Fixes a common issue in image editing programs where fully transparent pixels are saved with fully black colors.
+     *
+     * This causes issues with mipmapped texture filtering, since the black color is used to calculate the final color
+     * even though the alpha value is zero. While ideally it would be disregarded, we do not control that. Instead,
+     * this code tries to calculate a decent average color to assign to these fully-transparent pixels so that their
+     * black color does not leak over into sampling.
+     */
+    @Unique
+    private static void iris$fillInTransparentPixelColors(NativeImage nativeImage) {
+        // Calculate an average color from all pixels that are not completely transparent.
+        //
+        // This average is weighted based on the (non-zero) alpha value of the pixel.
+        float r = 0.0f;
+        float g = 0.0f;
+        float b = 0.0f;
+        float totalAlpha = 0.0f;
+
+        for (int y = 0; y < nativeImage.getHeight(); y++) {
+            for (int x = 0; x < nativeImage.getWidth(); x++) {
+                int color = nativeImage.getColor(x, y);
+                int alpha = (color >> 24) & 255;
+
+                if (alpha == 0) {
+                    // Ignore all fully-transparent pixels for the purposes of computing an average color.
+                    continue;
+                }
+
+                totalAlpha += alpha;
+
+                // Make sure to convert to linear space so that we don't lose brightness.
+                r += iris$unpackLinearComponent(color, 0) * alpha;
+                g += iris$unpackLinearComponent(color, 8) * alpha;
+                b += iris$unpackLinearComponent(color, 16) * alpha;
+            }
+        }
+
+        r /= totalAlpha;
+        g /= totalAlpha;
+        b /= totalAlpha;
+
+        // If there weren't any pixels that were not fully transparent, bail out.
+        if (totalAlpha == 0.0f) {
+            return;
+        }
+
+        // Convert that color in linear space back to sRGB.
+        // Use an alpha value of zero - this works since we only replace pixels with an alpha value of 0.
+        int resultColor = iris$packLinearToSrgb(r, g, b);
+
+        for (int y = 0; y < nativeImage.getHeight(); y++) {
+            for (int x = 0; x < nativeImage.getWidth(); x++) {
+                int color = nativeImage.getColor(x, y);
+                int alpha = (color >> 24) & 255;
+
+                // If this pixel has nonzero alpha, don't touch it.
+                if (alpha > 0) {
+                    continue;
+                }
+
+                // Replace the color values of this pixel with the average colors.
+                nativeImage.setColor(x, y, resultColor);
+            }
+        }
+    }
+
+    // Unpacks a single color component into linear color space from sRGB.
+    @Unique
+    private static float iris$unpackLinearComponent(int color, int shift) {
+        return SRGB_TO_LINEAR[(color >> shift) & 255];
+    }
+
+    // Packs 3 color components into sRGB from linear color space.
+    @Unique
+    private static int iris$packLinearToSrgb(float r, float g, float b) {
+        int srgbR = (int) (Math.pow(r, 1.0 / 2.2) * 255.0);
+        int srgbG = (int) (Math.pow(g, 1.0 / 2.2) * 255.0);
+        int srgbB = (int) (Math.pow(b, 1.0 / 2.2) * 255.0);
+
+        return (srgbB << 16) | (srgbG << 8) | srgbR;
+    }
+}

--- a/src/main/resources/sodium.mixins.json
+++ b/src/main/resources/sodium.mixins.json
@@ -49,6 +49,8 @@
     "features.item.MixinItemRenderer",
     "features.matrix_stack.MixinMatrixStack",
     "features.matrix_stack.MixinVertexConsumer",
+    "features.mipmaps.MixinMipmapHelper",
+    "features.mipmaps.MixinSpriteContents",
     "features.model.MixinMultipartBakedModel",
     "features.model.MixinWeightedBakedModel",
     "features.options.MixinInGameHud",


### PR DESCRIPTION
This implements a significantly enhanced mipmap sampling filter, using linear color spaces. This also removes black spots from alpha in textures to remove black mipmap bleeding.