### PR TITLE
Remove unnecessary RefCells

### DIFF
--- a/native/core/src/graph.rs
+++ b/native/core/src/graph.rs
@@ -508,6 +508,10 @@ impl Graph {
                             .search_state
                             .enqueue(neighbor, GraphDirectionSet::single(direction.opposite()));
                     }
+                } else {
+                    context.origin
+                        .search_state
+                        .enqueue(neighbor, GraphDirectionSet::single(direction.opposite()));
                 }
             }
         }


### PR DESCRIPTION
I removed all of the RefCells with the addition of a Funsafe trait to "get_several_mut" from a HashMap (which should definitely be renamed).