### PR TITLE
Avoid List#get in BufferBuilder#nextElement

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/buffer_builder/fast_advance/MixinBufferBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/buffer_builder/fast_advance/MixinBufferBuilder.java
@@ -27,7 +27,7 @@ public abstract class MixinBufferBuilder extends FixedColorVertexConsumer implem
     private int currentElementId;
 
     @Unique
-    private VertexFormatElement[] formatElements = new VertexFormatElement[16];
+    private VertexFormatElement[] formatElements = new VertexFormatElement[32];
     @Unique
     private int formatElementCount = 0;
 

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/buffer_builder/fast_advance/MixinBufferBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/buffer_builder/fast_advance/MixinBufferBuilder.java
@@ -1,10 +1,16 @@
 package me.jellysquid.mods.sodium.mixin.features.buffer_builder.fast_advance;
 
 import com.google.common.collect.ImmutableList;
+import net.caffeinemc.mods.sodium.api.vertex.format.VertexFormatRegistry;
 import net.minecraft.client.render.*;
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(BufferBuilder.class)
 public abstract class MixinBufferBuilder extends FixedColorVertexConsumer implements BufferVertexConsumer {
@@ -20,24 +26,36 @@ public abstract class MixinBufferBuilder extends FixedColorVertexConsumer implem
     @Shadow
     private int currentElementId;
 
+    @Unique
+    private VertexFormatElement[] formatElements;
+
+    @Inject(method = "setFormat",
+        at = @At(
+            value = "FIELD",
+            target = "Lnet/minecraft/client/render/BufferBuilder;format:Lnet/minecraft/client/render/VertexFormat;",
+            opcode = Opcodes.PUTFIELD
+        )
+    )
+    private void onFormatChanged(VertexFormat format, CallbackInfo ci) {
+        this.formatElements = format.getElements().toArray(new VertexFormatElement[0]);
+    }
+
     /**
      * @author JellySquid
-     * @reason Remove modulo operations and recursion
+     * @reason Remove modulo operations, recursion and use array instead of list
      */
     @Override
     @Overwrite
     public void nextElement() {
-        ImmutableList<VertexFormatElement> elements = this.format.getElements();
-
         do {
             this.elementOffset += this.currentElement.getByteLength();
 
             // Wrap around the element pointer without using modulo
-            if (++this.currentElementId >= elements.size()) {
-                this.currentElementId -= elements.size();
+            if (++this.currentElementId >= this.formatElements.length) {
+                this.currentElementId -= this.formatElements.length;
             }
 
-            this.currentElement = elements.get(this.currentElementId);
+            this.currentElement = this.formatElements[this.currentElementId];
         } while (this.currentElement.getType() == VertexFormatElement.Type.PADDING);
 
         if (this.colorFixed && this.currentElement.getType() == VertexFormatElement.Type.COLOR) {

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/buffer_builder/fast_advance/MixinBufferBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/buffer_builder/fast_advance/MixinBufferBuilder.java
@@ -27,7 +27,9 @@ public abstract class MixinBufferBuilder extends FixedColorVertexConsumer implem
     private int currentElementId;
 
     @Unique
-    private VertexFormatElement[] formatElements;
+    private VertexFormatElement[] formatElements = new VertexFormatElement[16];
+    @Unique
+    private int formatElementCount = 0;
 
     @Inject(method = "setFormat",
         at = @At(
@@ -37,7 +39,8 @@ public abstract class MixinBufferBuilder extends FixedColorVertexConsumer implem
         )
     )
     private void onFormatChanged(VertexFormat format, CallbackInfo ci) {
-        this.formatElements = format.getElements().toArray(new VertexFormatElement[0]);
+        this.formatElements = format.getElements().toArray(this.formatElements);
+        this.formatElementCount = format.getElements().size();
     }
 
     /**
@@ -51,8 +54,8 @@ public abstract class MixinBufferBuilder extends FixedColorVertexConsumer implem
             this.elementOffset += this.currentElement.getByteLength();
 
             // Wrap around the element pointer without using modulo
-            if (++this.currentElementId >= this.formatElements.length) {
-                this.currentElementId -= this.formatElements.length;
+            if (++this.currentElementId >= this.formatElementCount) {
+                this.currentElementId -= this.formatElementCount;
             }
 
             this.currentElement = this.formatElements[this.currentElementId];


### PR DESCRIPTION
Calling List#get in BufferBuilder#nextElement has to perform a lot of pointer accesses.

BufferBuilder -> VertexFormat -> List -> Map -> Array -> Entry -> VertexFormatElement

Let's not do that, shall we?

Use a single array inside BufferBuilder instead