### PR TITLE
Show "No Error Context" option as unavailable under Wayland

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -11,6 +11,7 @@ import me.jellysquid.mods.sodium.client.gui.options.control.SliderControl;
 import me.jellysquid.mods.sodium.client.gui.options.control.TickBoxControl;
 import me.jellysquid.mods.sodium.client.gui.options.storage.MinecraftOptionsStorage;
 import me.jellysquid.mods.sodium.client.gui.options.storage.SodiumOptionsStorage;
+import me.jellysquid.mods.sodium.client.util.workarounds.Workarounds;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gl.Framebuffer;
 import net.minecraft.client.option.*;
@@ -314,7 +315,8 @@ public class SodiumGameOptionPages {
 
     private static boolean supportsNoErrorContext() {
         GLCapabilities capabilities = GL.getCapabilities();
-        return capabilities.OpenGL46 || capabilities.GL_KHR_no_error;
+        return (capabilities.OpenGL46 || capabilities.GL_KHR_no_error)
+                && !Workarounds.isWorkaroundEnabled(Workarounds.Reference.NO_ERROR_CONTEXT_UNSUPPORTED);
     }
 
     public static OptionPage advanced() {


### PR DESCRIPTION
As of https://github.com/CaffeineMC/sodium-fabric/commit/fa594b4d88c7e8736e235492607d3fefc83272cd, "No Error Context" is force-disabled on Wayland, but the option is still togglable in video settings, which might mislead the user into thinking changing the option does something. This PR prevents the option from being togglable and crosses it out if the workaround is currently active to indicate that the option is not available.