### PR TITLE
Add error screen when Indium is missing and mods request a FRAPI implementation

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/screen/MissingIndiumScreen.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/screen/MissingIndiumScreen.java
@@ -1,0 +1,97 @@
+package me.jellysquid.mods.sodium.client.gui.screen;
+
+import me.jellysquid.mods.sodium.client.SodiumClientMod;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.text.Text;
+import net.minecraft.util.Util;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class MissingIndiumScreen extends Screen {
+    public static boolean shouldShow() {
+        if (FabricLoader.getInstance().isModLoaded("indium")) {
+            return false;
+        }
+
+        List<ModContainer> modsRequiringRenderer = FabricLoader.getInstance().getAllMods().stream()
+                .filter(mod -> mod.getMetadata().containsCustomValue("requires_renderer"))
+                .toList();
+
+        if (modsRequiringRenderer.size() > 0) {
+            SodiumClientMod.logger().error("Found %d mods that require Indium to be installed: %s".formatted(
+                    modsRequiringRenderer.size(),
+                    modsRequiringRenderer.stream().map(mod -> mod.getMetadata().getId()).collect(Collectors.joining(", "))
+            ));
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private static final String TEXT_BODY_RAW = """
+            Some mods require an implementation of the Fabric Rendering API to be
+            installed. Such an implementation is provided by Indium.
+            Please download and install Indium for these mods to render correctly.
+
+            The list of such mods can be found in the log file.
+            """;
+
+    private static final List<Text> TEXT_BODY = Arrays.stream(TEXT_BODY_RAW.split("\n"))
+            .map(Text::literal)
+            .collect(Collectors.toList());
+
+    private static final Text TEXT_BUTTON_DOWNLOAD_INDIUM_CURSEFORGE = Text.literal("CurseForge");
+    private static final Text TEXT_BUTTON_DOWNLOAD_INDIUM_MODRINTH = Text.literal("Modrinth");
+    private static final Text TEXT_BUTTON_IGNORE_WARNING = Text.literal("Ignore warning");
+
+    private final Supplier<Screen> child;
+
+    public MissingIndiumScreen(Supplier<Screen> child) {
+        super(Text.literal("Missing Indium"));
+
+        this.child = child;
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+
+        this.addDrawableChild(ButtonWidget.builder(TEXT_BUTTON_DOWNLOAD_INDIUM_CURSEFORGE, (btn) -> {
+            Util.getOperatingSystem().open("https://www.curseforge.com/minecraft/mc-mods/indium");
+        }).dimensions(32, this.height - 40, 120, 20).build());
+
+        this.addDrawableChild(ButtonWidget.builder(TEXT_BUTTON_DOWNLOAD_INDIUM_MODRINTH, (btn) -> {
+            Util.getOperatingSystem().open("https://modrinth.com/mod/indium");
+        }).dimensions(this.width / 2 - 120 / 2, this.height - 40, 120, 20).build());
+
+        this.addDrawableChild(ButtonWidget.builder(TEXT_BUTTON_IGNORE_WARNING, (btn) -> {
+            MinecraftClient.getInstance().setScreen(this.child.get());
+        }).dimensions(this.width - 120 - 32, this.height - 40, 120, 20).build());
+    }
+
+    @Override
+    public void render(MatrixStack matrices, int mouseX, int mouseY, float delta) {
+        this.renderBackground(matrices);
+
+        super.render(matrices, mouseX, mouseY, delta);
+
+        drawTextWithShadow(matrices, this.textRenderer, Text.literal("Sodium Renderer"), 32, 32, 0xffffff);
+        drawTextWithShadow(matrices, this.textRenderer, Text.literal("Missing Indium"), 32, 48, 0xff0000);
+
+        for (int i = 0; i < TEXT_BODY.size(); i++) {
+            if (TEXT_BODY.get(i).getString().isEmpty()) {
+                continue;
+            }
+
+            drawTextWithShadow(matrices, this.textRenderer, TEXT_BODY.get(i), 32, 68 + (i * 12), 0xffffff);
+        }
+    }
+}

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/MixinMinecraftClient.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/MixinMinecraftClient.java
@@ -3,6 +3,7 @@ package me.jellysquid.mods.sodium.mixin.core;
 import it.unimi.dsi.fastutil.longs.LongArrayFIFOQueue;
 import me.jellysquid.mods.sodium.client.SodiumClientMod;
 import me.jellysquid.mods.sodium.client.gui.screen.ConfigCorruptedScreen;
+import me.jellysquid.mods.sodium.client.gui.screen.MissingIndiumScreen;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.RunArgs;
 import org.lwjgl.opengl.GL32C;
@@ -17,9 +18,12 @@ public class MixinMinecraftClient {
 
     @Inject(method = "<init>", at = @At("RETURN"))
     private void postInit(RunArgs args, CallbackInfo ci) {
+        var parent = MinecraftClient.getInstance().currentScreen;
+
         if (SodiumClientMod.options().isReadOnly()) {
-            var parent = MinecraftClient.getInstance().currentScreen;
             MinecraftClient.getInstance().setScreen(new ConfigCorruptedScreen(() -> parent));
+        } else if (MissingIndiumScreen.shouldShow()) {
+            MinecraftClient.getInstance().setScreen(new MissingIndiumScreen(() -> parent));
         }
     }
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,7 +24,8 @@
     ]
   },
   "custom": {
-    "fabric-renderer-api-v1:contains_renderer": true
+    "fabric-renderer-api-v1:contains_renderer": true,
+    "requires_renderer": true
   },
   "accessWidener": "sodium.accesswidener",
   "mixins": [


### PR DESCRIPTION
I assume there are reasons why Sodium does not include (i.e. jar-in-jar) Indium directly, so here is a compromise that I think would be acceptable. The general idea is:
- Mods declare that they want a FRAPI implementation by adding the `requires_renderer` custom value.
- Sodium detects that, and if Indium is missing, displays a warning screen to the user.

This is what the screen looks like at the moment:
![image](https://user-images.githubusercontent.com/13494793/220680684-49d64709-a538-42ce-8b67-3b06dc286054.png)

Of course, the screen likely needs to be tweaked more to be optimal!