### PR TITLE
Fix fluid height check in fluid renderer

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/pipeline/FluidRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/pipeline/FluidRenderer.java
@@ -479,7 +479,7 @@ public class FluidRenderer {
                 return fluidState.getHeight();
             }
         }
-        if (!blockState.isOpaque()) {
+        if (!blockState.isSolid()) {
             return 0.0f;
         }
         return -1.0f;


### PR DESCRIPTION
Currently the fluid renderer calculates an incorrect height for blocks like shulker boxes or beacons.

Problem is that it incorrectly checks if a block is not opaque, when it should check if a block is not solid.

1.20.1 Vanilla:
```java
return !blockState.isSolid() ? 0.0F : -1.0F;
```

Current Sodium:
```java
if (!blockState.isOpaque()) {
    return 0.0f;
}
return -1.0f;
```

fixes #1870 