### PR TITLE
Fix incorrect chunk tracking with multiple updates in a single frame

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/map/ChunkTracker.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/map/ChunkTracker.java
@@ -80,11 +80,11 @@ public class ChunkTracker implements ClientChunkEventListener {
         }
 
         if (flags == ChunkStatus.FLAG_ALL) {
-            if (this.chunkReady.add(key)) {
+            if (this.chunkReady.add(key) && !this.unloadQueue.remove(key)) {
                 this.loadQueue.add(key);
             }
         } else {
-            if (this.chunkReady.remove(key)) {
+            if (this.chunkReady.remove(key) && !this.loadQueue.remove(key)) {
                 this.unloadQueue.add(key);
             }
         }


### PR DESCRIPTION
When the same chunk is added and removed within the same frame (before the `loadQueue` could be drained), it could end up in both queues at the same time. This commit fixes this issue such that any combination of any number of loads/unloads within a single frame will produce correct results.

Albeit seemingly unlikely on a vanilla server, I reckon this issue would be fairly easy to run into with e.g. the ReplayMod when fast-forwarding (although I don't think I've seen any reports of it yet), or on highly custom servers.