### PR TITLE
Add Fabric BlockView API v2 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,8 +82,12 @@ dependencies {
 
     // Fabric API
     modIncludeImplementation(fabricApi.module("fabric-api-base", project.fabric_version))
+    modIncludeImplementation(fabricApi.module("fabric-block-view-api-v2", project.fabric_version))
     modIncludeImplementation(fabricApi.module("fabric-rendering-fluids-v1", project.fabric_version))
-    modIncludeImplementation(fabricApi.module("fabric-rendering-data-attachment-v1", project.fabric_version))
+    // `fabricApi.module` does not work with deprecated modules, so add the module dependency manually.
+    // This is planned to be fixed in Loom 1.4.
+    // modIncludeImplementation(fabricApi.module("fabric-rendering-data-attachment-v1", project.fabric_version))
+    modIncludeImplementation("net.fabricmc.fabric-api:fabric-rendering-data-attachment-v1:0.3.36+92a0d36777")
     modIncludeImplementation(fabricApi.module("fabric-resource-loader-v0", project.fabric_version))
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.jvmargs=-Xmx2G
 minecraft_version=1.20.1
 yarn_mappings=1.20.1+build.9
 loader_version=0.14.21
-fabric_version=0.85.0+1.20.1
+fabric_version=0.88.1+1.20.1
 
 # Mod Properties
 mod_version=0.5.2

--- a/src/main/java/me/jellysquid/mods/sodium/client/world/biome/BiomeColorCache.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/biome/BiomeColorCache.java
@@ -73,7 +73,7 @@ public class BiomeColorCache {
 
         for (int worldZ = this.minZ; worldZ <= this.maxZ; worldZ++) {
             for (int worldX = this.minX; worldX <= this.maxX; worldX++) {
-                Biome biome = this.biomeData.getBiome(worldX, worldY, worldZ);
+                Biome biome = this.biomeData.getBiome(worldX, worldY, worldZ).value();
 
                 int relativeX = worldX - this.minX;
                 int relativeZ = worldZ - this.minZ;

--- a/src/main/java/me/jellysquid/mods/sodium/client/world/biome/BiomeSlice.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/biome/BiomeSlice.java
@@ -5,6 +5,7 @@ import me.jellysquid.mods.sodium.client.world.WorldSlice;
 import me.jellysquid.mods.sodium.client.world.cloned.ChunkRenderContext;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
@@ -16,7 +17,8 @@ public class BiomeSlice {
     private static final int SIZE = 3 * 4; // 3 chunks * 4 biomes per chunk
 
     // Arrays are in ZYX order
-    private final Biome[] biomes = new Biome[SIZE * SIZE * SIZE];
+    @SuppressWarnings("unchecked")
+    private final RegistryEntry<Biome>[] biomes = new RegistryEntry[SIZE * SIZE * SIZE];
     private final boolean[] uniform = new boolean[SIZE * SIZE * SIZE];
     private final BiasMap bias = new BiasMap();
 
@@ -40,8 +42,7 @@ public class BiomeSlice {
     private void copyBiomeData(World world, ChunkRenderContext context) {
         var defaultValue = world.getRegistryManager()
                 .get(RegistryKeys.BIOME)
-                .entryOf(BiomeKeys.PLAINS)
-                .value();
+                .entryOf(BiomeKeys.PLAINS);
 
         for (int sectionX = 0; sectionX < 3; sectionX++) {
             for (int sectionY = 0; sectionY < 3; sectionY++) {
@@ -52,7 +53,7 @@ public class BiomeSlice {
         }
     }
 
-    private void copySectionBiomeData(ChunkRenderContext context, int sectionX, int sectionY, int sectionZ, Biome defaultBiome) {
+    private void copySectionBiomeData(ChunkRenderContext context, int sectionX, int sectionY, int sectionZ, RegistryEntry<Biome> defaultBiome) {
         var section = context.getSections()[WorldSlice.getLocalSectionIndex(sectionX, sectionY, sectionZ)];
         var biomeData = section.getBiomeData();
 
@@ -68,7 +69,7 @@ public class BiomeSlice {
                     if (biomeData == null) {
                         this.biomes[idx] = defaultBiome;
                     } else {
-                        this.biomes[idx] = biomeData.get(x, y, z).value();
+                        this.biomes[idx] = biomeData.get(x, y, z);
                     }
                 }
             }
@@ -125,8 +126,8 @@ public class BiomeSlice {
     }
 
     private boolean hasUniformNeighbors(int x, int y, int z) {
-        Biome biome = this.biomes[dataArrayIndex(x, y, z)];
-        
+        Biome biome = this.biomes[dataArrayIndex(x, y, z)].value();
+
         int minX = x - 1, maxX = x + 1;
         int minY = y - 1, maxY = y + 1;
         int minZ = z - 1, maxZ = z + 1;
@@ -134,7 +135,7 @@ public class BiomeSlice {
         for (int adjX = minX; adjX <= maxX; adjX++) {
             for (int adjY = minY; adjY <= maxY; adjY++) {
                 for (int adjZ = minZ; adjZ <= maxZ; adjZ++) {
-                    if (this.biomes[dataArrayIndex(adjX, adjY, adjZ)] != biome) {
+                    if (this.biomes[dataArrayIndex(adjX, adjY, adjZ)].value() != biome) {
                         return false;
                     }
                 }
@@ -144,7 +145,7 @@ public class BiomeSlice {
         return true;
     }
 
-    public Biome getBiome(int x, int y, int z) {
+    public RegistryEntry<Biome> getBiome(int x, int y, int z) {
         int relX = x - this.worldX;
         int relY = y - this.worldY;
         int relZ = z - this.worldZ;
@@ -161,7 +162,7 @@ public class BiomeSlice {
         return this.getBiomeUsingVoronoi(relX, relY, relZ);
     }
 
-    private Biome getBiomeUsingVoronoi(int worldX, int worldY, int worldZ) {
+    private RegistryEntry<Biome> getBiomeUsingVoronoi(int worldX, int worldY, int worldZ) {
         int x = worldX - 2;
         int y = worldY - 2;
         int z = worldZ - 2;


### PR DESCRIPTION
- Modify `BiomeSlice` to store and use `RegistryEntry<Biome>` instead of `Biome`
- Rename "block entity attachment" to "block entity render data" to match terminology of BlockView API v2
- Trim BlockEntity and BlockEntity render data maps

`WorldSlice` still implements the deprecated `RenderAttachedBlockView` interface and Rendering Data Attachment v1 is still JiJed so that Rendering Data Attachment v1 is still supported, since `RenderAttachedBlockView` is only automatically implemented on instances of `WorldView`, which `WorldSlice` does not implement. `WorldSlice` can stop implementing `RenderAttachedBlockView` and the module dependency can be dropped once most mod developers have migrated to Fabric BlockView API v2.