### PR TITLE
Fix block updates being ignored before initial build completes

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -454,7 +454,7 @@ public class RenderSectionManager {
                 this.needsUpdate = true;
 
                 CancellationToken token = section.getBuildCancellationToken();
-                if(token != null) {
+                if (token != null) {
                     token.setCancelled();
                     section.setBuildCancellationToken(null); // to allow queuing it again
                 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -30,7 +30,6 @@ import me.jellysquid.mods.sodium.client.render.texture.SpriteUtil;
 import me.jellysquid.mods.sodium.client.render.viewport.CameraTransform;
 import me.jellysquid.mods.sodium.client.render.viewport.Viewport;
 import me.jellysquid.mods.sodium.client.util.MathUtil;
-import me.jellysquid.mods.sodium.client.util.task.CancellationToken;
 import me.jellysquid.mods.sodium.client.world.WorldSlice;
 import me.jellysquid.mods.sodium.client.world.cloned.ChunkRenderContext;
 import me.jellysquid.mods.sodium.client.world.cloned.ClonedChunkSectionCache;

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -452,12 +452,6 @@ public class RenderSectionManager {
                 section.setPendingUpdate(pendingUpdate);
 
                 this.needsUpdate = true;
-
-                CancellationToken token = section.getBuildCancellationToken();
-                if (token != null) {
-                    token.setCancelled();
-                    section.setBuildCancellationToken(null); // to allow queuing it again
-                }
             }
         }
     }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -30,6 +30,7 @@ import me.jellysquid.mods.sodium.client.render.texture.SpriteUtil;
 import me.jellysquid.mods.sodium.client.render.viewport.CameraTransform;
 import me.jellysquid.mods.sodium.client.render.viewport.Viewport;
 import me.jellysquid.mods.sodium.client.util.MathUtil;
+import me.jellysquid.mods.sodium.client.util.task.CancellationToken;
 import me.jellysquid.mods.sodium.client.world.WorldSlice;
 import me.jellysquid.mods.sodium.client.world.cloned.ChunkRenderContext;
 import me.jellysquid.mods.sodium.client.world.cloned.ClonedChunkSectionCache;
@@ -438,7 +439,7 @@ public class RenderSectionManager {
 
         RenderSection section = this.sectionByPosition.get(ChunkSectionPos.asLong(x, y, z));
 
-        if (section != null && section.isBuilt()) {
+        if (section != null) {
             ChunkUpdateType pendingUpdate;
 
             if (allowImportantRebuilds() && (important || this.shouldPrioritizeRebuild(section))) {
@@ -451,6 +452,12 @@ public class RenderSectionManager {
                 section.setPendingUpdate(pendingUpdate);
 
                 this.needsUpdate = true;
+
+                CancellationToken token = section.getBuildCancellationToken();
+                if(token != null) {
+                    token.setCancelled();
+                    section.setBuildCancellationToken(null); // to allow queuing it again
+                }
             }
         }
     }


### PR DESCRIPTION
If the following sequence of events takes place:

* A chunk section is loaded and scheduled for an initial build (including creation of the world snapshot).
* A block update, etc. attempts to schedule the section for re-rendering.
* The initial build of the section completes.

it appears that the section is never actually built a second time with the new information. This causes problems with mods like AE2, which render disconnected cables initially and then connect them with a block update later. When Sodium is installed, and with a PC of the correct speed, it's possible to reliably reproduce behavior in which the cables remain visually disconnected (despite their hitbox changing) until F3+A is run manually. I was also able to make the reproduction more reliable by artificially adding a 2 second delay to chunk meshing tasks.

After several hours of tinkering and analysis, I believe I've found the culprit: the section manager explicitly avoids scheduling render updates for chunks which are not marked as built. This behavior seems incorrect; we need to process block updates as soon as the section has been added to our tracker and a snapshot of its data has been taken.

I've thus changed the logic to always schedule the block update even for non-null sections. On my system this appears to have fixed the issue, but I would like someone more familiar with the chunk tracker to validate that this does not violate some other invariant.