### PR TITLE
Restrict total number of chunk update threads based off heap size

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -11,6 +11,7 @@ import me.jellysquid.mods.sodium.client.gui.options.control.SliderControl;
 import me.jellysquid.mods.sodium.client.gui.options.control.TickBoxControl;
 import me.jellysquid.mods.sodium.client.gui.options.storage.MinecraftOptionsStorage;
 import me.jellysquid.mods.sodium.client.gui.options.storage.SodiumOptionsStorage;
+import me.jellysquid.mods.sodium.client.render.chunk.compile.executor.ChunkBuilder;
 import me.jellysquid.mods.sodium.client.util.workarounds.Workarounds;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gl.Framebuffer;
@@ -246,7 +247,7 @@ public class SodiumGameOptionPages {
                 .add(OptionImpl.createBuilder(int.class, sodiumOpts)
                         .setName(Text.translatable("sodium.options.chunk_update_threads.name"))
                         .setTooltip(Text.translatable("sodium.options.chunk_update_threads.tooltip"))
-                        .setControl(o -> new SliderControl(o, 0, Runtime.getRuntime().availableProcessors(), 1, ControlValueFormatter.quantityOrDisabled("threads", "Default")))
+                        .setControl(o -> new SliderControl(o, 0, ChunkBuilder.getMaxThreadCount(), 1, ControlValueFormatter.quantityOrDisabled("threads", "Default")))
                         .setImpact(OptionImpact.HIGH)
                         .setBinding((opts, value) -> opts.performance.chunkBuilderThreads = value, opts -> opts.performance.chunkBuilderThreads)
                         .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/executor/ChunkBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/executor/ChunkBuilder.java
@@ -18,6 +18,7 @@ import java.util.function.Consumer;
 
 public class ChunkBuilder {
     static final Logger LOGGER = LogManager.getLogger("ChunkBuilder");
+    private static final int MBS_PER_CHUNK_BUILDER = 64;
 
     private volatile boolean isRunning;
 
@@ -130,8 +131,13 @@ public class ChunkBuilder {
         return requested == 0 ? getOptimalThreadCount() : Math.min(requested, getMaxThreadCount());
     }
 
-    private static int getMaxThreadCount() {
-        return Runtime.getRuntime().availableProcessors();
+    public static int getMaxThreadCount() {
+        int totalCores = Runtime.getRuntime().availableProcessors();
+        long memoryMb = Runtime.getRuntime().maxMemory() / (1024L * 1024L);
+        // always allow at least one builder regardless of heap size
+        int maxBuilders = Math.max(1, (int)(memoryMb / MBS_PER_CHUNK_BUILDER));
+        // choose the total CPU cores or the number of builders the heap permits, whichever is smaller
+        return Math.min(totalCores, maxBuilders);
     }
 
     /**


### PR DESCRIPTION
### Proposed Changes

With the right combination of optimization mods and configs it is possible to run the game on very small heap sizes (<=256MB). However, due to Sodium allowing users to configure the number of chunk builder threads as high as they would like, it is possible to starve the game of memory by having too many threads attempting to update chunks at once.

This PR solves that issue by introducing additional logic that caps the number of threads based off maximum heap size. Vanilla's chunk builder uses its own heuristic dependent on the `RenderLayer`s' expected buffer sizes. Here, we use simpler logic, and allow one thread for every 64MB of heap. On the default vanilla RAM allocation (2GB) this would permit 32 threads, which should still be plenty (Sodium doesn't even try to use more than 10 by default).

Example screenshot attached showing that the maximum number of threads is now 2 even on a 4-thread system due to the low heap size.

![image](https://github.com/CaffeineMC/sodium-fabric/assets/42941056/9e878c95-54f4-4a81-ac64-d1565006cda2)
