### PR TITLE
Improve option GUI navigation

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumOptionsGUI.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumOptionsGUI.java
@@ -307,6 +307,18 @@ public class SodiumOptionsGUI extends Screen {
     }
 
     @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        boolean clicked = super.mouseClicked(mouseX, mouseY, button);
+
+        if (!clicked) {
+            this.setFocused(null);
+            return true;
+        }
+
+        return clicked;
+    }
+
+    @Override
     public boolean shouldCloseOnEsc() {
         return !this.hasPendingChanges;
     }

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/widgets/AbstractWidget.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/widgets/AbstractWidget.java
@@ -8,6 +8,7 @@ import net.minecraft.client.gui.Element;
 import net.minecraft.client.gui.Selectable;
 import net.minecraft.client.gui.navigation.GuiNavigation;
 import net.minecraft.client.gui.navigation.GuiNavigationPath;
+import net.minecraft.client.gui.navigation.GuiNavigationType;
 import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
 import net.minecraft.client.gui.screen.narration.NarrationPart;
 import net.minecraft.client.sound.PositionedSoundInstance;
@@ -81,7 +82,14 @@ public abstract class AbstractWidget implements Drawable, Element, Selectable {
 
     @Override
     public void setFocused(boolean focused) {
-        this.focused = focused;
+        if (!focused) {
+            this.focused = false;
+        } else {
+            GuiNavigationType guiNavigationType = MinecraftClient.getInstance().getNavigationType();
+            if (guiNavigationType == GuiNavigationType.KEYBOARD_TAB || guiNavigationType == GuiNavigationType.KEYBOARD_ARROW) {
+                this.focused = true;
+            }
+        }
     }
 
     protected void drawBorder(DrawContext drawContext, int x1, int y1, int x2, int y2, int color) {


### PR DESCRIPTION
Improves the navigation of the option GUI by only focusing elements when using a keyboard.

https://github.com/CaffeineMC/sodium-fabric/assets/69988482/70f99d49-3e81-4436-8f0d-347e66434d50