### PR TITLE
new: Add mixin rule override-ability, disable `core` overrides

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/mixin/MixinOption.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/MixinOption.java
@@ -11,11 +11,17 @@ public class MixinOption {
     private Set<String> modDefined = null;
     private boolean enabled;
     private boolean userDefined;
+    private boolean overrideable;
 
-    public MixinOption(String name, boolean enabled, boolean userDefined) {
+    public MixinOption(String name, boolean enabled, boolean userDefined, boolean overrideable) {
         this.name = name;
         this.enabled = enabled;
         this.userDefined = userDefined;
+        this.overrideable = overrideable;
+    }
+
+    public void setOverrideable(boolean overrideable) {
+        this.overrideable = overrideable;
     }
 
     public void setEnabled(boolean enabled, boolean userDefined) {
@@ -47,6 +53,10 @@ public class MixinOption {
 
     public boolean isModDefined() {
         return this.modDefined != null;
+    }
+
+    public boolean isOverrideable() {
+        return overrideable;
     }
 
     public String getName() {


### PR DESCRIPTION
Allows mixin override-ability to particular rules and disables `core` mixin rule overrides.

I'm unsure if I should port over Lithium's mixin config here or to [mixin-config](https://github.com/CaffeineMC/mixin-config) repository and then apply it here after it's on the CaffeineMC maven.