### PR TITLE
Allow more precise adjustment of Max Framerate option

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -95,7 +95,7 @@ public class SodiumGameOptionPages {
                 .add(OptionImpl.createBuilder(int.class, vanillaOpts)
                         .setName(Text.translatable("options.framerateLimit"))
                         .setTooltip(Text.translatable("sodium.options.fps_limit.tooltip"))
-                        .setControl(option -> new SliderControl(option, 10, 260, 10, ControlValueFormatter.fpsLimit()))
+                        .setControl(option -> new SliderControl(option, 10, 260, 1, ControlValueFormatter.fpsLimit()))
                         .setBinding((opts, value) -> {
                             opts.getMaxFps().setValue(value);
                             MinecraftClient.getInstance().getWindow().setFramerateLimit(value);


### PR DESCRIPTION
### Proposed Changes

This allows catering to displays with variable refresh rate enabled. For example, when using a 120 Hz monitor, you can set the maximum framerate to 117, enable V-Sync and get low input lag without tearing. This works because the framerate remains just below the display's maximum VRR range, which prevents queued frames from accumulating.

Previously, you would either have to edit the settings file manually to achieve this, use a third-party FPS limiter (which is harder to set up and increases input lag), or stick to a lower FPS limit that is below the maximum VRR range (such as 110 FPS for 120 Hz).

The exact value to use in this scenario depends on your monitor refresh rate. Values to use for common refresh rates are:

- 60 Hz: 58 FPS
- 120 Hz: 117 FPS
- 144 Hz: 141 FPS
- 240 Hz: 235 FPS

For other refresh rates, you can calculate the FPS limit to use with `refresh_rate - (int(refresh_rate / 60.0) + 1)`.

See <https://blurbusters.com/howto-low-lag-vsync-on/> for more information.
