### PR TITLE
 Fix face culling precision errors

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkCameraContext.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ChunkCameraContext.java
@@ -3,7 +3,7 @@ package me.jellysquid.mods.sodium.client.render.chunk;
 public class ChunkCameraContext {
     public final int blockX, blockY, blockZ;
     public final float deltaX, deltaY, deltaZ;
-    public final float posX, posY, posZ;
+    public final double posX, posY, posZ;
 
     public ChunkCameraContext(double x, double y, double z) {
         this.blockX = (int) x;
@@ -15,9 +15,9 @@ public class ChunkCameraContext {
         this.deltaY = (float) Math.round((y - this.blockY) * 0x1p14f) * 0x1p-14f;
         this.deltaZ = (float) Math.round((z - this.blockZ) * 0x1p14f) * 0x1p-14f;
 
-        this.posX = (float) x;
-        this.posY = (float) y;
-        this.posZ = (float) z;
+        this.posX = x;
+        this.posY = y;
+        this.posZ = z;
     }
 
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/data/ChunkRenderBounds.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/data/ChunkRenderBounds.java
@@ -7,10 +7,10 @@ public class ChunkRenderBounds {
     public static final ChunkRenderBounds ALWAYS_FALSE = new ChunkRenderBounds(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY,
             Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY);
 
-    public final float minX, minY, minZ;
-    public final float maxX, maxY, maxZ;
+    public final double minX, minY, minZ;
+    public final double maxX, maxY, maxZ;
 
-    public ChunkRenderBounds(float minX, float minY, float minZ, float maxX, float maxY, float maxZ) {
+    public ChunkRenderBounds(double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
         this.minX = minX;
         this.minY = minY;
         this.minZ = minZ;
@@ -51,14 +51,14 @@ public class ChunkRenderBounds {
         }
 
         public ChunkRenderBounds build(ChunkSectionPos origin) {
-            float minX = origin.getMinX() + this.minX;
-            float maxX = origin.getMinX() + this.maxX;
+            double minX = origin.getMinX() + (double) this.minX;
+            double maxX = origin.getMinX() + (double) this.maxX;
 
-            float minY = origin.getMinY() + this.minY;
-            float maxY = origin.getMinY() + this.maxY;
+            double minY = origin.getMinY() + (double) this.minY;
+            double maxY = origin.getMinY() + (double) this.maxY;
 
-            float minZ = origin.getMinZ() + this.minZ;
-            float maxZ = origin.getMinZ() + this.maxZ;
+            double minZ = origin.getMinZ() + (double) this.minZ;
+            double maxZ = origin.getMinZ() + (double) this.maxZ;
 
             return new ChunkRenderBounds(minX, minY, minZ, maxX, maxY, maxZ);
         }


### PR DESCRIPTION
- Use doubles instead of floats to represent the camera position and render bounds