### PR TITLE
Revert to original center lightmap calculation

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/model/light/smooth/AoFaceData.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/model/light/smooth/AoFaceData.java
@@ -40,18 +40,13 @@ class AoFaceData {
         final int calm;
         final boolean caem;
 
-        if (offset) {
+        if (offset && unpackFO(adjWord)) {
+            final int originWord = cache.get(x, y, z);
+            calm = getLightmap(originWord);
+            caem = unpackEM(originWord);
+        } else {
             calm = getLightmap(adjWord);
             caem = unpackEM(adjWord);
-        } else {
-            final int offsetWord = cache.get(x, y, z, direction);
-            if (unpackFO(offsetWord)) {
-                calm = getLightmap(adjWord);
-                caem = unpackEM(adjWord);
-            } else {
-                calm = getLightmap(offsetWord);
-                caem = unpackEM(offsetWord);
-            }
         }
 
         final float caao = unpackAO(adjWord);


### PR DESCRIPTION
The current calculation matches vanilla. The vanilla calculation likely performs additional checks for inset quads so that they are not rendered too dark. However, Sodium does not need to perform these checks because it interpolates AO values for inset faces. Additionally, since the offset face is used during interpolation, the inset quad may appear darker than expected if the offset block is full opaque. The original calculation accounts for this possibility.