### PR TITLE
More Lighting Fixes

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/model/light/data/ArrayLightDataCache.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/model/light/data/ArrayLightDataCache.java
@@ -1,6 +1,5 @@
-package me.jellysquid.mods.sodium.client.model.light.cache;
+package me.jellysquid.mods.sodium.client.model.light.data;
 
-import me.jellysquid.mods.sodium.client.model.light.data.LightDataAccess;
 import me.jellysquid.mods.sodium.client.world.WorldSlice;
 import net.minecraft.util.math.ChunkSectionPos;
 import net.minecraft.world.BlockRenderView;
@@ -16,13 +15,13 @@ public class ArrayLightDataCache extends LightDataAccess {
     private static final int NEIGHBOR_BLOCK_RADIUS = 2;
     private static final int BLOCK_LENGTH = 16 + (NEIGHBOR_BLOCK_RADIUS * 2);
 
-    private final long[] light;
+    private final int[] light;
 
     private int xOffset, yOffset, zOffset;
 
     public ArrayLightDataCache(BlockRenderView world) {
         this.world = world;
-        this.light = new long[BLOCK_LENGTH * BLOCK_LENGTH * BLOCK_LENGTH];
+        this.light = new int[BLOCK_LENGTH * BLOCK_LENGTH * BLOCK_LENGTH];
     }
 
     public void reset(ChunkSectionPos origin) {
@@ -30,7 +29,7 @@ public class ArrayLightDataCache extends LightDataAccess {
         this.yOffset = origin.getMinY() - NEIGHBOR_BLOCK_RADIUS;
         this.zOffset = origin.getMinZ() - NEIGHBOR_BLOCK_RADIUS;
 
-        Arrays.fill(this.light, 0L);
+        Arrays.fill(this.light, 0);
     }
 
     private int index(int x, int y, int z) {
@@ -42,10 +41,10 @@ public class ArrayLightDataCache extends LightDataAccess {
     }
 
     @Override
-    public long get(int x, int y, int z) {
+    public int get(int x, int y, int z) {
         int l = this.index(x, y, z);
 
-        long word = this.light[l];
+        int word = this.light[l];
 
         if (word != 0) {
             return word;
@@ -53,5 +52,4 @@ public class ArrayLightDataCache extends LightDataAccess {
 
         return this.light[l] = this.compute(x, y, z);
     }
-
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/model/light/data/HashLightDataCache.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/model/light/data/HashLightDataCache.java
@@ -1,7 +1,6 @@
-package me.jellysquid.mods.sodium.client.model.light.cache;
+package me.jellysquid.mods.sodium.client.model.light.data;
 
-import it.unimi.dsi.fastutil.longs.Long2LongLinkedOpenHashMap;
-import me.jellysquid.mods.sodium.client.model.light.data.LightDataAccess;
+import it.unimi.dsi.fastutil.longs.Long2IntLinkedOpenHashMap;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockRenderView;
 
@@ -9,20 +8,20 @@ import net.minecraft.world.BlockRenderView;
  * A light data cache which uses a hash table to store previously accessed values.
  */
 public class HashLightDataCache extends LightDataAccess {
-    private final Long2LongLinkedOpenHashMap map = new Long2LongLinkedOpenHashMap(1024, 0.50f);
+    private final Long2IntLinkedOpenHashMap map = new Long2IntLinkedOpenHashMap(1024, 0.50f);
 
     public HashLightDataCache(BlockRenderView world) {
         this.world = world;
     }
 
     @Override
-    public long get(int x, int y, int z) {
+    public int get(int x, int y, int z) {
         long key = BlockPos.asLong(x, y, z);
-        long word = this.map.getAndMoveToFirst(key);
+        int word = this.map.getAndMoveToFirst(key);
 
         if (word == 0) {
             if (this.map.size() > 1024) {
-                this.map.removeLastLong();
+                this.map.removeLastInt();
             }
 
             this.map.put(key, word = this.compute(x, y, z));

--- a/src/main/java/me/jellysquid/mods/sodium/client/model/light/flat/FlatLightPipeline.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/model/light/flat/FlatLightPipeline.java
@@ -60,7 +60,7 @@ public class FlatLightPipeline implements LightPipeline {
      * inconsistent values so this method exists to mirror vanilla behavior as closely as possible.
      */
     private int getOffsetLightmap(BlockPos pos, Direction face) {
-        long word = this.lightCache.get(pos);
+        int word = this.lightCache.get(pos);
 
         // Check emissivity of the origin state
         if (unpackEM(word)) {
@@ -68,7 +68,7 @@ public class FlatLightPipeline implements LightPipeline {
         }
 
         // Use world light values from the offset pos, but luminance from the origin pos
-        long adjWord = this.lightCache.get(pos, face);
+        int adjWord = this.lightCache.get(pos, face);
         return LightmapTextureManager.pack(Math.max(unpackBL(adjWord), unpackLU(word)), unpackSL(adjWord));
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/model/light/smooth/AoFaceData.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/model/light/smooth/AoFaceData.java
@@ -41,15 +41,15 @@ class AoFaceData {
         final boolean caem;
 
         if (offset) {
-            calm = unpackLM(adjWord);
+            calm = getLightmap(adjWord);
             caem = unpackEM(adjWord);
         } else {
             final long offsetWord = cache.get(x, y, z, direction);
             if (unpackFO(offsetWord)) {
-                calm = unpackLM(adjWord);
+                calm = getLightmap(adjWord);
                 caem = unpackEM(adjWord);
             } else {
-                calm = unpackLM(offsetWord);
+                calm = getLightmap(offsetWord);
                 caem = unpackEM(offsetWord);
             }
         }
@@ -59,25 +59,25 @@ class AoFaceData {
         Direction[] faces = AoNeighborInfo.get(direction).faces;
 
         final long e0 = cache.get(adjX, adjY, adjZ, faces[0]);
-        final int e0lm = unpackLM(e0);
+        final int e0lm = getLightmap(e0);
         final float e0ao = unpackAO(e0);
         final boolean e0op = unpackOP(e0);
         final boolean e0em = unpackEM(e0);
 
         final long e1 = cache.get(adjX, adjY, adjZ, faces[1]);
-        final int e1lm = unpackLM(e1);
+        final int e1lm = getLightmap(e1);
         final float e1ao = unpackAO(e1);
         final boolean e1op = unpackOP(e1);
         final boolean e1em = unpackEM(e1);
 
         final long e2 = cache.get(adjX, adjY, adjZ, faces[2]);
-        final int e2lm = unpackLM(e2);
+        final int e2lm = getLightmap(e2);
         final float e2ao = unpackAO(e2);
         final boolean e2op = unpackOP(e2);
         final boolean e2em = unpackEM(e2);
 
         final long e3 = cache.get(adjX, adjY, adjZ, faces[3]);
-        final int e3lm = unpackLM(e3);
+        final int e3lm = getLightmap(e3);
         final float e3ao = unpackAO(e3);
         final boolean e3op = unpackOP(e3);
         final boolean e3em = unpackEM(e3);
@@ -93,7 +93,7 @@ class AoFaceData {
             c0em = e0em;
         } else {
             long d0 = cache.get(adjX, adjY, adjZ, faces[0], faces[2]);
-            c0lm = unpackLM(d0);
+            c0lm = getLightmap(d0);
             c0ao = unpackAO(d0);
             c0em = unpackEM(d0);
         }
@@ -108,7 +108,7 @@ class AoFaceData {
             c1em = e0em;
         } else {
             long d1 = cache.get(adjX, adjY, adjZ, faces[0], faces[3]);
-            c1lm = unpackLM(d1);
+            c1lm = getLightmap(d1);
             c1ao = unpackAO(d1);
             c1em = unpackEM(d1);
         }
@@ -124,7 +124,7 @@ class AoFaceData {
             c2em = e1em;
         } else {
             long d2 = cache.get(adjX, adjY, adjZ, faces[1], faces[2]);
-            c2lm = unpackLM(d2);
+            c2lm = getLightmap(d2);
             c2ao = unpackAO(d2);
             c2em = unpackEM(d2);
         }
@@ -140,7 +140,7 @@ class AoFaceData {
             c3em = e1em;
         } else {
             long d3 = cache.get(adjX, adjY, adjZ, faces[1], faces[3]);
-            c3lm = unpackLM(d3);
+            c3lm = getLightmap(d3);
             c3ao = unpackAO(d3);
             c3em = unpackEM(d3);
         }

--- a/src/main/java/me/jellysquid/mods/sodium/client/model/light/smooth/AoFaceData.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/model/light/smooth/AoFaceData.java
@@ -5,7 +5,7 @@ import net.minecraft.client.render.LightmapTextureManager;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 
-import static me.jellysquid.mods.sodium.client.model.light.cache.ArrayLightDataCache.*;
+import static me.jellysquid.mods.sodium.client.model.light.data.ArrayLightDataCache.*;
 
 class AoFaceData {
     public final int[] lm = new int[4];
@@ -35,7 +35,7 @@ class AoFaceData {
             adjZ = z;
         }
 
-        long adjWord = cache.get(adjX, adjY, adjZ);
+        final int adjWord = cache.get(adjX, adjY, adjZ);
 
         final int calm;
         final boolean caem;
@@ -44,7 +44,7 @@ class AoFaceData {
             calm = getLightmap(adjWord);
             caem = unpackEM(adjWord);
         } else {
-            final long offsetWord = cache.get(x, y, z, direction);
+            final int offsetWord = cache.get(x, y, z, direction);
             if (unpackFO(offsetWord)) {
                 calm = getLightmap(adjWord);
                 caem = unpackEM(adjWord);
@@ -58,25 +58,25 @@ class AoFaceData {
 
         Direction[] faces = AoNeighborInfo.get(direction).faces;
 
-        final long e0 = cache.get(adjX, adjY, adjZ, faces[0]);
+        final int e0 = cache.get(adjX, adjY, adjZ, faces[0]);
         final int e0lm = getLightmap(e0);
         final float e0ao = unpackAO(e0);
         final boolean e0op = unpackOP(e0);
         final boolean e0em = unpackEM(e0);
 
-        final long e1 = cache.get(adjX, adjY, adjZ, faces[1]);
+        final int e1 = cache.get(adjX, adjY, adjZ, faces[1]);
         final int e1lm = getLightmap(e1);
         final float e1ao = unpackAO(e1);
         final boolean e1op = unpackOP(e1);
         final boolean e1em = unpackEM(e1);
 
-        final long e2 = cache.get(adjX, adjY, adjZ, faces[2]);
+        final int e2 = cache.get(adjX, adjY, adjZ, faces[2]);
         final int e2lm = getLightmap(e2);
         final float e2ao = unpackAO(e2);
         final boolean e2op = unpackOP(e2);
         final boolean e2em = unpackEM(e2);
 
-        final long e3 = cache.get(adjX, adjY, adjZ, faces[3]);
+        final int e3 = cache.get(adjX, adjY, adjZ, faces[3]);
         final int e3lm = getLightmap(e3);
         final float e3ao = unpackAO(e3);
         final boolean e3op = unpackOP(e3);
@@ -92,7 +92,7 @@ class AoFaceData {
             c0ao = e0ao;
             c0em = e0em;
         } else {
-            long d0 = cache.get(adjX, adjY, adjZ, faces[0], faces[2]);
+            int d0 = cache.get(adjX, adjY, adjZ, faces[0], faces[2]);
             c0lm = getLightmap(d0);
             c0ao = unpackAO(d0);
             c0em = unpackEM(d0);
@@ -107,7 +107,7 @@ class AoFaceData {
             c1ao = e0ao;
             c1em = e0em;
         } else {
-            long d1 = cache.get(adjX, adjY, adjZ, faces[0], faces[3]);
+            int d1 = cache.get(adjX, adjY, adjZ, faces[0], faces[3]);
             c1lm = getLightmap(d1);
             c1ao = unpackAO(d1);
             c1em = unpackEM(d1);
@@ -123,7 +123,7 @@ class AoFaceData {
             c2ao = e1ao;
             c2em = e1em;
         } else {
-            long d2 = cache.get(adjX, adjY, adjZ, faces[1], faces[2]);
+            int d2 = cache.get(adjX, adjY, adjZ, faces[1], faces[2]);
             c2lm = getLightmap(d2);
             c2ao = unpackAO(d2);
             c2em = unpackEM(d2);
@@ -139,7 +139,7 @@ class AoFaceData {
             c3ao = e1ao;
             c3em = e1em;
         } else {
-            long d3 = cache.get(adjX, adjY, adjZ, faces[1], faces[3]);
+            int d3 = cache.get(adjX, adjY, adjZ, faces[1], faces[3]);
             c3lm = getLightmap(d3);
             c3ao = unpackAO(d3);
             c3em = unpackEM(d3);

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/executor/ChunkBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/executor/ChunkBuilder.java
@@ -1,7 +1,6 @@
 package me.jellysquid.mods.sodium.client.render.chunk.compile.executor;
 
 import me.jellysquid.mods.sodium.client.SodiumClientMod;
-import me.jellysquid.mods.sodium.client.model.light.cache.ArrayLightDataCache;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.ChunkBuildContext;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.tasks.ChunkBuilderTask;
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexType;
@@ -12,7 +11,8 @@ import org.apache.commons.lang3.Validate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/pipeline/BlockRenderCache.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/pipeline/BlockRenderCache.java
@@ -1,8 +1,8 @@
 package me.jellysquid.mods.sodium.client.render.chunk.compile.pipeline;
 
-import me.jellysquid.mods.sodium.client.model.light.LightPipelineProvider;
-import me.jellysquid.mods.sodium.client.model.light.cache.ArrayLightDataCache;
 import me.jellysquid.mods.sodium.client.model.color.ColorProviderRegistry;
+import me.jellysquid.mods.sodium.client.model.light.LightPipelineProvider;
+import me.jellysquid.mods.sodium.client.model.light.data.ArrayLightDataCache;
 import me.jellysquid.mods.sodium.client.world.WorldSlice;
 import me.jellysquid.mods.sodium.client.world.cloned.ChunkRenderContext;
 import net.minecraft.client.MinecraftClient;


### PR DESCRIPTION
- Flat lighting calculation now almost perfectly matches vanilla. The only difference is that `state.hasEmissiveLighting` is passed a different `BlockPos`, but this does not cause a difference in vanilla as all vanilla implementations of this method do not use the `BlockPos`. Modded implementations might benefit from this discrepancy as the `BlockPos` vanilla passes does not correspond to the state and thus could be considered a bug; in Sodium, the passed `BlockPos` does correspond to the state.
- The light data cache now uses `int`s instead of `long`s to represent packed light data. This may benefit performance.
- Some classes were moved to improve organization.