### PR TITLE
Terminate workers by releasing more semaphore permits instead of interrupting

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/executor/ChunkBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/executor/ChunkBuilder.java
@@ -20,9 +20,7 @@ import java.util.function.Consumer;
 public class ChunkBuilder {
     static final Logger LOGGER = LogManager.getLogger("ChunkBuilder");
 
-    private final AtomicBoolean isRunning = new AtomicBoolean(true);
-
-    private final ChunkJobQueue queue = new ChunkJobQueue(isRunning);
+    private final ChunkJobQueue queue = new ChunkJobQueue();
 
     private final List<Thread> threads = new ArrayList<>();
 
@@ -66,7 +64,7 @@ public class ChunkBuilder {
      * waiting for worker threads to shut down will still have their results processed for later cleanup.</p>
      */
     public void shutdown() {
-        if (!this.isRunning.get()) {
+        if (!this.queue.isRunning()) {
             throw new IllegalStateException("Worker threads are not running");
         }
 
@@ -98,7 +96,7 @@ public class ChunkBuilder {
     {
         Validate.notNull(task, "Task must be non-null");
 
-        if (!this.isRunning.get()) {
+        if (!this.queue.isRunning()) {
             throw new IllegalStateException("Executor is stopped");
         }
 
@@ -168,7 +166,7 @@ public class ChunkBuilder {
         @Override
         public void run() {
             // Run until the chunk builder shuts down
-            while (ChunkBuilder.this.isRunning.get()) {
+            while (ChunkBuilder.this.queue.isRunning()) {
                 ChunkJob job;
 
                 try {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/executor/ChunkJobQueue.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/executor/ChunkJobQueue.java
@@ -21,7 +21,7 @@ class ChunkJobQueue {
     }
 
     public void add(ChunkJob job, boolean important) {
-        Validate.isTrue(this.isRunning());
+        Validate.isTrue(this.isRunning(), "Queue is no longer running");
 
         if (important) {
             this.jobs.addFirst(job);
@@ -34,8 +34,9 @@ class ChunkJobQueue {
 
     @Nullable
     public ChunkJob waitForNextJob() throws InterruptedException {
-        if(!this.isRunning())
+        if (!this.isRunning()) {
             return null;
+        }
 
         this.semaphore.acquire();
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/executor/ChunkJobQueue.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/executor/ChunkJobQueue.java
@@ -1,5 +1,6 @@
 package me.jellysquid.mods.sodium.client.render.chunk.compile.executor;
 
+import org.apache.commons.lang3.Validate;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayDeque;
@@ -13,14 +14,14 @@ class ChunkJobQueue {
 
     private final Semaphore semaphore = new Semaphore(0);
 
-    private final AtomicBoolean isRunning;
+    private final AtomicBoolean isRunning = new AtomicBoolean(true);
 
-    public ChunkJobQueue(AtomicBoolean isRunning) {
-        this.isRunning = isRunning;
+    public boolean isRunning() {
+        return this.isRunning.get();
     }
 
     public void add(ChunkJob job, boolean important) {
-        assert this.isRunning.get();
+        Validate.isTrue(this.isRunning());
 
         if (important) {
             this.jobs.addFirst(job);
@@ -33,6 +34,8 @@ class ChunkJobQueue {
 
     @Nullable
     public ChunkJob waitForNextJob() throws InterruptedException {
+        if(!this.isRunning())
+            return null;
         this.semaphore.acquire();
 
         return this.getNextTask();

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/executor/ChunkJobQueue.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/executor/ChunkJobQueue.java
@@ -36,6 +36,7 @@ class ChunkJobQueue {
     public ChunkJob waitForNextJob() throws InterruptedException {
         if(!this.isRunning())
             return null;
+
         this.semaphore.acquire();
 
         return this.getNextTask();


### PR DESCRIPTION
### Linked Issues

Fixes #2011

### Proposed Changes

This PR avoids use of `Thread.interrupt` by following Jelly's recommended design in the #dev-sodium Discord channel.