### PR TITLE
fix: Use GUI render layer when drawing rectangles for options

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/ControlElement.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/ControlElement.java
@@ -7,7 +7,6 @@ import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.ScreenRect;
 import net.minecraft.client.gui.navigation.GuiNavigation;
 import net.minecraft.client.gui.navigation.GuiNavigationPath;
-import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Formatting;
 import org.jetbrains.annotations.Nullable;
 
@@ -42,11 +41,11 @@ public class ControlElement<T> extends AbstractWidget {
 
         this.hovered = this.dim.containsCursor(mouseX, mouseY);
 
-        this.drawRect(this.dim.x(), this.dim.y(), this.dim.getLimitX(), this.dim.getLimitY(), this.hovered ? 0xE0000000 : 0x90000000);
+        this.drawRect(drawContext, this.dim.x(), this.dim.y(), this.dim.getLimitX(), this.dim.getLimitY(), this.hovered ? 0xE0000000 : 0x90000000);
         this.drawString(drawContext, label, this.dim.x() + 6, this.dim.getCenterY() - 4, 0xFFFFFFFF);
 
         if (this.isFocused()) {
-            this.drawBorder(this.dim.x(), this.dim.y(), this.dim.getLimitX(), this.dim.getLimitY());
+            this.drawBorder(drawContext, this.dim.x(), this.dim.y(), this.dim.getLimitX(), this.dim.getLimitY(), -1);
         }
     }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/ControlValueFormatter.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/ControlValueFormatter.java
@@ -4,48 +4,48 @@ import net.minecraft.text.Text;
 
 public interface ControlValueFormatter {
     static ControlValueFormatter guiScale() {
-        return (v) -> (v == 0) ? Text.translatable("options.guiScale.auto").getString() : v + "x";
+        return (v) -> (v == 0) ? Text.translatable("options.guiScale.auto") : Text.literal(v + "x");
     }
 
     static ControlValueFormatter fpsLimit() {
-        return (v) -> (v == 260) ? Text.translatable("options.framerateLimit.max").getString() : Text.translatable("options.framerate", v).getString();
+        return (v) -> (v == 260) ? Text.translatable("options.framerateLimit.max") : Text.translatable("options.framerate", v);
     }
 
     static ControlValueFormatter brightness() {
         return (v) -> {
             if (v == 0) {
-                return Text.translatable("options.gamma.min").getString();
+                return Text.translatable("options.gamma.min");
             } else if (v == 100) {
-                return Text.translatable("options.gamma.max").getString();
+                return Text.translatable("options.gamma.max");
             } else {
-                return v + "%";
+                return Text.literal(v + "%");
             }
         };
     }
 
     static ControlValueFormatter biomeBlend() {
-        return (v) -> (v == 0) ? Text.translatable("gui.none").getString() : Text.translatable("sodium.options.biome_blend.value", v).getString();
+        return (v) -> (v == 0) ? Text.translatable("gui.none") : Text.translatable("sodium.options.biome_blend.value", v);
     }
 
-    String format(int value);
+    Text format(int value);
 
     static ControlValueFormatter translateVariable(String key) {
-        return (v) -> Text.translatable(key, v).getString();
+        return (v) -> Text.translatable(key, v);
     }
 
     static ControlValueFormatter percentage() {
-        return (v) -> v + "%";
+        return (v) -> Text.literal(v + "%");
     }
 
     static ControlValueFormatter multiplier() {
-        return (v) -> v + "x";
+        return (v) -> Text.literal(v + "%");
     }
 
     static ControlValueFormatter quantityOrDisabled(String name, String disableText) {
-        return (v) -> v == 0 ? disableText : v + " " + name;
+        return (v) -> Text.literal(v == 0 ? disableText : v + " " + name);
     }
 
     static ControlValueFormatter number() {
-        return String::valueOf;
+        return (v) -> Text.literal(String.valueOf(v));
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/ControlValueFormatter.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/ControlValueFormatter.java
@@ -38,7 +38,7 @@ public interface ControlValueFormatter {
     }
 
     static ControlValueFormatter multiplier() {
-        return (v) -> Text.literal(v + "%");
+        return (v) -> Text.literal(v + "x");
     }
 
     static ControlValueFormatter quantityOrDisabled(String name, String disableText) {

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/SliderControl.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/SliderControl.java
@@ -6,6 +6,7 @@ import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.client.util.math.Rect2i;
+import net.minecraft.text.Text;
 import net.minecraft.util.math.MathHelper;
 import org.apache.commons.lang3.Validate;
 
@@ -90,7 +91,7 @@ public class SliderControl implements Control<Integer> {
             int sliderWidth = this.sliderBounds.getWidth();
             int sliderHeight = this.sliderBounds.getHeight();
 
-            String label = this.formatter.format(this.option.getValue());
+            Text label = this.formatter.format(this.option.getValue());
             int labelWidth = this.font.getWidth(label);
 
             this.drawString(drawContext, label, sliderX + sliderWidth - labelWidth, sliderY + (sliderHeight / 2) - 4, 0xFFFFFFFF);
@@ -106,11 +107,11 @@ public class SliderControl implements Control<Integer> {
 
             double thumbOffset = MathHelper.clamp((double) (this.getIntValue() - this.min) / this.range * sliderWidth, 0, sliderWidth);
 
-            double thumbX = sliderX + thumbOffset - THUMB_WIDTH;
-            double trackY = sliderY + (sliderHeight / 2f) - ((double) TRACK_HEIGHT / 2);
+            int thumbX = (int) (sliderX + thumbOffset - THUMB_WIDTH);
+            int trackY = (int) (sliderY + (sliderHeight / 2f) - ((double) TRACK_HEIGHT / 2));
 
-            this.drawRect(thumbX, sliderY, thumbX + (THUMB_WIDTH * 2), sliderY + sliderHeight, 0xFFFFFFFF);
-            this.drawRect(sliderX, trackY, sliderX + sliderWidth, trackY + TRACK_HEIGHT, 0xFFFFFFFF);
+            this.drawRect(drawContext, thumbX, sliderY, thumbX + (THUMB_WIDTH * 2), sliderY + sliderHeight, 0xFFFFFFFF);
+            this.drawRect(drawContext, sliderX, trackY, sliderX + sliderWidth, trackY + TRACK_HEIGHT, 0xFFFFFFFF);
 
             String label = String.valueOf(this.getIntValue());
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/TickBoxControl.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/TickBoxControl.java
@@ -5,7 +5,6 @@ import me.jellysquid.mods.sodium.client.util.Dim2i;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.client.util.math.Rect2i;
-import net.minecraft.client.util.math.MatrixStack;
 
 public class TickBoxControl implements Control<Boolean> {
     private final Option<Boolean> option;
@@ -59,10 +58,10 @@ public class TickBoxControl implements Control<Boolean> {
             }
 
             if (ticked) {
-                this.drawRect(x + 2, y + 2, w - 2, h - 2, color);
+                this.drawRect(drawContext, x + 2, y + 2, w - 2, h - 2, color);
             }
 
-            this.drawRectOutline(x, y, w, h, color);
+            this.drawBorder(drawContext, x, y, w, h, color);
         }
 
         @Override
@@ -94,21 +93,5 @@ public class TickBoxControl implements Control<Boolean> {
         public void toggleControl() {
             this.option.setValue(!this.option.getValue());
         }
-
-        protected void drawRectOutline(int x, int y, int w, int h, int color) {
-            final float a = (float) (color >> 24 & 255) / 255.0F;
-            final float r = (float) (color >> 16 & 255) / 255.0F;
-            final float g = (float) (color >> 8 & 255) / 255.0F;
-            final float b = (float) (color & 255) / 255.0F;
-
-            this.drawQuads(vertices -> {
-                addQuad(vertices, x, y, w, y + 1, a, r, g, b);
-                addQuad(vertices, x, h - 1, w, h, a, r, g, b);
-                addQuad(vertices, x, y, x + 1, h, a, r, g, b);
-                addQuad(vertices, w - 1, y, w, h, a, r, g, b);
-            });
-        }
     }
-
-
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/widgets/AbstractWidget.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/widgets/AbstractWidget.java
@@ -1,6 +1,5 @@
 package me.jellysquid.mods.sodium.client.gui.widgets;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.Drawable;
@@ -11,15 +10,11 @@ import net.minecraft.client.gui.navigation.GuiNavigation;
 import net.minecraft.client.gui.navigation.GuiNavigationPath;
 import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
 import net.minecraft.client.gui.screen.narration.NarrationPart;
-import net.minecraft.client.render.*;
 import net.minecraft.client.sound.PositionedSoundInstance;
-import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.text.StringVisitable;
 import net.minecraft.text.Text;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.function.Consumer;
 
 public abstract class AbstractWidget implements Drawable, Element, Selectable {
     protected final TextRenderer font;
@@ -42,37 +37,8 @@ public abstract class AbstractWidget implements Drawable, Element, Selectable {
         return this.hovered;
     }
 
-    protected void drawRect(double x1, double y1, double x2, double y2, int color) {
-        float a = (float) (color >> 24 & 255) / 255.0F;
-        float r = (float) (color >> 16 & 255) / 255.0F;
-        float g = (float) (color >> 8 & 255) / 255.0F;
-        float b = (float) (color & 255) / 255.0F;
-
-        this.drawQuads(vertices -> addQuad(vertices, x1, y1, x2, y2, a, r, g, b));
-    }
-
-    protected void drawQuads(Consumer<VertexConsumer> consumer) {
-        RenderSystem.setShader(GameRenderer::getPositionColorProgram);
-
-        RenderSystem.enableBlend();
-        RenderSystem.defaultBlendFunc();
-
-        BufferBuilder bufferBuilder = Tessellator.getInstance().getBuffer();
-        bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_COLOR);
-
-        consumer.accept(bufferBuilder);
-
-        BufferBuilder.BuiltBuffer output = bufferBuilder.end();
-
-        BufferRenderer.drawWithGlobalProgram(output);
-        RenderSystem.disableBlend();
-    }
-
-    protected static void addQuad(VertexConsumer consumer, double x1, double y1, double x2, double y2, float a, float r, float g, float b) {
-        consumer.vertex(x2, y1, 0.0D).color(r, g, b, a).next();
-        consumer.vertex(x1, y1, 0.0D).color(r, g, b, a).next();
-        consumer.vertex(x1, y2, 0.0D).color(r, g, b, a).next();
-        consumer.vertex(x2, y2, 0.0D).color(r, g, b, a).next();
+    protected void drawRect(DrawContext drawContext, int x1, int y1, int x2, int y2, int color) {
+        drawContext.fill(x1, y1, x2, y2, color);
     }
 
     protected void playClickSound() {
@@ -113,19 +79,19 @@ public abstract class AbstractWidget implements Drawable, Element, Selectable {
     }
 
     @Override
-    public void setFocused(boolean focused) {
-        this.focused = focused;
-    }
-
-    @Override
     public boolean isFocused() {
         return focused;
     }
 
-    protected void drawBorder(int x1, int y1, int x2, int y2) {
-        this.drawRect(x1, y1, x2, y1 + 1, -1);
-        this.drawRect(x1, y2 - 1, x2, y2, -1);
-        this.drawRect(x1, y1, x1 + 1, y2, -1);
-        this.drawRect(x2 - 1, y1, x2, y2, -1);
+    @Override
+    public void setFocused(boolean focused) {
+        this.focused = focused;
+    }
+
+    protected void drawBorder(DrawContext drawContext, int x1, int y1, int x2, int y2, int color) {
+        drawContext.fill(x1, y1, x2, y1 + 1, color);
+        drawContext.fill(x1, y2 - 1, x2, y2, color);
+        drawContext.fill(x1, y1, x1 + 1, y2, color);
+        drawContext.fill(x2 - 1, y1, x2, y2, color);
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/widgets/FlatButtonWidget.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/widgets/FlatButtonWidget.java
@@ -7,7 +7,6 @@ import net.minecraft.client.gui.ScreenRect;
 import net.minecraft.client.gui.navigation.GuiNavigation;
 import net.minecraft.client.gui.navigation.GuiNavigationPath;
 import net.minecraft.client.util.InputUtil;
-import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.Text;
 import org.jetbrains.annotations.Nullable;
 
@@ -40,14 +39,14 @@ public class FlatButtonWidget extends AbstractWidget implements Drawable {
 
         int strWidth = this.font.getWidth(this.label);
 
-        this.drawRect(this.dim.x(), this.dim.y(), this.dim.getLimitX(), this.dim.getLimitY(), backgroundColor);
+        this.drawRect(drawContext, this.dim.x(), this.dim.y(), this.dim.getLimitX(), this.dim.getLimitY(), backgroundColor);
         this.drawString(drawContext, this.label, this.dim.getCenterX() - (strWidth / 2), this.dim.getCenterY() - 4, textColor);
 
         if (this.enabled && this.selected) {
-            this.drawRect(this.dim.x(), this.dim.getLimitY() - 1, this.dim.getLimitX(), this.dim.getLimitY(), 0xFF94E4D3);
+            this.drawRect(drawContext, this.dim.x(), this.dim.getLimitY() - 1, this.dim.getLimitX(), this.dim.getLimitY(), 0xFF94E4D3);
         }
         if (this.enabled && this.isFocused()) {
-            this.drawBorder(this.dim.x(), this.dim.y(), this.dim.getLimitX(), this.dim.getLimitY());
+            this.drawBorder(drawContext, this.dim.x(), this.dim.y(), this.dim.getLimitX(), this.dim.getLimitY(), -1);
         }
     }
 


### PR DESCRIPTION
# Bug Discovery Process

While investigating a specific scenario involving the following mods:

- `sodium-fabric-mc1.20-0.4.10+build.27`
- `owo-lib-0.11.1+1.20`
- `fabric-api-0.85.0+1.20.1`
- `isometric-renders-0.4.4+1.20`

When joining a world, the options rectangles were not being rendered correctly, as shown in the image below:

![Before PR](https://github.com/CaffeineMC/sodium-fabric/assets/30311066/9d8ffe5c-b2ad-4e25-95cd-5f63d77edbfb)

# Bug Explanation
Starting from version 1.20, a significant change was made to the `DrawableHelper` utility. Previously, it was commonly subclassed and used by passing `MatrixStack` matrices parameters. However, in the latest update, `DrawableHelper` has been replaced by `DrawContext`, which is now directly passed as an object to rendering methods. This eliminates the need to manually construct our own. **In addition to this change, the rectangle rendering was not occurring in the dedicated GUI layer, which was part of the recent update. As a result, the rectangles were not rendering properly.**

# Bug Resolution

After implementing this PR, the options screens now display correctly, as depicted in the following image:

![After PR](https://github.com/CaffeineMC/sodium-fabric/assets/30311066/da5c9d67-9344-4e1b-93b1-c2f4d0a41b91)