### PR TITLE
change: increase build performance by remapping once

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import net.fabricmc.loom.task.RemapJarTask
-
 plugins {
     id 'fabric-loom' version '1.0-SNAPSHOT'
     id 'org.ajoberstar.grgit' version '4.1.0'
@@ -40,20 +38,20 @@ sourceSets {
 }
 
 tasks.register('apiJar', Jar) {
-    classifier "api-dev"
-
-    from sourceSets.api.output
-}
-
-tasks.register('remapApiJar', RemapJarTask) {
+    dependsOn(remapJar)
     classifier "api"
 
-    input = apiJar.archiveFile.get().asFile
-    addNestedDependencies = false
+    from(zipTree(remapJar.getOutputs().getFiles().first())) {
+        include("LICENSE.txt")
+        include("net/caffeinemc/mods/sodium/api/**")
+    }
+
+    manifest {
+        attributes("Fabric-Loom-Remap": "true")
+    }
 }
 
 build.dependsOn apiJar
-build.dependsOn remapApiJar
 
 jar {
     from sourceSets.api.output.classesDirs

--- a/build.gradle
+++ b/build.gradle
@@ -41,13 +41,19 @@ tasks.register('apiJar', Jar) {
     dependsOn(remapJar)
     classifier "api"
 
+    from(sourceSets.api.output.resourcesDir)
+
     from(zipTree(remapJar.getOutputs().getFiles().first())) {
         include("LICENSE.txt")
         include("net/caffeinemc/mods/sodium/api/**")
     }
+}
 
-    manifest {
-        attributes("Fabric-Loom-Remap": "true")
+processApiResources {
+    inputs.property "version", project.version
+
+    filesMatching("fabric.mod.json") {
+        expand "version": project.version
     }
 }
 
@@ -55,7 +61,6 @@ build.dependsOn apiJar
 
 jar {
     from sourceSets.api.output.classesDirs
-    from sourceSets.api.output.resourcesDir
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Done to increase the memory available to gradle.
-org.gradle.jvmargs=-Xmx2G
+org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop/

--- a/src/api/resources/fabric.mod.json
+++ b/src/api/resources/fabric.mod.json
@@ -1,0 +1,7 @@
+{
+    "schemaVersion": 1,
+    "id": "sodium-api",
+    "version": "${version}",
+    "license": "LGPL-3.0-only",
+    "environment": "client"
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,6 +30,9 @@
   "mixins": [
     "sodium.mixins.json"
   ],
+  "provides": [
+      "sodium-api"
+  ],
   "depends": {
     "fabricloader": ">=0.12.0",
     "fabric-rendering-data-attachment-v1": ">=0.1",


### PR DESCRIPTION
Instead of remapping both the api jar and the mod jar (which includes all of the api classes anyway), we can just remap the mod jar, then extract the api classes out of it

This is slightly hacky, but avoids doing double the work