### PR TITLE
Ignore undersized quads

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/render/immediate/buffer_builder/intrinsics/BufferBuilderMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/render/immediate/buffer_builder/intrinsics/BufferBuilderMixin.java
@@ -32,6 +32,10 @@ public abstract class BufferBuilderMixin extends FixedColorVertexConsumer {
             throw new IllegalStateException();
         }
 
+        if (bakedQuad.getVertexData().length < 32) {
+            return; // we do not accept quads with less than 4 properly sized vertices
+        }
+
         VertexBufferWriter writer = VertexBufferWriter.of(this);
 
         ModelQuadView quad = (ModelQuadView) bakedQuad;
@@ -54,6 +58,10 @@ public abstract class BufferBuilderMixin extends FixedColorVertexConsumer {
 
         if (this.colorFixed) {
             throw new IllegalStateException();
+        }
+
+        if (bakedQuad.getVertexData().length < 32) {
+            return; // we do not accept quads with less than 4 properly sized vertices
         }
 
         VertexBufferWriter writer = VertexBufferWriter.of(this);

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/render/model/block/BlockModelRendererMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/render/model/block/BlockModelRendererMixin.java
@@ -74,6 +74,11 @@ public class BlockModelRendererMixin {
     private static void renderQuads(MatrixStack.Entry matrices, VertexBufferWriter writer, int defaultColor, List<BakedQuad> quads, int light, int overlay) {
         for (int i = 0; i < quads.size(); i++) {
             BakedQuad bakedQuad = quads.get(i);
+
+            if (bakedQuad.getVertexData().length < 32) {
+                continue; // ignore bad quads
+            }
+
             BakedQuadView quad = (BakedQuadView) bakedQuad;
 
             int color = quad.hasColor() ? defaultColor : 0xFFFFFFFF;

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/render/model/item/ItemRendererMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/render/model/item/ItemRendererMixin.java
@@ -80,6 +80,11 @@ public class ItemRendererMixin {
     private void renderBakedItemQuads(MatrixStack.Entry matrices, VertexBufferWriter writer, List<BakedQuad> quads, ItemStack itemStack, ItemColorProvider colorProvider, int light, int overlay) {
         for (int i = 0; i < quads.size(); i++) {
             BakedQuad bakedQuad = quads.get(i);
+
+            if (bakedQuad.getVertexData().length < 32) {
+                continue; // ignore bad quads
+            }
+
             BakedQuadView quad = (BakedQuadView) bakedQuad;
 
             int color = 0xFFFFFFFF;


### PR DESCRIPTION
Some mods provide baked quads with less than 32 entries in `vertexData`. Sodium doesn't do range checks and assumes all quads have at least 32 entries, causing crashes with these mods. We cannot render anything logical with this information but we can at least skip the bad quads entirely, preventing the crash.