### PR TITLE
Switch render order of block aligned and unaligned block faces 

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/pipeline/BlockRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/pipeline/BlockRenderer.java
@@ -68,18 +68,19 @@ public class BlockRenderer {
             renderOffset = Vec3d.ZERO;
         }
 
+        List<BakedQuad> all = this.getGeometry(ctx, null);
+
+        // render non axis aligned faces first as blocks such as honey & slime have internal faces that should be rendered first.
+        if (!all.isEmpty()) {
+            this.renderQuadList(ctx, material, lighter, colorizer, renderOffset, meshBuilder, all, null);
+        }
+
         for (Direction face : DirectionUtil.ALL_DIRECTIONS) {
             List<BakedQuad> quads = this.getGeometry(ctx, face);
 
             if (!quads.isEmpty() && this.isFaceVisible(ctx, face)) {
                 this.renderQuadList(ctx, material, lighter, colorizer, renderOffset, meshBuilder, quads, face);
             }
-        }
-
-        List<BakedQuad> all = this.getGeometry(ctx, null);
-
-        if (!all.isEmpty()) {
-            this.renderQuadList(ctx, material, lighter, colorizer, renderOffset, meshBuilder, all, null);
         }
     }
 


### PR DESCRIPTION
This results in the internal cube for slime and honey blocks being rendered more correctly.
![262338598-f1d33679-49a5-4644-a8ac-13339b5c1e25](https://github.com/CaffeineMC/sodium-fabric/assets/19439141/41f81b22-fcbd-45ad-8983-d14836776cf5)

it seems to render fine but does this negatively affect performance if those faces are done before axis-aligned ones?