### PR TITLE
Restore `VertexConsumer.quad` optimization and resolve #1354

### DIFF
--- a/src/api/java/net/caffeinemc/mods/sodium/api/util/ColorU8.java
+++ b/src/api/java/net/caffeinemc/mods/sodium/api/util/ColorU8.java
@@ -36,6 +36,15 @@ public interface ColorU8 {
      * @return The floating point value of the integer component in the range of 0.0..1.0
      */
     static float byteToNormalizedFloat(byte value) {
+        return (float) Byte.toUnsignedInt(value) * COMPONENT_RANGE_INVERSE;
+    }
+
+    /**
+     * Converts an integer component to a normalized floating point value.
+     * @param value The integer component in 0..255 range
+     * @return The floating point value of the integer component in the range of 0.0..1.0
+     */
+    static float byteToNormalizedFloat(int value) {
         return (float) value * COMPONENT_RANGE_INVERSE;
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/data/ChunkRenderData.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/data/ChunkRenderData.java
@@ -4,7 +4,7 @@ import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import me.jellysquid.mods.sodium.client.render.chunk.RenderSectionFlags;
 import me.jellysquid.mods.sodium.client.render.chunk.terrain.TerrainRenderPass;
-import me.jellysquid.mods.sodium.client.render.texture.SpriteExtended;
+import me.jellysquid.mods.sodium.client.render.texture.SpriteContentsExtended;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.client.render.chunk.ChunkOcclusionData;
 import net.minecraft.client.texture.Sprite;
@@ -98,7 +98,7 @@ public class ChunkRenderData {
          * @param sprite The sprite
          */
         public void addSprite(Sprite sprite) {
-            if (((SpriteExtended) sprite.getContents()).hasAnimation()) {
+            if (((SpriteContentsExtended) sprite.getContents()).hasAnimation()) {
                 this.animatedSprites.add(sprite);
             }
         }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/immediate/model/BakedModelEncoder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/immediate/model/BakedModelEncoder.java
@@ -1,17 +1,19 @@
 package me.jellysquid.mods.sodium.client.render.immediate.model;
 
 import me.jellysquid.mods.sodium.client.model.quad.ModelQuadView;
-import net.caffeinemc.mods.sodium.api.vertex.format.common.ModelVertex;
 import net.caffeinemc.mods.sodium.api.math.MatrixHelper;
 import net.caffeinemc.mods.sodium.api.render.immediate.RenderImmediate;
+import net.caffeinemc.mods.sodium.api.util.ColorABGR;
+import net.caffeinemc.mods.sodium.api.util.ColorU8;
 import net.caffeinemc.mods.sodium.api.vertex.buffer.VertexBufferWriter;
+import net.caffeinemc.mods.sodium.api.vertex.format.common.ModelVertex;
 import net.minecraft.client.util.math.MatrixStack;
 import org.joml.Matrix3f;
 import org.joml.Matrix4f;
 import org.lwjgl.system.MemoryStack;
 
 public class BakedModelEncoder {
-    public static void writeQuadVertices(VertexBufferWriter writer, MatrixStack.Entry matrices, ModelQuadView quad, int light, int overlay, int color) {
+    public static void writeQuadVertices(VertexBufferWriter writer, MatrixStack.Entry matrices, ModelQuadView quad, int color, int light, int overlay) {
         Matrix3f matNormal = matrices.getNormalMatrix();
         Matrix4f matPosition = matrices.getPositionMatrix();
 
@@ -34,6 +36,60 @@ public class BakedModelEncoder {
                 float zt = MatrixHelper.transformPositionZ(matPosition, x, y, z);
 
                 ModelVertex.write(ptr, xt, yt, zt, color, quad.getTexU(i), quad.getTexV(i), overlay, light, normal);
+                ptr += ModelVertex.STRIDE;
+            }
+
+            writer.push(stack, buffer, 4, ModelVertex.FORMAT);
+        }
+    }
+
+    public static void writeQuadVertices(VertexBufferWriter writer, MatrixStack.Entry matrices, ModelQuadView quad, float r, float g, float b, float[] brightnessTable, boolean colorize, int[] light, int overlay) {
+        Matrix3f matNormal = matrices.getNormalMatrix();
+        Matrix4f matPosition = matrices.getPositionMatrix();
+
+        try (MemoryStack stack = RenderImmediate.VERTEX_DATA.push()) {
+            long buffer = stack.nmalloc(4 * ModelVertex.STRIDE);
+            long ptr = buffer;
+
+            // The packed transformed normal vector
+            var normal = MatrixHelper.transformNormal(matNormal, quad.getNormal());
+
+            for (int i = 0; i < 4; i++) {
+                // The position vector
+                float x = quad.getX(i);
+                float y = quad.getY(i);
+                float z = quad.getZ(i);
+
+                // The transformed position vector
+                float xt = MatrixHelper.transformPositionX(matPosition, x, y, z);
+                float yt = MatrixHelper.transformPositionY(matPosition, x, y, z);
+                float zt = MatrixHelper.transformPositionZ(matPosition, x, y, z);
+
+                float fR;
+                float fG;
+                float fB;
+
+                float brightness = brightnessTable[i];
+
+                if (colorize) {
+                    int color = quad.getColor(i);
+
+                    float oR = ColorU8.byteToNormalizedFloat(ColorABGR.unpackRed(color));
+                    float oG = ColorU8.byteToNormalizedFloat(ColorABGR.unpackGreen(color));
+                    float oB = ColorU8.byteToNormalizedFloat(ColorABGR.unpackBlue(color));
+
+                    fR = oR * brightness * r;
+                    fG = oG * brightness * g;
+                    fB = oB * brightness * b;
+                } else {
+                    fR = brightness * r;
+                    fG = brightness * g;
+                    fB = brightness * b;
+                }
+
+                int color = ColorABGR.pack(fR, fG, fB, 1.0F);
+
+                ModelVertex.write(ptr, xt, yt, zt, color, quad.getTexU(i), quad.getTexV(i), overlay, light[i], normal);
                 ptr += ModelVertex.STRIDE;
             }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/texture/SpriteContentsExtended.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/texture/SpriteContentsExtended.java
@@ -1,6 +1,6 @@
 package me.jellysquid.mods.sodium.client.render.texture;
 
-public interface SpriteExtended {
+public interface SpriteContentsExtended {
     void setActive(boolean b);
 
     boolean hasAnimation();

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/texture/SpriteUtil.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/texture/SpriteUtil.java
@@ -4,8 +4,8 @@ import net.minecraft.client.texture.Sprite;
 
 public class SpriteUtil {
     public static void markSpriteActive(Sprite sprite) {
-        if (sprite.getContents() instanceof SpriteExtended) {
-            ((SpriteExtended) sprite.getContents()).setActive(true);
+        if (sprite.getContents() instanceof SpriteContentsExtended) {
+            ((SpriteContentsExtended) sprite.getContents()).setActive(true);
         }
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/block/MixinBlockModelRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/block/MixinBlockModelRenderer.java
@@ -1,11 +1,11 @@
 package me.jellysquid.mods.sodium.mixin.features.block;
 
-import me.jellysquid.mods.sodium.client.model.quad.ModelQuadView;
+import me.jellysquid.mods.sodium.client.model.quad.BakedQuadView;
 import me.jellysquid.mods.sodium.client.render.immediate.model.BakedModelEncoder;
-import net.caffeinemc.mods.sodium.api.vertex.buffer.VertexBufferWriter;
 import me.jellysquid.mods.sodium.client.render.texture.SpriteUtil;
-import net.caffeinemc.mods.sodium.api.util.ColorABGR;
 import me.jellysquid.mods.sodium.common.util.DirectionUtil;
+import net.caffeinemc.mods.sodium.api.util.ColorABGR;
+import net.caffeinemc.mods.sodium.api.vertex.buffer.VertexBufferWriter;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.block.BlockModelRenderer;
@@ -18,6 +18,7 @@ import net.minecraft.util.math.random.LocalRandom;
 import net.minecraft.util.math.random.Random;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Unique;
 
 import java.util.List;
 
@@ -31,9 +32,9 @@ public class MixinBlockModelRenderer {
      */
     @Overwrite
     public void render(MatrixStack.Entry entry, VertexConsumer vertexConsumer, BlockState blockState, BakedModel bakedModel, float red, float green, float blue, int light, int overlay) {
-        Random random = this.random;
-
         var writer = VertexBufferWriter.of(vertexConsumer);
+
+        Random random = this.random;
 
         // Clamp color ranges
         red = MathHelper.clamp(red, 0.0F, 1.0F);
@@ -47,7 +48,7 @@ public class MixinBlockModelRenderer {
             List<BakedQuad> quads = bakedModel.getQuads(blockState, direction, random);
 
             if (!quads.isEmpty()) {
-                renderQuad(entry, writer, defaultColor, quads, light, overlay);
+                renderQuads(entry, writer, defaultColor, quads, light, overlay);
             }
         }
 
@@ -55,19 +56,20 @@ public class MixinBlockModelRenderer {
         List<BakedQuad> quads = bakedModel.getQuads(blockState, null, random);
 
         if (!quads.isEmpty()) {
-            renderQuad(entry, writer, defaultColor, quads, light, overlay);
+            renderQuads(entry, writer, defaultColor, quads, light, overlay);
         }
     }
 
+    @Unique
     @SuppressWarnings("ForLoopReplaceableByForEach")
-    private static void renderQuad(MatrixStack.Entry matrices, VertexBufferWriter writer, int defaultColor, List<BakedQuad> list, int light, int overlay) {
-        for (int j = 0; j < list.size(); j++) {
-            BakedQuad bakedQuad = list.get(j);
-            int color = bakedQuad.hasColor() ? defaultColor : 0xFFFFFFFF;
+    private static void renderQuads(MatrixStack.Entry matrices, VertexBufferWriter writer, int defaultColor, List<BakedQuad> quads, int light, int overlay) {
+        for (int i = 0; i < quads.size(); i++) {
+            BakedQuad bakedQuad = quads.get(i);
+            BakedQuadView quad = (BakedQuadView) bakedQuad;
 
-            ModelQuadView quad = ((ModelQuadView) bakedQuad);
+            int color = quad.hasColor() ? defaultColor : 0xFFFFFFFF;
 
-            BakedModelEncoder.writeQuadVertices(writer, matrices, quad, light, overlay, color);
+            BakedModelEncoder.writeQuadVertices(writer, matrices, quad, color, light, overlay);
 
             SpriteUtil.markSpriteActive(quad.getSprite());
         }

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/buffer_builder/intrinsics/MixinBufferBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/buffer_builder/intrinsics/MixinBufferBuilder.java
@@ -1,8 +1,14 @@
 package me.jellysquid.mods.sodium.mixin.features.buffer_builder.intrinsics;
 
+import me.jellysquid.mods.sodium.client.model.quad.ModelQuadView;
+import me.jellysquid.mods.sodium.client.render.immediate.model.BakedModelEncoder;
+import me.jellysquid.mods.sodium.client.render.texture.SpriteUtil;
+import net.caffeinemc.mods.sodium.api.util.ColorABGR;
+import net.caffeinemc.mods.sodium.api.vertex.buffer.VertexBufferWriter;
 import net.minecraft.client.render.BufferBuilder;
 import net.minecraft.client.render.FixedColorVertexConsumer;
-
+import net.minecraft.client.render.model.BakedQuad;
+import net.minecraft.client.util.math.MatrixStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
@@ -12,81 +18,46 @@ public abstract class MixinBufferBuilder extends FixedColorVertexConsumer {
     @Shadow
     private boolean canSkipElementChecks;
 
-//    @Override
-//    public void quad(MatrixStack.Entry matrices, BakedQuad quad, float[] brightnessTable, float r, float g, float b, int[] light, int overlay, boolean colorize) {
-//        if (!this.canSkipElementChecks) {
-//            super.quad(matrices, quad, brightnessTable, r, g, b, light, overlay, colorize);
-//
-//            return;
-//        }
-//
-//        if (this.colorFixed) {
-//            throw new IllegalStateException();
-//        }
-//
-//        ModelQuadView quadView = (ModelQuadView) quad;
-//
-//        Matrix4f positionMatrix = matrices.getPositionMatrix();
-//        Matrix3f normalMatrix = matrices.getNormalMatrix();
-//
-//        int norm = this.computeNormal(normalMatrix, quad.getFace());
-//
-//        QuadVertexSink drain = VertexDrain.of(this)
-//                .createSink(VanillaVertexTypes.QUADS);
-//        drain.ensureCapacity(4);
-//
-//        for (int i = 0; i < 4; i++) {
-//            float x = quadView.getX(i);
-//            float y = quadView.getY(i);
-//            float z = quadView.getZ(i);
-//
-//            float fR;
-//            float fG;
-//            float fB;
-//
-//            float brightness = brightnessTable[i];
-//
-//            if (colorize) {
-//                int color = quadView.getColor(i);
-//
-//                float oR = ColorU8.normalize(ColorABGR.unpackRed(color));
-//                float oG = ColorU8.normalize(ColorABGR.unpackGreen(color));
-//                float oB = ColorU8.normalize(ColorABGR.unpackBlue(color));
-//
-//                fR = oR * brightness * r;
-//                fG = oG * brightness * g;
-//                fB = oB * brightness * b;
-//            } else {
-//                fR = brightness * r;
-//                fG = brightness * g;
-//                fB = brightness * b;
-//            }
-//
-//            float u = quadView.getTexU(i);
-//            float v = quadView.getTexV(i);
-//
-//            int color = ColorABGR.pack(fR, fG, fB, 1.0F);
-//
-//            Vector4f pos = new Vector4f(x, y, z, 1.0F);
-//            positionMatrix.transform(pos);
-//
-//            drain.writeQuad(pos.x(), pos.y(), pos.z(), color, u, v, light[i], overlay, norm);
-//        }
-//
-//        drain.flush();
-//    }
-//
-//    private int computeNormal(Matrix3f normalMatrix, Direction face) {
-//        Vec3i faceNorm = face.getVector();
-//
-//        float x = faceNorm.getX();
-//        float y = faceNorm.getY();
-//        float z = faceNorm.getZ();
-//
-//        float x2 = normalMatrix.m00 * x + normalMatrix.m01 * y + normalMatrix.m02 * z;
-//        float y2 = normalMatrix.m10 * x + normalMatrix.m11 * y + normalMatrix.m12 * z;
-//        float z2 = normalMatrix.m20 * x + normalMatrix.m21 * y + normalMatrix.m22 * z;
-//
-//        return Norm3b.pack(x2, y2, z2);
-//    }
+    @Override
+    public void quad(MatrixStack.Entry matrices, BakedQuad bakedQuad, float r, float g, float b, int light, int overlay) {
+        if (!this.canSkipElementChecks) {
+            super.quad(matrices, bakedQuad, r, g, b, light, overlay);
+
+            return;
+        }
+
+        if (this.colorFixed) {
+            throw new IllegalStateException();
+        }
+
+        VertexBufferWriter writer = VertexBufferWriter.of(this);
+
+        ModelQuadView quad = (ModelQuadView) bakedQuad;
+
+        int color = ColorABGR.pack(r, g, b, 1.0F);
+        BakedModelEncoder.writeQuadVertices(writer, matrices, quad, color, light, overlay);
+
+        SpriteUtil.markSpriteActive(quad.getSprite());
+    }
+
+    @Override
+    public void quad(MatrixStack.Entry matrices, BakedQuad bakedQuad, float[] brightnessTable, float r, float g, float b, int[] light, int overlay, boolean colorize) {
+        if (!this.canSkipElementChecks) {
+            super.quad(matrices, bakedQuad, brightnessTable, r, g, b, light, overlay, colorize);
+
+            return;
+        }
+
+        if (this.colorFixed) {
+            throw new IllegalStateException();
+        }
+
+        VertexBufferWriter writer = VertexBufferWriter.of(this);
+
+        ModelQuadView quad = (ModelQuadView) bakedQuad;
+
+        BakedModelEncoder.writeQuadVertices(writer, matrices, quad, r, g, b, brightnessTable, colorize, light, overlay);
+
+        SpriteUtil.markSpriteActive(quad.getSprite());
+    }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/buffer_builder/intrinsics/MixinBufferBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/buffer_builder/intrinsics/MixinBufferBuilder.java
@@ -23,6 +23,8 @@ public abstract class MixinBufferBuilder extends FixedColorVertexConsumer {
         if (!this.canSkipElementChecks) {
             super.quad(matrices, bakedQuad, r, g, b, light, overlay);
 
+            SpriteUtil.markSpriteActive(bakedQuad.getSprite());
+
             return;
         }
 
@@ -44,6 +46,8 @@ public abstract class MixinBufferBuilder extends FixedColorVertexConsumer {
     public void quad(MatrixStack.Entry matrices, BakedQuad bakedQuad, float[] brightnessTable, float r, float g, float b, int[] light, int overlay, boolean colorize) {
         if (!this.canSkipElementChecks) {
             super.quad(matrices, bakedQuad, brightnessTable, r, g, b, light, overlay, colorize);
+
+            SpriteUtil.markSpriteActive(bakedQuad.getSprite());
 
             return;
         }

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/texture_tracking/MixinDrawableHelper.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/texture_tracking/MixinDrawableHelper.java
@@ -1,0 +1,18 @@
+package me.jellysquid.mods.sodium.mixin.features.texture_tracking;
+
+import me.jellysquid.mods.sodium.client.render.texture.SpriteUtil;
+import net.minecraft.client.gui.DrawableHelper;
+import net.minecraft.client.texture.Sprite;
+import net.minecraft.client.util.math.MatrixStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(DrawableHelper.class)
+public class MixinDrawableHelper {
+    @Inject(method = "drawSprite(Lnet/minecraft/client/util/math/MatrixStack;IIIIILnet/minecraft/client/texture/Sprite;)V\n", at = @At("HEAD"))
+    private static void onHeadDrawSprite(MatrixStack matrices, int x, int y, int z, int width, int height, Sprite sprite, CallbackInfo ci) {
+        SpriteUtil.markSpriteActive(sprite);
+    }
+}

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/texture_tracking/MixinSpriteBillboardParticle.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/texture_tracking/MixinSpriteBillboardParticle.java
@@ -1,6 +1,6 @@
 package me.jellysquid.mods.sodium.mixin.features.texture_tracking;
 
-import me.jellysquid.mods.sodium.client.render.texture.SpriteExtended;
+import me.jellysquid.mods.sodium.client.render.texture.SpriteContentsExtended;
 import me.jellysquid.mods.sodium.client.render.texture.SpriteUtil;
 import net.minecraft.client.particle.BillboardParticle;
 import net.minecraft.client.particle.SpriteBillboardParticle;
@@ -27,7 +27,7 @@ public abstract class MixinSpriteBillboardParticle extends BillboardParticle {
 
     @Inject(method = "setSprite(Lnet/minecraft/client/texture/Sprite;)V", at = @At("RETURN"))
     private void afterSetSprite(Sprite sprite, CallbackInfo ci) {
-        this.shouldTickSprite = sprite != null && ((SpriteExtended) sprite.getContents()).hasAnimation();
+        this.shouldTickSprite = sprite != null && ((SpriteContentsExtended) sprite.getContents()).hasAnimation();
     }
 
     @Override

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/texture_tracking/MixinSpriteContents.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/texture_tracking/MixinSpriteContents.java
@@ -1,19 +1,21 @@
 package me.jellysquid.mods.sodium.mixin.features.texture_tracking;
 
-import me.jellysquid.mods.sodium.client.render.texture.SpriteExtended;
+import me.jellysquid.mods.sodium.client.render.texture.SpriteContentsExtended;
 import net.minecraft.client.texture.SpriteContents;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 
 @Mixin(SpriteContents.class)
-public abstract class MixinSpriteContents implements SpriteExtended {
+public abstract class MixinSpriteContents implements SpriteContentsExtended {
     @Shadow
     @Final
     @Nullable
     private SpriteContents.Animation animation;
 
+    @Unique
     private boolean active;
 
     @Override

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/texture_tracking/MixinSpriteContentsAnimatorImpl.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/texture_tracking/MixinSpriteContentsAnimatorImpl.java
@@ -1,7 +1,7 @@
 package me.jellysquid.mods.sodium.mixin.features.texture_tracking;
 
 import me.jellysquid.mods.sodium.client.SodiumClientMod;
-import me.jellysquid.mods.sodium.client.render.texture.SpriteExtended;
+import me.jellysquid.mods.sodium.client.render.texture.SpriteContentsExtended;
 import net.minecraft.client.texture.SpriteContents;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
@@ -25,7 +25,7 @@ public class MixinSpriteContentsAnimatorImpl {
 
     @Inject(method = "tick", at = @At("HEAD"), cancellable = true)
     private void preTick(CallbackInfo ci) {
-        SpriteExtended parent = (SpriteExtended) this.parent;
+        SpriteContentsExtended parent = (SpriteContentsExtended) this.parent;
 
         boolean onDemand = SodiumClientMod.options().performance.animateOnlyVisibleTextures;
 
@@ -36,7 +36,7 @@ public class MixinSpriteContentsAnimatorImpl {
 
     @Inject(method = "tick", at = @At("TAIL"))
     private void postTick(CallbackInfo ci) {
-        SpriteExtended parent = (SpriteExtended) this.parent;
+        SpriteContentsExtended parent = (SpriteContentsExtended) this.parent;
         parent.setActive(false);
     }
 }

--- a/src/main/resources/sodium.mixins.json
+++ b/src/main/resources/sodium.mixins.json
@@ -62,6 +62,7 @@
     "features.render_layer.leaves.MixinLeavesBlock",
     "features.render_layer.leaves.MixinRenderLayers",
     "features.sky.MixinWorldRenderer",
+    "features.texture_tracking.MixinDrawableHelper",
     "features.texture_tracking.MixinSpriteAtlasTexture",
     "features.texture_tracking.MixinSpriteBillboardParticle",
     "features.texture_tracking.MixinSpriteContents",


### PR DESCRIPTION
- Restore optimization in `MixinBufferBuilder`
- Add additional optimization to `MixinBufferBuilder`
- Mark sprites used by `BufferBuilder.quad` as active; Resolve #1354
- Mark sprites used by `DrawableHelper.drawSprite` as active
- Fix `ColorU8.byteToNormalizedFloat` and add int variant
- Rename `SpriteExtended` to `SpriteContentsExtended`