### PR TITLE
Fix broken normals in WorldRenderer#drawBox

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/buffer_builder/intrinsics/MixinWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/buffer_builder/intrinsics/MixinWorldRenderer.java
@@ -72,30 +72,30 @@ public class MixinWorldRenderer {
 
         var writer = VertexBufferWriter.of(vertexConsumer);
 
-        writeLineVertices(writer, v1x, v1y, v1z, ColorABGR.pack(red, yAxisGreen, zAxisBlue, alpha), NormI8.pack(normal.m00(), normal.m10(), normal.m20()));
-        writeLineVertices(writer, v2x, v2y, v2z, ColorABGR.pack(red, yAxisGreen, zAxisBlue, alpha), NormI8.pack(normal.m00(), normal.m10(), normal.m20()));
-        writeLineVertices(writer, v1x, v1y, v1z, ColorABGR.pack(xAxisRed, green, zAxisBlue, alpha), NormI8.pack(normal.m01(), normal.m11(), normal.m21()));
-        writeLineVertices(writer, v3x, v3y, v3z, ColorABGR.pack(xAxisRed, green, zAxisBlue, alpha), NormI8.pack(normal.m01(), normal.m11(), normal.m21()));
-        writeLineVertices(writer, v1x, v1y, v1z, ColorABGR.pack(xAxisRed, yAxisGreen, blue, alpha), NormI8.pack(normal.m02(), normal.m12(), normal.m22()));
-        writeLineVertices(writer, v4x, v4y, v4z, ColorABGR.pack(xAxisRed, yAxisGreen, blue, alpha), NormI8.pack(normal.m02(), normal.m12(), normal.m22()));
-        writeLineVertices(writer, v2x, v2y, v2z, color, NormI8.pack(normal.m01(), normal.m11(), normal.m21()));
-        writeLineVertices(writer, v5x, v5y, v5z, color, NormI8.pack(normal.m01(), normal.m11(), normal.m21()));
-        writeLineVertices(writer, v5x, v5y, v5z, color, NormI8.pack(-normal.m00(), -normal.m10(), -normal.m20()));
-        writeLineVertices(writer, v3x, v3y, v3z, color, NormI8.pack(-normal.m00(), -normal.m10(), -normal.m20()));
-        writeLineVertices(writer, v3x, v3y, v3z, color, NormI8.pack(normal.m02(), normal.m12(), normal.m22()));
-        writeLineVertices(writer, v6x, v6y, v6z, color, NormI8.pack(normal.m02(), normal.m12(), normal.m22()));
-        writeLineVertices(writer, v6x, v6y, v6z, color, NormI8.pack(-normal.m01(), -normal.m11(), -normal.m21()));
-        writeLineVertices(writer, v4x, v4y, v4z, color, NormI8.pack(-normal.m01(), -normal.m11(), -normal.m21()));
-        writeLineVertices(writer, v4x, v4y, v4z, color, NormI8.pack(normal.m00(), normal.m10(), normal.m20()));
-        writeLineVertices(writer, v7x, v7y, v7z, color, NormI8.pack(normal.m00(), normal.m10(), normal.m20()));
-        writeLineVertices(writer, v7x, v7y, v7z, color, NormI8.pack(-normal.m02(), -normal.m12(), -normal.m22()));
-        writeLineVertices(writer, v2x, v2y, v2z, color, NormI8.pack(-normal.m02(), -normal.m12(), -normal.m22()));
-        writeLineVertices(writer, v6x, v6y, v6z, color, NormI8.pack(normal.m00(), normal.m10(), normal.m20()));
-        writeLineVertices(writer, v8x, v8y, v8z, color, NormI8.pack(normal.m00(), normal.m10(), normal.m20()));
-        writeLineVertices(writer, v7x, v7y, v7z, color, NormI8.pack(normal.m01(), normal.m11(), normal.m21()));
-        writeLineVertices(writer, v8x, v8y, v8z, color, NormI8.pack(normal.m01(), normal.m11(), normal.m21()));
-        writeLineVertices(writer, v5x, v5y, v5z, color, NormI8.pack(normal.m02(), normal.m12(), normal.m22()));
-        writeLineVertices(writer, v8x, v8y, v8z, color, NormI8.pack(normal.m02(), normal.m12(), normal.m22()));
+        writeLineVertices(writer, v1x, v1y, v1z, ColorABGR.pack(red, yAxisGreen, zAxisBlue, alpha), NormI8.pack(normal.m00(), normal.m01(), normal.m02()));
+        writeLineVertices(writer, v2x, v2y, v2z, ColorABGR.pack(red, yAxisGreen, zAxisBlue, alpha), NormI8.pack(normal.m00(), normal.m01(), normal.m02()));
+        writeLineVertices(writer, v1x, v1y, v1z, ColorABGR.pack(xAxisRed, green, zAxisBlue, alpha), NormI8.pack(normal.m10(), normal.m11(), normal.m12()));
+        writeLineVertices(writer, v3x, v3y, v3z, ColorABGR.pack(xAxisRed, green, zAxisBlue, alpha), NormI8.pack(normal.m10(), normal.m11(), normal.m12()));
+        writeLineVertices(writer, v1x, v1y, v1z, ColorABGR.pack(xAxisRed, yAxisGreen, blue, alpha), NormI8.pack(normal.m20(), normal.m21(), normal.m22()));
+        writeLineVertices(writer, v4x, v4y, v4z, ColorABGR.pack(xAxisRed, yAxisGreen, blue, alpha), NormI8.pack(normal.m20(), normal.m21(), normal.m22()));
+        writeLineVertices(writer, v2x, v2y, v2z, color, NormI8.pack(normal.m10(), normal.m11(), normal.m12()));
+        writeLineVertices(writer, v5x, v5y, v5z, color, NormI8.pack(normal.m10(), normal.m11(), normal.m12()));
+        writeLineVertices(writer, v5x, v5y, v5z, color, NormI8.pack(-normal.m00(), -normal.m01(), -normal.m02()));
+        writeLineVertices(writer, v3x, v3y, v3z, color, NormI8.pack(-normal.m00(), -normal.m01(), -normal.m02()));
+        writeLineVertices(writer, v3x, v3y, v3z, color, NormI8.pack(normal.m20(), normal.m21(), normal.m22()));
+        writeLineVertices(writer, v6x, v6y, v6z, color, NormI8.pack(normal.m20(), normal.m21(), normal.m22()));
+        writeLineVertices(writer, v6x, v6y, v6z, color, NormI8.pack(-normal.m10(), -normal.m11(), -normal.m12()));
+        writeLineVertices(writer, v4x, v4y, v4z, color, NormI8.pack(-normal.m10(), -normal.m11(), -normal.m12()));
+        writeLineVertices(writer, v4x, v4y, v4z, color, NormI8.pack(normal.m00(), normal.m01(), normal.m02()));
+        writeLineVertices(writer, v7x, v7y, v7z, color, NormI8.pack(normal.m00(), normal.m01(), normal.m02()));
+        writeLineVertices(writer, v7x, v7y, v7z, color, NormI8.pack(-normal.m20(), -normal.m21(), -normal.m22()));
+        writeLineVertices(writer, v2x, v2y, v2z, color, NormI8.pack(-normal.m20(), -normal.m21(), -normal.m22()));
+        writeLineVertices(writer, v6x, v6y, v6z, color, NormI8.pack(normal.m00(), normal.m01(), normal.m02()));
+        writeLineVertices(writer, v8x, v8y, v8z, color, NormI8.pack(normal.m00(), normal.m01(), normal.m02()));
+        writeLineVertices(writer, v7x, v7y, v7z, color, NormI8.pack(normal.m10(), normal.m11(), normal.m12()));
+        writeLineVertices(writer, v8x, v8y, v8z, color, NormI8.pack(normal.m10(), normal.m11(), normal.m12()));
+        writeLineVertices(writer, v5x, v5y, v5z, color, NormI8.pack(normal.m20(), normal.m21(), normal.m22()));
+        writeLineVertices(writer, v8x, v8y, v8z, color, NormI8.pack(normal.m20(), normal.m21(), normal.m22()));
     }
 
     private static void writeLineVertices(VertexBufferWriter writer, float x, float y, float z, int color, int normal) {


### PR DESCRIPTION
The original author got the rows & columns the wrong way around.
This PR swaps the rows and columns. eg. m00, m10, m20 becomes m00, m01, m02.

This was done using using the following find & replace:
Find:    \.m(\d)(\d)
Replace: .m$2$1

Before (current): https://cdn.discordapp.com/attachments/867325617367810071/1119571223974772797/image.png
After (this PR): https://cdn.discordapp.com/attachments/867325617367810071/1119570983230111825/image.png