### PR TITLE
Improve graphics card probing on Linux

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/util/workarounds/probe/GraphicsAdapterProbe.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/util/workarounds/probe/GraphicsAdapterProbe.java
@@ -21,6 +21,8 @@ public class GraphicsAdapterProbe {
     public static void findAdapters() {
         LOGGER.info("Searching for graphics cards...");
 
+        // We rely on separate detection logic for Linux because Oshi fails to find GPUs without
+        // display outputs, and we can also retrieve the driver version for NVIDIA GPUs this way.
         var results = Util.getOperatingSystem() == Util.OperatingSystem.LINUX
                 ? findAdaptersLinux()
                 : findAdaptersCrossPlatform();

--- a/src/main/java/me/jellysquid/mods/sodium/client/util/workarounds/probe/GraphicsAdapterProbe.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/util/workarounds/probe/GraphicsAdapterProbe.java
@@ -1,12 +1,16 @@
 package me.jellysquid.mods.sodium.client.util.workarounds.probe;
 
+import net.minecraft.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import oshi.SystemInfo;
+import oshi.util.ExecutingCommand;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 public class GraphicsAdapterProbe {
@@ -17,6 +21,19 @@ public class GraphicsAdapterProbe {
     public static void findAdapters() {
         LOGGER.info("Searching for graphics cards...");
 
+        var results = Util.getOperatingSystem() == Util.OperatingSystem.LINUX
+                ? findAdaptersLinux()
+                : findAdaptersCrossPlatform();
+
+        if (results.isEmpty()) {
+            LOGGER.warn("No graphics cards were found. Either you have no hardware devices supporting 3D acceleration, or " +
+                    "something has gone terribly wrong!");
+        }
+
+        ADAPTERS = results;
+    }
+
+    public static List<GraphicsAdapterInfo> findAdaptersCrossPlatform() {
         var systemInfo = new SystemInfo();
         var hardwareInfo = systemInfo.getHardware();
 
@@ -33,12 +50,51 @@ public class GraphicsAdapterProbe {
             LOGGER.info("Found graphics card: {}", info);
         }
 
-        if (results.isEmpty()) {
-            LOGGER.warn("No graphics cards were found. Either you have no hardware devices supporting 3D acceleration, or " +
-                    "something has gone terribly wrong!");
-        }
+        return results;
+    }
 
-        ADAPTERS = results;
+    private static List<GraphicsAdapterInfo> findAdaptersLinux() {
+        var results = new ArrayList<GraphicsAdapterInfo>();
+
+        try (var devices = Files.list(Path.of("/sys/bus/pci/devices/"))) {
+            Iterable<Path> devicesIter = devices::iterator;
+
+            for (var devicePath : devicesIter) {
+                // 0x030000 = VGA compatible controller
+                // 0x030200 = 3D controller (GPUs with no inputs attached, e.g. hybrid graphics laptops)
+                var deviceClass = Files.readString(devicePath.resolve("class")).trim();
+                if (!deviceClass.equals("0x030000") && !deviceClass.equals("0x030200")) {
+                    continue;
+                }
+
+                var deviceVendor = Files.readString(devicePath.resolve("vendor")).trim();
+                GraphicsAdapterVendor vendor = GraphicsAdapterVendor.identifyVendorFromString(deviceVendor);
+
+                // The Linux kernel doesn't provide a way to get the device name, so we need to use lspci,
+                // since it comes with a list of known device names mapped to device IDs.
+                var deviceId = Files.readString(devicePath.resolve("device")).trim();
+                var name = ExecutingCommand // See `man lspci` for more information
+                        .runNative("lspci -vmm -d " + deviceVendor.substring(2) + ":" + deviceId.substring(2))
+                        .stream()
+                        .filter(line -> line.startsWith("Device:"))
+                        .map(line -> line.substring("Device:".length()).trim())
+                        .findFirst()
+                        .orElse("unknown");
+
+                // This works for the NVIDIA driver, not for i915/amdgpu/etc. though (for obvious reasons).
+                var versionInfo = "unknown";
+                try {
+                    versionInfo = Files.readString(devicePath.resolve("driver/module/version")).trim();
+                } catch (IOException ignored) {}
+
+                var info = new GraphicsAdapterInfo(vendor, name, versionInfo);
+                results.add(info);
+
+                LOGGER.info("Found graphics card: {}", info);
+            }
+        } catch (IOException ignored) {}
+
+        return results;
     }
 
     public static Collection<GraphicsAdapterInfo> getAdapters() {

--- a/src/main/java/me/jellysquid/mods/sodium/client/util/workarounds/probe/GraphicsAdapterVendor.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/util/workarounds/probe/GraphicsAdapterVendor.java
@@ -10,11 +10,11 @@ public enum GraphicsAdapterVendor {
 
     @NotNull
     static GraphicsAdapterVendor identifyVendorFromString(String vendor) {
-        if (vendor.startsWith("Advanced Micro Devices, Inc.") || vendor.contains("(0x1002)")) {
+        if (vendor.startsWith("Advanced Micro Devices, Inc.") || vendor.contains("(0x1002)") || vendor.equals("0x1002")) {
             return AMD;
-        } else if (vendor.startsWith("NVIDIA") || vendor.contains("(0x10de)")) {
+        } else if (vendor.startsWith("NVIDIA") || vendor.contains("(0x10de)") || vendor.equals("0x10de")) {
             return NVIDIA;
-        } else if (vendor.startsWith("Intel") || vendor.contains("(0x8086)")) {
+        } else if (vendor.startsWith("Intel") || vendor.contains("(0x8086)") || vendor.equals("0x8086")) {
             return INTEL;
         }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/util/workarounds/probe/GraphicsAdapterVendor.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/util/workarounds/probe/GraphicsAdapterVendor.java
@@ -10,11 +10,11 @@ public enum GraphicsAdapterVendor {
 
     @NotNull
     static GraphicsAdapterVendor identifyVendorFromString(String vendor) {
-        if (vendor.startsWith("Advanced Micro Devices, Inc.") || vendor.contains("(0x1002)") || vendor.equals("0x1002")) {
+        if (vendor.startsWith("Advanced Micro Devices, Inc.") || vendor.contains("0x1002")) {
             return AMD;
-        } else if (vendor.startsWith("NVIDIA") || vendor.contains("(0x10de)") || vendor.equals("0x10de")) {
+        } else if (vendor.startsWith("NVIDIA") || vendor.contains("0x10de")) {
             return NVIDIA;
-        } else if (vendor.startsWith("Intel") || vendor.contains("(0x8086)") || vendor.equals("0x8086")) {
+        } else if (vendor.startsWith("Intel") || vendor.contains("0x8086")) {
             return INTEL;
         }
 


### PR DESCRIPTION
Discrete GPUs in hybrid graphics laptops often don't have display out ports, and `lspci` refers to them as "3D controllers" instead of "VGA compatible controllers." Oshi fails to detect these GPUs, so we replace its detection logic under Linux by enumerating PCIe devices in `/sys/bus/pci/devices` ourselves.

Since the Linux kernel doesn't provide the device names, we use `lspci`, which has a database of PCIe device names mapped to IDs, to retrieve the graphics card name. This code still functions without `lspci`, but the graphics card names will be missing.

We also try to retrieve the NVIDIA driver version through sysfs (another improvement over the previous probing logic).

Note: This doesn't cover NVIDIA's Tegra SoCs which don't have the GPU on the PCIe bus.