### PR TITLE
Fix incorrect Intel broken driver check

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/util/workarounds/PreLaunchChecks.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/util/workarounds/PreLaunchChecks.java
@@ -52,7 +52,7 @@ public class PreLaunchChecks {
             try {
                 var version = WindowsDriverStoreVersion.parse(adapter.version());
 
-                if (version.equals(new WindowsDriverStoreVersion(10, 18, 10, 4538))) {
+                if (version.driverModel() == 10 && version.featureLevel() == 18 && version.major() == 10) {
                     return true;
                 }
             } catch (WindowsDriverStoreVersion.ParseException ignored) { }


### PR DESCRIPTION
This changes the pre-launch check for the broken Intel drivers to include every Intel driver version that starts with `10.18.10`.
Blacklisting only one minor version is not enough, as there are several of them which are confirmed broken:

`10.18.10.4358` - https://github.com/CaffeineMC/sodium-fabric/issues/899
`10.18.10.4242` - https://github.com/CaffeineMC/sodium-fabric/issues/1710
`10.18.10.4885` - https://github.com/CaffeineMC/sodium-fabric/issues/1817
`10.18.10.4425` - https://github.com/CaffeineMC/sodium-fabric/issues/1863
`10.18.10.4653` - Support thread on the Discord server

As such, it would most likely be safe to assume that all minor versions of this driver are broken in the same manner. We direct users to download version `15.33.53.5161` to fix the problem, anyways.