### PR TITLE
Manually set IncomingDirections for neighbor chunks during searching

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/occlusion/OcclusionCuller.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/occlusion/OcclusionCuller.java
@@ -74,6 +74,7 @@ public class OcclusionCuller {
 
             if (adj != null) {
                 enqueue(queue, adj, 1 << GraphDirection.opposite(direction), frame);
+                adj.setIncomingDirections(1 << GraphDirection.opposite(direction));
             }
         }
     }


### PR DESCRIPTION
This commit should make fewer chunks be loaded (the number approximately equals to 0.4.x)