### PR TITLE
Allow running with latest Not Enough Crashes versions

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -38,6 +38,6 @@
   "breaks": {
     "optifabric": "*",
     "canvas": "*",
-    "notenoughcrashes": "*"
+    "notenoughcrashes": "<=4.4.5+1.20.1"
   }
 }


### PR DESCRIPTION
NEC as of 4.4.6 doesn't show the crash screen when Sodium is installed, so the issue should be resolved. 
If there are any other issues feel free to contact me. 