### PR TITLE
fix: Shader uniform mixin config

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/mixin/MixinConfig.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/MixinConfig.java
@@ -67,8 +67,8 @@ public class MixinConfig {
         this.addMixinRule("features.render.world.clouds", true);
         this.addMixinRule("features.render.world.sky", true);
 
-        this.addMixinRule("features.render.shader", true);
-        this.addMixinRule("features.render.shader.uniform", true);
+        this.addMixinRule("features.shader", true);
+        this.addMixinRule("features.shader.uniform", true);
 
         this.addMixinRule("features.textures", true);
         this.addMixinRule("features.textures.animations", true);


### PR DESCRIPTION
Sodium changed the location of the ShaderProgramMixin without changing the feature name which made the mixin feature not longer work.