### PR TITLE
Fix option sliders focusing outside there bounds

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/SliderControl.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/SliderControl.java
@@ -132,8 +132,8 @@ public class SliderControl implements Control<Integer> {
             // What is this?
             // It's a ridiculous solution to the slider element not getting "focused" when it is clicked unless it is in the slider bounds. This breaks what every other element does,
             // so we need this stupid hack.
-            if (this.option.isAvailable() && button == 0 && mouseY >= this.sliderBounds.getY() && mouseY <= this.sliderBounds.getY() + this.sliderBounds.getHeight()) {
-                if (this.sliderBounds.contains((int) mouseX, (int) mouseY)) {
+            if (this.option.isAvailable() && button == 0 && this.dim.containsCursor(mouseX, mouseY)) {
+                if (this.sliderBounds.contains((int) mouseX, (int) mouseY)){
                     this.setValueFromMouse(mouseX);
                 }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/SliderControl.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/SliderControl.java
@@ -3,8 +3,8 @@ package me.jellysquid.mods.sodium.client.gui.options.control;
 import me.jellysquid.mods.sodium.client.gui.options.Option;
 import me.jellysquid.mods.sodium.client.util.Dim2i;
 import net.minecraft.client.util.InputUtil;
-import net.minecraft.client.util.math.Rect2i;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.client.util.math.Rect2i;
 import net.minecraft.util.math.MathHelper;
 import org.apache.commons.lang3.Validate;
 
@@ -56,6 +56,8 @@ public class SliderControl implements Control<Integer> {
 
         private double thumbPosition;
 
+        private boolean sliderHeld;
+
         public Button(Option<Integer> option, Dim2i dim, int min, int max, int interval, ControlValueFormatter formatter) {
             super(option, dim);
 
@@ -67,6 +69,7 @@ public class SliderControl implements Control<Integer> {
             this.formatter = formatter;
 
             this.sliderBounds = new Rect2i(dim.getLimitX() - 96, dim.getCenterY() - 5, 90, 10);
+            this.sliderHeld = false;
         }
 
         @Override
@@ -129,12 +132,12 @@ public class SliderControl implements Control<Integer> {
 
         @Override
         public boolean mouseClicked(double mouseX, double mouseY, int button) {
-            // What is this?
-            // It's a ridiculous solution to the slider element not getting "focused" when it is clicked unless it is in the slider bounds. This breaks what every other element does,
-            // so we need this stupid hack.
+            this.sliderHeld = false;
+
             if (this.option.isAvailable() && button == 0 && this.dim.containsCursor(mouseX, mouseY)) {
-                if (this.sliderBounds.contains((int) mouseX, (int) mouseY)){
+                if (this.sliderBounds.contains((int) mouseX, (int) mouseY)) {
                     this.setValueFromMouse(mouseX);
+                    this.sliderHeld = true;
                 }
 
                 return true;
@@ -175,7 +178,9 @@ public class SliderControl implements Control<Integer> {
         @Override
         public boolean mouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
             if (this.option.isAvailable() && button == 0) {
-                this.setValueFromMouse(mouseX);
+                if (this.sliderHeld) {
+                    this.setValueFromMouse(mouseX);
+                }
 
                 return true;
             }


### PR DESCRIPTION
Currently sliders are focused even when the mouse click is outside there horizontal bounds.

This fixes the selection of the sliders and checks if the slider is held when the mouse is dragged.

this should fix #1770 