### PR TITLE
Fix keyboard navigation for 1.19.4

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/ControlElement.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/ControlElement.java
@@ -3,8 +3,12 @@ package me.jellysquid.mods.sodium.client.gui.options.control;
 import me.jellysquid.mods.sodium.client.gui.options.Option;
 import me.jellysquid.mods.sodium.client.gui.widgets.AbstractWidget;
 import me.jellysquid.mods.sodium.client.util.Dim2i;
+import net.minecraft.client.gui.navigation.FocusedRect;
+import net.minecraft.client.gui.navigation.GuiNavigation;
+import net.minecraft.client.gui.navigation.GuiNavigationPath;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Formatting;
+import org.jetbrains.annotations.Nullable;
 
 public class ControlElement<T> extends AbstractWidget {
     protected final Option<T> option;
@@ -21,7 +25,7 @@ public class ControlElement<T> extends AbstractWidget {
         String name = this.option.getName().getString();
         String label;
 
-        if (this.hovered && this.font.getWidth(name) > (this.dim.width() - this.option.getControl().getMaxWidth())) {
+        if ((this.hovered || this.isFocused()) && this.font.getWidth(name) > (this.dim.width() - this.option.getControl().getMaxWidth())) {
             name = name.substring(0, Math.min(name.length(), 10)) + "...";
         }
 
@@ -39,6 +43,10 @@ public class ControlElement<T> extends AbstractWidget {
 
         this.drawRect(this.dim.x(), this.dim.y(), this.dim.getLimitX(), this.dim.getLimitY(), this.hovered ? 0xE0000000 : 0x90000000);
         this.drawString(matrixStack, label, this.dim.x() + 6, this.dim.getCenterY() - 4, 0xFFFFFFFF);
+
+        if (this.isFocused()) {
+            this.drawBorder(this.dim.x(), this.dim.y(), this.dim.getLimitX(), this.dim.getLimitY());
+        }
     }
 
     public Option<T> getOption() {
@@ -47,5 +55,17 @@ public class ControlElement<T> extends AbstractWidget {
 
     public Dim2i getDimensions() {
         return this.dim;
+    }
+
+    @Override
+    public @Nullable GuiNavigationPath getNavigationPath(GuiNavigation navigation) {
+        if (!this.option.isAvailable())
+            return null;
+        return super.getNavigationPath(navigation);
+    }
+
+    @Override
+    public FocusedRect getNavigationFocus() {
+        return new FocusedRect(this.dim.x(), this.dim.y(), this.dim.width(), this.dim.height());
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/CyclingControl.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/CyclingControl.java
@@ -3,6 +3,8 @@ package me.jellysquid.mods.sodium.client.gui.options.control;
 import me.jellysquid.mods.sodium.client.gui.options.Option;
 import me.jellysquid.mods.sodium.client.gui.options.TextProvider;
 import me.jellysquid.mods.sodium.client.util.Dim2i;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.util.InputUtil;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.Text;
 import org.apache.commons.lang3.Validate;
@@ -97,14 +99,34 @@ public class CyclingControl<T extends Enum<T>> implements Control<T> {
         @Override
         public boolean mouseClicked(double mouseX, double mouseY, int button) {
             if (this.option.isAvailable() && button == 0 && this.dim.containsCursor(mouseX, mouseY)) {
-                this.currentIndex = (this.option.getValue().ordinal() + 1) % this.allowedValues.length;
-                this.option.setValue(this.allowedValues[this.currentIndex]);
+                cycleControl(Screen.hasShiftDown());
                 this.playClickSound();
 
                 return true;
             }
 
             return false;
+        }
+
+        @Override
+        public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+            if (!isFocused()) return false;
+
+            if (keyCode == InputUtil.GLFW_KEY_ENTER) {
+                cycleControl(Screen.hasShiftDown());
+                return true;
+            }
+
+            return false;
+        }
+
+        public void cycleControl(boolean reverse) {
+            if (reverse) {
+                this.currentIndex = (this.currentIndex + this.allowedValues.length - 1) % this.allowedValues.length;
+            } else {
+                this.currentIndex = (this.currentIndex + 1) % this.allowedValues.length;
+            }
+            this.option.setValue(this.allowedValues[this.currentIndex]);
         }
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/SliderControl.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/SliderControl.java
@@ -70,7 +70,7 @@ public class SliderControl implements Control<Integer> {
         public void render(MatrixStack matrixStack, int mouseX, int mouseY, float delta) {
             super.render(matrixStack, mouseX, mouseY, delta);
 
-            if (this.option.isAvailable() && this.hovered) {
+            if (this.option.isAvailable() && (this.hovered || this.isFocused())) {
                 this.renderSlider(matrixStack);
             } else {
                 this.renderStandaloneValue(matrixStack);
@@ -100,7 +100,7 @@ public class SliderControl implements Control<Integer> {
             double thumbOffset = MathHelper.clamp((double) (this.getIntValue() - this.min) / this.range * sliderWidth, 0, sliderWidth);
 
             double thumbX = sliderX + thumbOffset - THUMB_WIDTH;
-            double trackY = sliderY + (sliderHeight / 2) - ((double) TRACK_HEIGHT / 2);
+            double trackY = sliderY + (sliderHeight / 2f) - ((double) TRACK_HEIGHT / 2);
 
             this.drawRect(thumbX, sliderY, thumbX + (THUMB_WIDTH * 2), sliderY + sliderHeight, 0xFFFFFFFF);
             this.drawRect(sliderX, trackY, sliderX + sliderWidth, trackY + TRACK_HEIGHT, 0xFFFFFFFF);
@@ -139,7 +139,7 @@ public class SliderControl implements Control<Integer> {
             this.setValue((d - (double) this.sliderBounds.getX()) / (double) this.sliderBounds.getWidth());
         }
 
-        private void setValue(double d) {
+        public void setValue(double d) {
             this.thumbPosition = MathHelper.clamp(d, 0.0D, 1.0D);
 
             int value = this.getIntValue();

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/TickBoxControl.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/TickBoxControl.java
@@ -2,6 +2,7 @@ package me.jellysquid.mods.sodium.client.gui.options.control;
 
 import me.jellysquid.mods.sodium.client.gui.options.Option;
 import me.jellysquid.mods.sodium.client.util.Dim2i;
+import net.minecraft.client.util.InputUtil;
 import net.minecraft.client.util.math.Rect2i;
 import net.minecraft.client.util.math.MatrixStack;
 
@@ -66,13 +67,31 @@ public class TickBoxControl implements Control<Boolean> {
         @Override
         public boolean mouseClicked(double mouseX, double mouseY, int button) {
             if (this.option.isAvailable() && button == 0 && this.dim.containsCursor(mouseX, mouseY)) {
-                this.option.setValue(!this.option.getValue());
+                toggleControl();
                 this.playClickSound();
 
                 return true;
             }
 
             return false;
+        }
+
+        @Override
+        public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+            if (!isFocused()) return false;
+
+            if (keyCode == InputUtil.GLFW_KEY_ENTER) {
+                toggleControl();
+                this.playClickSound();
+
+                return true;
+            }
+
+            return false;
+        }
+
+        public void toggleControl() {
+            this.option.setValue(!this.option.getValue());
         }
 
         protected void drawRectOutline(int x, int y, int w, int h, int color) {

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/widgets/AbstractWidget.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/widgets/AbstractWidget.java
@@ -6,6 +6,8 @@ import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.Drawable;
 import net.minecraft.client.gui.Element;
 import net.minecraft.client.gui.Selectable;
+import net.minecraft.client.gui.navigation.GuiNavigation;
+import net.minecraft.client.gui.navigation.GuiNavigationPath;
 import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
 import net.minecraft.client.gui.screen.narration.NarrationPart;
 import net.minecraft.client.render.*;
@@ -14,6 +16,7 @@ import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.text.StringVisitable;
 import net.minecraft.text.Text;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Consumer;
 
@@ -103,6 +106,11 @@ public abstract class AbstractWidget implements Drawable, Element, Selectable {
         }
     }
 
+    @Nullable
+    public GuiNavigationPath getNavigationPath(GuiNavigation navigation) {
+        return !this.isFocused() ? GuiNavigationPath.of(this) : null;
+    }
+
     @Override
     public void setFocused(boolean focused) {
         this.focused = focused;
@@ -111,5 +119,12 @@ public abstract class AbstractWidget implements Drawable, Element, Selectable {
     @Override
     public boolean isFocused() {
         return focused;
+    }
+
+    protected void drawBorder(int x1, int y1, int x2, int y2) {
+        this.drawRect(x1, y1, x2, y1 + 1, -1);
+        this.drawRect(x1, y2 - 1, x2, y2, -1);
+        this.drawRect(x1, y1, x1 + 1, y2, -1);
+        this.drawRect(x2 - 1, y1, x2, y2, -1);
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/widgets/FlatButtonWidget.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/widgets/FlatButtonWidget.java
@@ -2,8 +2,13 @@ package me.jellysquid.mods.sodium.client.gui.widgets;
 
 import me.jellysquid.mods.sodium.client.util.Dim2i;
 import net.minecraft.client.gui.Drawable;
+import net.minecraft.client.gui.navigation.FocusedRect;
+import net.minecraft.client.gui.navigation.GuiNavigation;
+import net.minecraft.client.gui.navigation.GuiNavigationPath;
+import net.minecraft.client.util.InputUtil;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.Text;
+import org.jetbrains.annotations.Nullable;
 
 public class FlatButtonWidget extends AbstractWidget implements Drawable {
     private final Dim2i dim;
@@ -40,6 +45,9 @@ public class FlatButtonWidget extends AbstractWidget implements Drawable {
         if (this.enabled && this.selected) {
             this.drawRect(this.dim.x(), this.dim.getLimitY() - 1, this.dim.getLimitX(), this.dim.getLimitY(), 0xFF94E4D3);
         }
+        if (this.enabled && this.isFocused()) {
+            this.drawBorder(this.dim.x(), this.dim.y(), this.dim.getLimitX(), this.dim.getLimitY());
+        }
     }
 
     public void setSelected(boolean selected) {
@@ -53,13 +61,30 @@ public class FlatButtonWidget extends AbstractWidget implements Drawable {
         }
 
         if (button == 0 && this.dim.containsCursor(mouseX, mouseY)) {
-            this.action.run();
-            this.playClickSound();
+            doAction();
 
             return true;
         }
 
         return false;
+    }
+
+    @Override
+    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+        if (!this.isFocused())
+            return false;
+
+        if (keyCode == InputUtil.GLFW_KEY_ENTER) {
+            doAction();
+            return true;
+        }
+
+        return false;
+    }
+
+    private void doAction() {
+        this.action.run();
+        this.playClickSound();
     }
 
     public void setEnabled(boolean enabled) {
@@ -76,5 +101,17 @@ public class FlatButtonWidget extends AbstractWidget implements Drawable {
 
     public Text getLabel() {
         return this.label;
+    }
+
+    @Override
+    public @Nullable GuiNavigationPath getNavigationPath(GuiNavigation navigation) {
+        if (!enabled || !visible)
+            return null;
+        return super.getNavigationPath(navigation);
+    }
+
+    @Override
+    public FocusedRect getNavigationFocus() {
+        return new FocusedRect(this.dim.x(), this.dim.y(), this.dim.width(), this.dim.height());
     }
 }


### PR DESCRIPTION
When testing, Sodium GUI could not be operated whatsoever by the snapshot's new arrow key navigation and the old tab key navigation.

This PR fixes this.

Sliders still cannot be controlled by a keyboard and am willing to take advice on the matter.