### PR TITLE
Add 'register' method to VertexSerializerRegistry

### DIFF
--- a/src/api/java/net/caffeinemc/mods/sodium/api/vertex/serializer/VertexSerializerRegistry.java
+++ b/src/api/java/net/caffeinemc/mods/sodium/api/vertex/serializer/VertexSerializerRegistry.java
@@ -12,4 +12,6 @@ public interface VertexSerializerRegistry {
     }
 
     VertexSerializer get(VertexFormatDescription srcFormat, VertexFormatDescription dstFormat);
+
+    void register(VertexFormatDescription srcFormat, VertexFormatDescription dstFormat, VertexSerializer serializer);
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/vertex/serializers/VertexSerializerRegistryImpl.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/vertex/serializers/VertexSerializerRegistryImpl.java
@@ -46,6 +46,27 @@ public class VertexSerializerRegistryImpl implements VertexSerializerRegistry {
         return serializer;
     }
 
+    @Override
+    public void register(VertexFormatDescription srcFormat, VertexFormatDescription dstFormat, VertexSerializer serializer) {
+        var identifier = createKey(srcFormat, dstFormat);
+
+        if (this.cache.containsKey(identifier)) {
+            throw new IllegalArgumentException("Serializer already exists for the given vertex formats: " + srcFormat + " -> " + dstFormat);
+        }
+
+        if (serializer == null) {
+            throw new NullPointerException("Serializer parameter is null.");
+        }
+
+        var stamp = this.lock.writeLock();
+
+        try {
+            this.cache.put(identifier, serializer);
+        } finally {
+            this.lock.unlockWrite(stamp);
+        }
+    }
+
     private VertexSerializer create(long identifier, VertexFormatDescription srcFormat, VertexFormatDescription dstFormat) {
         var serializer = createSerializer(srcFormat, dstFormat);
         var stamp = this.lock.writeLock();


### PR DESCRIPTION
This commit introduces a new 'register' method to the VertexSerializerRegistry interface, along with its implementation in the VertexSerializerRegistryImpl class. The 'register' method allows registering a custom VertexSerializer for a specific pair of source and destination VertexFormatDescriptions. When called, it creates an identifier based on the input formats and checks for an existing serializer in the cache. If a serializer already exists for the given formats, an IllegalArgumentException is thrown. Additionally, the 'serializer' parameter is validated to ensure it is not null.

This new functionality provides greater flexibility for developers to define and use custom VertexSerializers, facilitating efficient vertex data transformations during rendering.