### PR TITLE
Error handling improvements in chunk build threads

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSection.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSection.java
@@ -209,7 +209,7 @@ public class RenderSection {
         return String.format("RenderSection at chunk (%d, %d, %d) from (%d, %d, %d) to (%d, %d, %d)",
                 this.chunkX, this.chunkY, this.chunkZ,
                 this.getOriginX(), this.getOriginY(), this.getOriginZ(),
-                this.getOriginX() + 16, this.getOriginY() + 16, this.getOriginZ() + 16);
+                this.getOriginX() + 15, this.getOriginY() + 15, this.getOriginZ() + 15);
     }
 
     public boolean isBuilt() {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSection.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSection.java
@@ -206,8 +206,10 @@ public class RenderSection {
 
     @Override
     public String toString() {
-        return String.format("RenderChunk{chunkX=%d, chunkY=%d, chunkZ=%d}",
-                this.chunkX, this.chunkY, this.chunkZ);
+        return String.format("RenderSection at chunk (%d, %d, %d) from (%d, %d, %d) to (%d, %d, %d)",
+                this.chunkX, this.chunkY, this.chunkZ,
+                this.getOriginX(), this.getOriginY(), this.getOriginZ(),
+                this.getOriginX() + 16, this.getOriginY() + 16, this.getOriginZ() + 16);
     }
 
     public boolean isBuilt() {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/executor/ChunkBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/executor/ChunkBuilder.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 public class ChunkBuilder {
-    private static final Logger LOGGER = LogManager.getLogger("ChunkBuilder");
+    static final Logger LOGGER = LogManager.getLogger("ChunkBuilder");
 
     private volatile boolean isRunning;
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/executor/ChunkJobResult.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/executor/ChunkJobResult.java
@@ -20,9 +20,9 @@ public class ChunkJobResult<OUTPUT> {
     }
 
     public OUTPUT unwrap() {
-        if (this.throwable instanceof CrashException) {
+        if (this.throwable instanceof CrashException crashException) {
             // Propagate CrashExceptions directly to provide extra information
-            throw (CrashException)this.throwable;
+            throw crashException;
         } else if (this.throwable != null) {
             throw new RuntimeException("Exception thrown while executing job", this.throwable);
         }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/executor/ChunkJobResult.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/executor/ChunkJobResult.java
@@ -1,5 +1,7 @@
 package me.jellysquid.mods.sodium.client.render.chunk.compile.executor;
 
+import net.minecraft.util.crash.CrashException;
+
 public class ChunkJobResult<OUTPUT> {
     private final OUTPUT output;
     private final Throwable throwable;
@@ -18,7 +20,10 @@ public class ChunkJobResult<OUTPUT> {
     }
 
     public OUTPUT unwrap() {
-        if (this.throwable != null) {
+        if (this.throwable instanceof CrashException) {
+            // Propagate CrashExceptions directly to provide extra information
+            throw (CrashException)this.throwable;
+        } else if (this.throwable != null) {
             throw new RuntimeException("Exception thrown while executing job", this.throwable);
         }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/executor/ChunkJobTyped.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/executor/ChunkJobTyped.java
@@ -1,5 +1,6 @@
 package me.jellysquid.mods.sodium.client.render.chunk.compile.executor;
 
+import me.jellysquid.mods.sodium.client.SodiumClientMod;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.ChunkBuildContext;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.tasks.ChunkBuilderTask;
 
@@ -48,6 +49,7 @@ public class ChunkJobTyped<TASK extends ChunkBuilderTask<OUTPUT>, OUTPUT>
             result = ChunkJobResult.successfully(output);
         } catch (Throwable throwable) {
             result = ChunkJobResult.exceptionally(throwable);
+            SodiumClientMod.logger().error("Chunk build failed", throwable);
         } finally {
             this.task.releaseResources();
         }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/executor/ChunkJobTyped.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/executor/ChunkJobTyped.java
@@ -49,7 +49,7 @@ public class ChunkJobTyped<TASK extends ChunkBuilderTask<OUTPUT>, OUTPUT>
             result = ChunkJobResult.successfully(output);
         } catch (Throwable throwable) {
             result = ChunkJobResult.exceptionally(throwable);
-            SodiumClientMod.logger().error("Chunk build failed", throwable);
+            ChunkBuilder.LOGGER.error("Chunk build failed", throwable);
         } finally {
             this.task.releaseResources();
         }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderMeshingTask.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderMeshingTask.java
@@ -26,6 +26,7 @@ import net.minecraft.util.crash.CrashException;
 import net.minecraft.util.crash.CrashReport;
 import net.minecraft.util.crash.CrashReportSection;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.random.Random;
 
 import java.util.Map;
 
@@ -101,6 +102,9 @@ public class ChunkBuilderMeshingTask extends ChunkBuilderTask<ChunkBuildOutput> 
                             context.update(blockPos, modelOffset, blockState, model, seed);
                             cache.getBlockRenderer()
                                 .renderModel(context, buffers);
+                            if (Random.createLocal().nextInt(100000) == 0) {
+                                throw new RuntimeException("henlo");
+                            }
                         }
 
                         FluidState fluidState = blockState.getFluidState();
@@ -160,9 +164,9 @@ public class ChunkBuilderMeshingTask extends ChunkBuilderTask<ChunkBuildOutput> 
         } catch (Exception ignored) {}
         CrashReportSection.addBlockInfo(crashReportSection, slice, pos, state);
 
-        crashReportSection.add("Chunk section", render);
-        if (renderContext != null) {
-            crashReportSection.add("Render context volume", renderContext.getVolume());
+        crashReportSection.add("Chunk section", this.render);
+        if (this.renderContext != null) {
+            crashReportSection.add("Render context volume", this.renderContext.getVolume());
         }
 
         return new CrashException(report);

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderMeshingTask.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderMeshingTask.java
@@ -102,9 +102,6 @@ public class ChunkBuilderMeshingTask extends ChunkBuilderTask<ChunkBuildOutput> 
                             context.update(blockPos, modelOffset, blockState, model, seed);
                             cache.getBlockRenderer()
                                 .renderModel(context, buffers);
-                            if (Random.createLocal().nextInt(100000) == 0) {
-                                throw new RuntimeException("henlo");
-                            }
                         }
 
                         FluidState fluidState = blockState.getFluidState();


### PR DESCRIPTION
I noticed in some recent issue reports that chunk build exceptions weren't being propagated to the main thread as intended in https://github.com/CaffeineMC/sodium-fabric/pull/615. This is because deferred (non-important) chunk builds aren't polled from the main thread using `join()` unlike important chunk rebuilds, and since https://github.com/CaffeineMC/sodium-fabric/commit/696da3c219b0d21febdea9dd73e07516f694248a Sodium always treats initial chunk builds as deferred, so if a particular error makes a chunk never successfully build, `join()` will never be called on it!

This PR therefore correctly propagates these exceptions, along with extra handling for crash reporting that adds Sodium rendering context, with the following changes:

- Added a queue to store chunk build failures in `ChunkBuilder`
- Modified `scheduleDeferred` to add `CompletableFuture` exceptions to this queue
- Created `handlePendingFailures` in `RenderSectionManager` to drain the failure queue and throw any found exception
- Modified `WorkStealingFutureDrain.findNext` to unwrap `CompletionException`s that contain `CrashException` so that the crash report context is preserved
- Wrapped the `ChunkRenderRebuildTask.performBuild` outer loop in a try-catch block to handle exceptions from chunk building and add chunk section / render context information
- Improved `RenderSection.toString` to provide more useful information
- Changed `ChunkBuilder.processJob` to use the Sodium logger rather than `printStackTrace`

For `scheduleDeferred` I changed it to use `whenComplete` as it doesn't wrap the exception in `CompletionException` (so any `CrashException` can be propagated directly) and it allows us to return `CompletableFuture<ChunkBuildResult>` matching the return type of `schedule`.

This is what the crash report context looks like:

```
-- Block being rendered --
Details:
	Block: Block{minecraft:gravel}
	Block location: World: (-16,-16,-48), Section: (at 0,0,0 in -1,-1,-3; chunk contains blocks -16,-64,-48 to -1,319,-33), Region: (-1,-1; contains chunks -32,-32 to -1,-1, blocks -512,-64,-512 to -1,319,-1)
	Chunk section: RenderSection at chunk (-1, -1, -3) from (-16, -16, -48) to (0, 0, -32)
	Render context volume: BlockBox{minX=-18, minY=-18, minZ=-50, maxX=1, maxY=1, maxZ=-31}
```