### PR TITLE
Feature: ray culling + frustum cache

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -307,8 +307,15 @@ public class SodiumGameOptionPages {
                         .setEnabled(supportsNoErrorContext())
                         .setFlags(OptionFlag.REQUIRES_GAME_RESTART)
                         .build())
+                .add(OptionImpl.createBuilder(boolean.class, sodiumOpts)
+                        .setName(Text.translatable("sodium.options.raycast_culling.name"))
+                        .setTooltip(Text.translatable("sodium.options.raycast_culling..tooltip"))
+                        .setControl(TickBoxControl::new)
+                        .setBinding((opts, value) -> opts.performance.useRaycastCulling = value, opts -> opts.performance.useRaycastCulling)
+                        .setFlags(OptionFlag.REQUIRES_RENDERER_UPDATE)
+                        .build()
+                )
                 .build());
-
         return new OptionPage(Text.translatable("sodium.options.pages.performance"), ImmutableList.copyOf(groups));
     }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -43,6 +43,8 @@ public class SodiumGameOptions {
         public boolean useFogOcclusion = true;
         public boolean useBlockFaceCulling = true;
         public boolean useNoErrorGLContext = true;
+
+        public boolean useRaycastCulling = true;
     }
 
     public static class AdvancedSettings {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -24,6 +24,7 @@ import me.jellysquid.mods.sodium.client.render.chunk.region.RenderRegionManager;
 import me.jellysquid.mods.sodium.client.render.chunk.tasks.ChunkRenderBuildTask;
 import me.jellysquid.mods.sodium.client.render.chunk.tasks.ChunkRenderEmptyBuildTask;
 import me.jellysquid.mods.sodium.client.render.chunk.tasks.ChunkRenderRebuildTask;
+import me.jellysquid.mods.sodium.client.util.BitArray;
 import me.jellysquid.mods.sodium.client.util.MathUtil;
 import me.jellysquid.mods.sodium.client.util.frustum.Frustum;
 import me.jellysquid.mods.sodium.client.world.WorldSlice;
@@ -42,6 +43,8 @@ import org.apache.commons.lang3.Validate;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+
+import static org.joml.FrustumIntersection.*;
 
 public class RenderSectionManager {
     /**
@@ -85,7 +88,7 @@ public class RenderSectionManager {
     private final int renderDistance;
 
     private float cameraX, cameraY, cameraZ;
-    private int centerChunkX, centerChunkZ;
+    private int centerChunkX, centerChunkY, centerChunkZ;
 
     private boolean needsUpdate;
 
@@ -96,12 +99,17 @@ public class RenderSectionManager {
 
     private Frustum frustum;
 
+    private RenderSectionUtils rsu;
+
     private int currentFrame = 0;
     private boolean alwaysDeferChunkUpdates;
 
     private final ChunkTracker tracker;
 
     private ChunkRenderList chunkRenderList;
+
+    private final int topSectionCoord;
+    private final int bottomSectionCoord;
 
     public RenderSectionManager(SodiumWorldRenderer worldRenderer, ClientWorld world, int renderDistance, CommandList commandList) {
         this.chunkRenderer = new RegionChunkRenderer(RenderDevice.INSTANCE, ChunkMeshFormats.COMPACT);
@@ -123,6 +131,10 @@ public class RenderSectionManager {
         }
 
         this.tracker = this.worldRenderer.getChunkTracker();
+        this.rsu = new RenderSectionUtils(renderDistance, world);
+
+        this.topSectionCoord = world.getTopSectionCoord();
+        this.bottomSectionCoord = world.getBottomSectionCoord();
     }
 
     public void reloadChunks(ChunkTracker tracker) {
@@ -131,6 +143,8 @@ public class RenderSectionManager {
     }
 
     public void update(Camera camera, Frustum frustum, int frame, boolean spectator) {
+        this.rsu.clear();
+        this.rsu.setFrustum(frustum);
         this.resetLists();
 
         var list = new ChunkRenderListBuilder();
@@ -169,6 +183,7 @@ public class RenderSectionManager {
         this.initSearch(list, camera, frustum, frame, spectator);
 
         ChunkGraphIterationQueue queue = this.iterationQueue;
+        boolean useRayCulling = SodiumClientMod.options().performance.useRaycastCulling;
 
         for (int i = 0; i < queue.size(); i++) {
             RenderSection section = queue.getRender(i);
@@ -176,6 +191,16 @@ public class RenderSectionManager {
 
             this.schedulePendingUpdates(section);
 
+
+            if (useRayCulling) {
+                int distance = Math.abs(section.getChunkX() - centerChunkX) +
+                        Math.abs(section.getChunkY() - centerChunkY) +
+                        Math.abs(section.getChunkZ() - centerChunkZ);
+                this.rsu.setVisible(section.getChunkX(), section.getChunkY(), section.getChunkZ());
+                if (distance > 5 && raycast(section.getChunkX(), section.getChunkY(), section.getChunkZ(), centerChunkX, centerChunkY, centerChunkZ)) {
+                    continue;
+                }
+            }
             for (Direction dir : DirectionUtil.ALL_DIRECTIONS) {
                 if (this.isCulled(section.getGraphInfo(), flow, dir)) {
                     continue;
@@ -189,6 +214,80 @@ public class RenderSectionManager {
             }
         }
     }
+
+
+
+
+    private boolean raycast(final int x0, final int y0, final int z0, final int x1, final int y1, final int z1)  {
+        if (y1 <= this.bottomSectionCoord || y1 >= this.topSectionCoord) {
+            return false;
+        }
+
+        final int deltaX = x1 - x0;
+        final int deltaY = y1 - y0;
+        final int deltaZ = z1 - z0;
+
+        final int lenX = Math.abs(deltaX);
+        final int lenY = Math.abs(deltaY);
+        final int lenZ = Math.abs(deltaZ);
+
+        final int longest = Math.max(lenX, Math.max(lenY, lenZ));
+
+        final int signX = Integer.compare(deltaX, 0);
+        final int signY = Integer.compare(deltaY, 0);
+        final int signZ = Integer.compare(deltaZ, 0);
+
+        // Divide by 2
+        int errX = longest >> 1;
+        int errY = longest >> 1;
+        int errZ = longest >> 1;
+
+        int x = x0;
+        int y = y0;
+        int z = z0;
+
+        int valid = 0;
+
+        for (int step = 0; step < longest; step++) {
+            errX -= lenX;
+            errY -= lenY;
+            errZ -= lenZ;
+
+            if (errX < 0) {
+                errX += longest;
+                x += signX;
+            }
+
+            if (errY < 0) {
+                errY += longest;
+                y += signY;
+            }
+
+            if (errZ < 0) {
+                errZ += longest;
+                z += signZ;
+            }
+
+            if (this.rsu.isVisible(x,y,z)) {
+                valid++;
+            } else {
+                switch (this.rsu.frustumCheck(x, y, z)) {
+                    case OUTSIDE:
+                        return false;
+                    case INTERSECT:
+                        break;
+                    case INSIDE:
+                        return true;
+                }
+            }
+
+            if (valid >= 5) {
+                break;
+            }
+        }
+        return false;
+    }
+
 
     private void schedulePendingUpdates(RenderSection section) {
         if (section.getPendingUpdate() == null || !this.tracker.hasMergedFlags(section.getChunkX(), section.getChunkZ(), ChunkStatus.FLAG_ALL)) {
@@ -517,6 +616,7 @@ public class RenderSectionManager {
         int chunkZ = origin.getZ() >> 4;
 
         this.centerChunkX = chunkX;
+        this.centerChunkY = chunkY;
         this.centerChunkZ = chunkZ;
 
         RenderSection rootRender = this.getRenderSection(chunkX, chunkY, chunkZ);
@@ -573,7 +673,7 @@ public class RenderSectionManager {
             return;
         }
 
-        if (info.isCulledByFrustum(this.frustum)) {
+        if (this.rsu.frustumCheck(render.getChunkX(), render.getChunkY(), render.getChunkZ())==OUTSIDE) {
             return;
         }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionUtils.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionUtils.java
@@ -1,0 +1,81 @@
+package me.jellysquid.mods.sodium.client.render.chunk;
+
+import me.jellysquid.mods.sodium.client.util.BitArray;
+import me.jellysquid.mods.sodium.client.util.frustum.Frustum;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.HeightLimitView;
+
+public class RenderSectionUtils {
+    private final int idxYShift;
+    private final int idxZShift;
+    private final int idxYMask;
+    private final int idxZMask;
+    private final int idxXMask;
+    private final int sectionWidthMask;
+    private final int sectionHeightOffset;
+
+    private final int tblSize;
+
+    private final long[] frustumChecks;
+    private final long[] visibilityCheck;
+    public RenderSectionUtils(int viewDistance, HeightLimitView heightLimitView) {
+        int sectionWidth = MathHelper.smallestEncompassingPowerOfTwo(viewDistance * 2 + 1);
+        int sectionWidthOffset = viewDistance;
+        int sectionWidthSquared = sectionWidth * sectionWidth;
+
+        sectionWidthMask = sectionWidth - 1;
+        this.idxZShift = Integer.numberOfTrailingZeros(sectionWidth);
+        this.idxYShift = this.idxZShift * 2;
+        this.idxYMask = -(1 << this.idxYShift);
+        this.idxXMask = sectionWidthMask;
+        this.idxZMask = sectionWidthMask << this.idxZShift;
+
+        int sectionHeight = heightLimitView.countVerticalSections();
+        sectionHeightOffset = -heightLimitView.getBottomSectionCoord();
+
+        tblSize = sectionWidthSquared * sectionHeight;
+
+        frustumChecks = BitArray.create(tblSize*2);
+        visibilityCheck = BitArray.create(tblSize);
+    }
+
+    public int getSectionId(int x, int y, int z) {
+        int tableY = y + this.sectionHeightOffset;
+        int tableZ = z & this.sectionWidthMask;
+        int tableX = x & this.sectionWidthMask;
+        return (tableY << this.idxYShift)
+                | (tableZ << this.idxZShift)
+                | tableX;
+    }
+
+    private Frustum frustum;
+
+    public void setFrustum(Frustum frustum) {
+        this.frustum = frustum;
+    }
+
+    public void clear() {
+        BitArray.clear(frustumChecks);
+        BitArray.clear(visibilityCheck);
+    }
+
+    public void setVisible(int x, int y, int z) {
+        BitArray.set(visibilityCheck, getSectionId(x,y,z));
+    }
+
+    public boolean isVisible(int x, int y, int z) {
+        return BitArray.get(visibilityCheck, getSectionId(x,y,z));
+    }
+
+    public int frustumCheck(int x, int y, int z) {
+        int id = getSectionId(x,y,z);
+        int check = BitArray.getPair(frustumChecks, id);
+        if (check != 0) {
+            return check - 4;
+        }
+        int res = frustum.testBox(x<<4, y<<4, z<<4, (x<<4) + 16.0f, (y<<4) + 16.0f, (z<<4) + 16.0f) + 4;
+        BitArray.set(frustumChecks, res);
+        return res-4;
+    }
+
+}

--- a/src/main/java/me/jellysquid/mods/sodium/client/util/BitArray.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/util/BitArray.java
@@ -1,0 +1,73 @@
+package me.jellysquid.mods.sodium.client.util;
+
+import java.util.Arrays;
+
+public class BitArray {
+    private static final int ADDRESS_BITS_PER_WORD = 6;
+    private static final int BITS_PER_WORD = 1 << ADDRESS_BITS_PER_WORD;
+    private static final int BIT_INDEX_MASK = BITS_PER_WORD - 1;
+
+    private BitArray()
+    {
+
+    }
+
+    public static long[] create(int count) {
+        return new long[(MathUtil.align(count, BITS_PER_WORD) >> ADDRESS_BITS_PER_WORD)];
+    }
+
+    public static boolean get(long[] words, int index) {
+        return (words[wordIndex(index)] & 1L << bitIndex(index)) != 0;
+    }
+
+    public static void set(long[] words, int index) {
+        words[wordIndex(index)] |= 1L << bitIndex(index);
+    }
+
+    public static void unset(long[] words, int index) {
+        words[wordIndex(index)] &= ~(1L << bitIndex(index));
+    }
+
+    public static void put(long[] words, int index, boolean value) {
+        int wordIndex = wordIndex(index);
+        int bitIndex = bitIndex(index);
+        long intValue = value ? 1 : 0;
+        words[wordIndex] = (words[wordIndex] & ~(1L << bitIndex)) | (intValue << bitIndex);
+    }
+
+    public static int count(long[] words) {
+        int sum = 0;
+
+        for (long word : words) {
+            sum += Long.bitCount(word);
+        }
+
+        return sum;
+    }
+
+    public static void clear(long[] words) {
+        Arrays.fill(words, 0L);
+    }
+
+    private static int wordIndex(int index) {
+        return index >> ADDRESS_BITS_PER_WORD;
+    }
+
+    private static int bitIndex(int index) {
+        return index & BIT_INDEX_MASK;
+    }
+
+
+    public static int getPair(long[] words, int index) {
+        return (int) ((words[index>>5] >> ((index&0b11111)<<1))&3);
+    }
+
+    public static void setPair(long[] words, int index, int pair) {
+        long w = words[index>>5];
+        int i = (index&0b11111)<<1;
+        long v = ((long)pair)<<(i);
+        w &= ~v;
+        w |= v;
+        words[index>>5] = w;
+    }
+}

--- a/src/main/java/me/jellysquid/mods/sodium/client/util/MathUtil.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/util/MathUtil.java
@@ -11,4 +11,10 @@ public class MathUtil {
     public static long toMib(long x) {
         return x / 1024L / 1024L;
     }
+
+    public static int align(int num, int alignment) {
+        int additive = alignment - 1;
+        int mask = ~additive;
+        return (num + additive) & mask;
+    }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/util/frustum/Frustum.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/util/frustum/Frustum.java
@@ -1,32 +1,17 @@
 package me.jellysquid.mods.sodium.client.util.frustum;
 
+import static org.joml.FrustumIntersection.OUTSIDE;
+
 public interface Frustum {
     /**
      * @return The visibility of an axis-aligned box within the frustum
      */
-    Visibility testBox(float minX, float minY, float minZ, float maxX, float maxY, float maxZ);
+    int testBox(float minX, float minY, float minZ, float maxX, float maxY, float maxZ);
 
     /**
      * @return true if the axis-aligned box is visible within the frustum, otherwise false
      */
     default boolean isBoxVisible(float minX, float minY, float minZ, float maxX, float maxY, float maxZ) {
-        return this.testBox(minX, minY, minZ, maxX, maxY, maxZ) != Visibility.OUTSIDE;
-    }
-
-    enum Visibility {
-        /**
-         * The object is fully outside the frustum and is not visible.
-         */
-        OUTSIDE,
-
-        /**
-         * The object intersects with a plane of the frustum and is visible.
-         */
-        INTERSECT,
-
-        /**
-         * The object is fully contained within the frustum and is visible.
-         */
-        INSIDE
+        return this.testBox(minX, minY, minZ, maxX, maxY, maxZ) != OUTSIDE;
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/util/frustum/JomlFrustum.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/util/frustum/JomlFrustum.java
@@ -21,12 +21,13 @@ public class JomlFrustum implements Frustum {
     }
 
     @Override
-    public Visibility testBox(float minX, float minY, float minZ, float maxX, float maxY, float maxZ) {
-        return switch (this.intersection.intersectAab(minX - this.offset.x, minY - this.offset.y, minZ - this.offset.z,
-                maxX - this.offset.x, maxY - this.offset.y, maxZ - this.offset.z)) {
-            case FrustumIntersection.INTERSECT -> Visibility.INTERSECT;
-            case FrustumIntersection.INSIDE -> Visibility.INSIDE;
-            default -> Visibility.OUTSIDE;
+    public int testBox(float minX, float minY, float minZ, float maxX, float maxY, float maxZ) {
+        int res = this.intersection.intersectAab(minX - this.offset.x, minY - this.offset.y, minZ - this.offset.z,
+                maxX - this.offset.x, maxY - this.offset.y, maxZ - this.offset.z);
+        return switch (res) {
+            case FrustumIntersection.INTERSECT -> FrustumIntersection.INTERSECT;
+            case FrustumIntersection.INSIDE -> FrustumIntersection.INSIDE;
+            default -> FrustumIntersection.OUTSIDE;
         };
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/MixinFrustum.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/MixinFrustum.java
@@ -28,12 +28,12 @@ public class MixinFrustum implements FrustumAdapter, me.jellysquid.mods.sodium.c
     }
 
     @Override
-    public Visibility testBox(float minX, float minY, float minZ, float maxX, float maxY, float maxZ) {
+    public int testBox(float minX, float minY, float minZ, float maxX, float maxY, float maxZ) {
         return switch (this.frustumIntersection.intersectAab(minX - (float) this.x, minY - (float) this.y, minZ - (float) this.z,
                 maxX - (float) this.x, maxY - (float) this.y, maxZ - (float) this.z)) {
-            case FrustumIntersection.INTERSECT -> Visibility.INTERSECT;
-            case FrustumIntersection.INSIDE -> Visibility.INSIDE;
-            default -> Visibility.OUTSIDE;
+            case FrustumIntersection.INTERSECT -> FrustumIntersection.INTERSECT;
+            case FrustumIntersection.INSIDE -> FrustumIntersection.INSIDE;
+            default -> FrustumIntersection.OUTSIDE;
         };
     }
 }


### PR DESCRIPTION
Implements a variant of rayculling from vanilla which only checks 5 chunks instead of all chunks so that performance is better at the loss of some accuracy