### PR TITLE
Improve fog shader parity to match vanilla

### DIFF
--- a/src/main/resources/assets/sodium/shaders/include/fog.glsl
+++ b/src/main/resources/assets/sodium/shaders/include/fog.glsl
@@ -3,8 +3,11 @@ const int FOG_SHAPE_CYLINDRICAL = 1;
 
 vec4 _linearFog(vec4 fragColor, float fragDistance, vec4 fogColor, float fogStart, float fogEnd) {
 #ifdef USE_FOG
-    float factor = smoothstep(fogStart, fogEnd, fragDistance * fogColor.a); // alpha value of fog is used as a weight
-    vec3 blended = mix(fragColor.rgb, fogColor.rgb, factor);
+    if (fragDistance <= fogStart) {
+        return fragColor;
+    }
+    float factor = fragDistance < fogEnd ? smoothstep(fogStart, fogEnd, fragDistance) : 1.0; // alpha value of fog is used as a weight
+    vec3 blended = mix(fragColor.rgb, fogColor.rgb, factor * fogColor.a);
 
     return vec4(blended, fragColor.a); // alpha value of fragment cannot be modified
 #else


### PR DESCRIPTION
This PR fixes a parity issue between the Sodium and vanilla fog shaders in the (admittedly undefined) case that `fogEnd < fogStart`. In this scenario, the original Sodium shader appears to produce fog filling the screen, while vanilla simply renders no fog at all. This appears to be caused by the conditional checks which were present in the vanilla function being removed.

I fixed this issue by restoring the conditionals, and also took the opportunity to fix the alpha component of the fog color being multiplied in the wrong place, as pointed out by a [user on Discord](https://discord.com/channels/602796788608401408/651120262129123330/1130164121145462804), and verbally endorsed by JellySquid at the time.

The new function appears to give identical results to vanilla.