### PR TITLE
Show render distance in debug hud

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -361,9 +361,9 @@ public class SodiumWorldRenderer {
     }
 
     public String getChunksDebugString() {
-        // C: visible/total
+        // C: visible/total D: distance
         // TODO: add dirty and queued counts
-        return String.format("C: %s/%s", this.renderSectionManager.getVisibleChunkCount(), this.renderSectionManager.getTotalSections());
+        return String.format("C: %d/%d D: %d", this.renderSectionManager.getVisibleChunkCount(), this.renderSectionManager.getTotalSections(), this.renderDistance);
     }
 
     /**


### PR DESCRIPTION
Sodium overwrites the chunk string in the debug hud and currently only shows the number of visible and total chunks.

This fix adds the render distance to the string to match vanilla.

fixes #1378 