### PR TITLE
Check lightmap when orienting quad

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/model/quad/properties/ModelQuadOrientation.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/model/quad/properties/ModelQuadOrientation.java
@@ -24,9 +24,20 @@ public enum ModelQuadOrientation {
     /**
      * Determines the orientation of the vertices in the quad.
      */
-    public static ModelQuadOrientation orientByBrightness(float[] brightnesses) {
+    public static ModelQuadOrientation orientByBrightness(float[] brightnesses, int[] lightmaps) {
         // If one side of the quad is brighter, flip the sides
-        if (brightnesses[0] + brightnesses[2] >= brightnesses[1] + brightnesses[3]) {
+        float br02 = brightnesses[0] + brightnesses[2];
+        float br13 = brightnesses[1] + brightnesses[3];
+        if (br02 > br13) {
+            return NORMAL;
+        } else if (br02 < br13) {
+            return FLIP;
+        }
+
+        // If one side of the quad is darker, flip the sides
+        int lm02 = lightmaps[0] + lightmaps[2];
+        int lm13 = lightmaps[1] + lightmaps[3];
+        if (lm02 <= lm13) {
             return NORMAL;
         } else {
             return FLIP;

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/pipeline/BlockRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/pipeline/BlockRenderer.java
@@ -138,7 +138,7 @@ public class BlockRenderer {
                                QuadLightData light,
                                ChunkRenderBounds.Builder bounds)
     {
-        ModelQuadOrientation orientation = ModelQuadOrientation.orientByBrightness(light.br);
+        ModelQuadOrientation orientation = ModelQuadOrientation.orientByBrightness(light.br, light.lm);
         var vertices = this.vertices;
 
         ModelQuadFacing normalFace = quad.getNormalFace();


### PR DESCRIPTION
Before, only the brightness (AO) values were checked. Now, if the diagonal brightness value sums are equal, the lightmaps are also checked in a similar way. This fixes the diamond light shape in cases where AO is not present, such as light sources on flat ground and emissive blocks like magma blocks and active sculk sensors.

Fixes #57.