### PR TITLE
More VertexBufferWriter fallbacks

### DIFF
--- a/src/api/java/net/caffeinemc/mods/sodium/api/vertex/buffer/VertexBufferWriter.java
+++ b/src/api/java/net/caffeinemc/mods/sodium/api/vertex/buffer/VertexBufferWriter.java
@@ -63,7 +63,9 @@ public interface VertexBufferWriter {
      */
     void push(MemoryStack stack, long ptr, int count, VertexFormatDescription format);
 
-    boolean isFullWriter();
+    default boolean isFullWriter() {
+        return true;
+    }
 
     /**
      * Creates a copy of the source data and pushes it into the specified {@param writer}. This is useful for when

--- a/src/api/java/net/caffeinemc/mods/sodium/api/vertex/buffer/VertexBufferWriter.java
+++ b/src/api/java/net/caffeinemc/mods/sodium/api/vertex/buffer/VertexBufferWriter.java
@@ -15,7 +15,7 @@ public interface VertexBufferWriter {
      * @throws IllegalArgumentException If the vertex consumer does not implement the necessary interface
      */
     static VertexBufferWriter of(VertexConsumer consumer) {
-        if (consumer instanceof VertexBufferWriter writer) {
+        if (consumer instanceof VertexBufferWriter writer && writer.isFullWriter()) {
             return writer;
         }
 
@@ -31,7 +31,7 @@ public interface VertexBufferWriter {
      */
     @Nullable
     static VertexBufferWriter tryOf(VertexConsumer consumer) {
-        if (consumer instanceof VertexBufferWriter writer) {
+        if (consumer instanceof VertexBufferWriter writer && writer.isFullWriter()) {
             return writer;
         }
 
@@ -62,6 +62,8 @@ public interface VertexBufferWriter {
      * @param format The format of the vertices
      */
     void push(MemoryStack stack, long ptr, int count, VertexFormatDescription format);
+
+    boolean isFullWriter();
 
     /**
      * Creates a copy of the source data and pushes it into the specified {@param writer}. This is useful for when

--- a/src/api/java/net/caffeinemc/mods/sodium/api/vertex/buffer/VertexBufferWriter.java
+++ b/src/api/java/net/caffeinemc/mods/sodium/api/vertex/buffer/VertexBufferWriter.java
@@ -15,7 +15,7 @@ public interface VertexBufferWriter {
      * @throws IllegalArgumentException If the vertex consumer does not implement the necessary interface
      */
     static VertexBufferWriter of(VertexConsumer consumer) {
-        if (consumer instanceof VertexBufferWriter writer && writer.isFullWriter()) {
+        if (consumer instanceof VertexBufferWriter writer && writer.canUseIntrinsics()) {
             return writer;
         }
 
@@ -31,7 +31,7 @@ public interface VertexBufferWriter {
      */
     @Nullable
     static VertexBufferWriter tryOf(VertexConsumer consumer) {
-        if (consumer instanceof VertexBufferWriter writer && writer.isFullWriter()) {
+        if (consumer instanceof VertexBufferWriter writer && writer.canUseIntrinsics()) {
             return writer;
         }
 
@@ -63,7 +63,13 @@ public interface VertexBufferWriter {
      */
     void push(MemoryStack stack, long ptr, int count, VertexFormatDescription format);
 
-    default boolean isFullWriter() {
+    /**
+     * If this {@link VertexBufferWriter} passes through data to nested {@link VertexConsumer} implementations,
+     * this method should be implemented to check that the nested implementations also support use of VertexBufferWriter
+     * methods.
+     * @return true if the inner consumer is also a valid {@link VertexBufferWriter} that can use intrinsics
+     */
+    default boolean canUseIntrinsics() {
         return true;
     }
 

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/BufferBuilderMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/BufferBuilderMixin.java
@@ -53,6 +53,11 @@ public abstract class BufferBuilderMixin implements VertexBufferWriter {
     }
 
     @Override
+    public boolean isFullWriter() {
+        return true;
+    }
+
+    @Override
     public void push(MemoryStack stack, long src, int count, VertexFormatDescription format) {
         var length = count * this.stride;
 

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/BufferBuilderMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/BufferBuilderMixin.java
@@ -53,7 +53,7 @@ public abstract class BufferBuilderMixin implements VertexBufferWriter {
     }
 
     @Override
-    public boolean isFullWriter() {
+    public boolean canUseIntrinsics() {
         return true;
     }
 

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/OutlineVertexConsumerMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/OutlineVertexConsumerMixin.java
@@ -12,12 +12,28 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(targets = "net/minecraft/client/render/OutlineVertexConsumerProvider$OutlineVertexConsumer")
 public abstract class OutlineVertexConsumerMixin extends FixedColorVertexConsumer implements VertexBufferWriter {
     @Shadow
     @Final
     private VertexConsumer delegate;
+
+    @Unique
+    private boolean isFullWriter;
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void onInit(CallbackInfo ci) {
+        this.isFullWriter = VertexBufferWriter.tryOf(this.delegate) != null;
+    }
+
+    @Override
+    public boolean isFullWriter() {
+        return this.isFullWriter;
+    }
 
     @Override
     public void push(MemoryStack stack, long ptr, int count, VertexFormatDescription format) {

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/OutlineVertexConsumerMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/OutlineVertexConsumerMixin.java
@@ -23,16 +23,16 @@ public abstract class OutlineVertexConsumerMixin extends FixedColorVertexConsume
     private VertexConsumer delegate;
 
     @Unique
-    private boolean isFullWriter;
+    private boolean canUseIntrinsics;
 
     @Inject(method = "<init>", at = @At("RETURN"))
     private void onInit(CallbackInfo ci) {
-        this.isFullWriter = VertexBufferWriter.tryOf(this.delegate) != null;
+        this.canUseIntrinsics = VertexBufferWriter.tryOf(this.delegate) != null;
     }
 
     @Override
-    public boolean isFullWriter() {
-        return this.isFullWriter;
+    public boolean canUseIntrinsics() {
+        return this.canUseIntrinsics;
     }
 
     @Override

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/OverlayVertexConsumerMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/OverlayVertexConsumerMixin.java
@@ -20,6 +20,9 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(OverlayVertexConsumer.class)
 public class OverlayVertexConsumerMixin implements VertexBufferWriter {
@@ -38,6 +41,19 @@ public class OverlayVertexConsumerMixin implements VertexBufferWriter {
     @Shadow
     @Final
     private float textureScale;
+
+    @Unique
+    private boolean isFullWriter;
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void onInit(CallbackInfo ci) {
+        this.isFullWriter = VertexBufferWriter.tryOf(this.delegate) != null;
+    }
+
+    @Override
+    public boolean isFullWriter() {
+        return this.isFullWriter;
+    }
 
     @Override
     public void push(MemoryStack stack, long ptr, int count, VertexFormatDescription format) {

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/OverlayVertexConsumerMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/OverlayVertexConsumerMixin.java
@@ -43,16 +43,16 @@ public class OverlayVertexConsumerMixin implements VertexBufferWriter {
     private float textureScale;
 
     @Unique
-    private boolean isFullWriter;
+    private boolean canUseIntrinsics;
 
     @Inject(method = "<init>", at = @At("RETURN"))
     private void onInit(CallbackInfo ci) {
-        this.isFullWriter = VertexBufferWriter.tryOf(this.delegate) != null;
+        this.canUseIntrinsics = VertexBufferWriter.tryOf(this.delegate) != null;
     }
 
     @Override
-    public boolean isFullWriter() {
-        return this.isFullWriter;
+    public boolean canUseIntrinsics() {
+        return this.canUseIntrinsics;
     }
 
     @Override

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/SpriteTexturedVertexConsumerMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/SpriteTexturedVertexConsumerMixin.java
@@ -23,6 +23,9 @@ public class SpriteTexturedVertexConsumerMixin implements VertexBufferWriter {
     private VertexConsumer delegate;
 
     @Unique
+    private boolean isFullWriter;
+
+    @Unique
     private float minU, minV;
 
     @Unique
@@ -35,6 +38,13 @@ public class SpriteTexturedVertexConsumerMixin implements VertexBufferWriter {
 
         this.maxU = sprite.getMaxU();
         this.maxV = sprite.getMaxV();
+
+        this.isFullWriter = VertexBufferWriter.tryOf(this.delegate) != null;
+    }
+
+    @Override
+    public boolean isFullWriter() {
+        return this.isFullWriter;
     }
 
     @Override

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/SpriteTexturedVertexConsumerMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/SpriteTexturedVertexConsumerMixin.java
@@ -23,7 +23,7 @@ public class SpriteTexturedVertexConsumerMixin implements VertexBufferWriter {
     private VertexConsumer delegate;
 
     @Unique
-    private boolean isFullWriter;
+    private boolean canUseIntrinsics;
 
     @Unique
     private float minU, minV;
@@ -39,12 +39,12 @@ public class SpriteTexturedVertexConsumerMixin implements VertexBufferWriter {
         this.maxU = sprite.getMaxU();
         this.maxV = sprite.getMaxV();
 
-        this.isFullWriter = VertexBufferWriter.tryOf(this.delegate) != null;
+        this.canUseIntrinsics = VertexBufferWriter.tryOf(this.delegate) != null;
     }
 
     @Override
-    public boolean isFullWriter() {
-        return this.isFullWriter;
+    public boolean canUseIntrinsics() {
+        return this.canUseIntrinsics;
     }
 
     @Override

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/VertexConsumersMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/VertexConsumersMixin.java
@@ -23,16 +23,16 @@ public class VertexConsumersMixin {
         @Final
         private VertexConsumer second;
 
-        private boolean isFullWriter;
+        private boolean canUseIntrinsics;
 
         @Inject(method = "<init>", at = @At("RETURN"))
         private void checkFullStatus(CallbackInfo ci) {
-            this.isFullWriter = VertexBufferWriter.tryOf(this.first) != null && VertexBufferWriter.tryOf(this.second) != null;
+            this.canUseIntrinsics = VertexBufferWriter.tryOf(this.first) != null && VertexBufferWriter.tryOf(this.second) != null;
         }
 
         @Override
-        public boolean isFullWriter() {
-            return this.isFullWriter;
+        public boolean canUseIntrinsics() {
+            return this.canUseIntrinsics;
         }
 
         @Override
@@ -48,7 +48,7 @@ public class VertexConsumersMixin {
         @Final
         private VertexConsumer[] delegates;
 
-        private boolean isFullWriter;
+        private boolean canUseIntrinsics;
 
         @Inject(method = "<init>", at = @At("RETURN"))
         private void checkFullStatus(CallbackInfo ci) {
@@ -59,12 +59,12 @@ public class VertexConsumersMixin {
                     break;
                 }
             }
-            this.isFullWriter = !notWriter;
+            this.canUseIntrinsics = !notWriter;
         }
 
         @Override
-        public boolean isFullWriter() {
-            return this.isFullWriter;
+        public boolean canUseIntrinsics() {
+            return this.canUseIntrinsics;
         }
 
         @Override

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/VertexConsumersMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/VertexConsumersMixin.java
@@ -8,6 +8,7 @@ import org.lwjgl.system.MemoryStack;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -52,14 +53,18 @@ public class VertexConsumersMixin {
 
         @Inject(method = "<init>", at = @At("RETURN"))
         private void checkFullStatus(CallbackInfo ci) {
-            boolean notWriter = false;
-            for(var delegate : this.delegates) {
-                if(VertexBufferWriter.tryOf(delegate) == null) {
-                    notWriter = true;
-                    break;
+            this.canUseIntrinsics = allDelegatesSupportIntrinsics();
+        }
+
+        @Unique
+        private boolean allDelegatesSupportIntrinsics() {
+            for (var delegate : this.delegates) {
+                if (VertexBufferWriter.tryOf(delegate) == null) {
+                    return false;
                 }
             }
-            this.canUseIntrinsics = !notWriter;
+
+            return true;
         }
 
         @Override

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/render/entity/shadows/EntityRenderDispatcherMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/render/entity/shadows/EntityRenderDispatcherMixin.java
@@ -115,8 +115,7 @@ public class EntityRenderDispatcherMixin {
             writeShadowVertex(ptr, matPosition, maxX, minY, minZ, u2, v1, color, normal);
             ptr += ModelVertex.STRIDE;
 
-            writer
-                    .push(stack, buffer, 4, ModelVertex.FORMAT);
+            writer.push(stack, buffer, 4, ModelVertex.FORMAT);
         }
     }
 

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/render/entity/shadows/EntityRenderDispatcherMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/render/entity/shadows/EntityRenderDispatcherMixin.java
@@ -19,7 +19,6 @@ import net.minecraft.world.chunk.Chunk;
 import org.joml.Matrix4f;
 import org.lwjgl.system.MemoryStack;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -82,14 +81,6 @@ public class EntityRenderDispatcherMixin {
 
             renderShadowPart(entry, writer, radius, alpha, minX, maxX, minY, minZ, maxZ);
         }
-    }
-
-    /**
-     * @deprecated don't call, but just in case...
-     */
-    @Deprecated
-    private static void renderShadowPart(MatrixStack.Entry matrices, VertexConsumer consumer, float radius, float alpha, float minX, float maxX, float minY, float minZ, float maxZ) {
-        renderShadowPart(matrices, VertexBufferWriter.of(consumer), radius, alpha, minX, maxX, minY, minZ, maxZ);
     }
 
     @Unique

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/render/entity/shadows/EntityRenderDispatcherMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/render/entity/shadows/EntityRenderDispatcherMixin.java
@@ -1,5 +1,6 @@
 package me.jellysquid.mods.sodium.mixin.features.render.entity.shadows;
 
+import me.jellysquid.mods.sodium.client.render.vertex.VertexConsumerUtils;
 import net.caffeinemc.mods.sodium.api.vertex.buffer.VertexBufferWriter;
 import net.caffeinemc.mods.sodium.api.vertex.format.common.ModelVertex;
 import net.caffeinemc.mods.sodium.api.util.ColorABGR;
@@ -35,10 +36,11 @@ public class EntityRenderDispatcherMixin {
      */
     @Inject(method = "renderShadowPart", at = @At("HEAD"), cancellable = true)
     private static void renderShadowPartFast(MatrixStack.Entry entry, VertexConsumer vertices, Chunk chunk, WorldView world, BlockPos pos, double x, double y, double z, float radius, float opacity, CallbackInfo ci) {
-        var writer = VertexBufferWriter.tryOf(vertices);
+        var writer = VertexConsumerUtils.convertOrLog(vertices);
 
-        if (writer == null)
+        if (writer == null) {
             return;
+        }
 
         ci.cancel();
 

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/render/gui/font/GlyphRendererMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/render/gui/font/GlyphRendererMixin.java
@@ -1,5 +1,6 @@
 package me.jellysquid.mods.sodium.mixin.features.render.gui.font;
 
+import me.jellysquid.mods.sodium.client.render.vertex.VertexConsumerUtils;
 import net.caffeinemc.mods.sodium.api.vertex.format.common.GlyphVertex;
 import net.caffeinemc.mods.sodium.api.vertex.buffer.VertexBufferWriter;
 import net.caffeinemc.mods.sodium.api.util.ColorABGR;
@@ -53,10 +54,11 @@ public class GlyphRendererMixin {
      */
     @Inject(method = "draw", at = @At("HEAD"), cancellable = true)
     private void drawFast(boolean italic, float x, float y, Matrix4f matrix, VertexConsumer vertexConsumer, float red, float green, float blue, float alpha, int light, CallbackInfo ci) {
-        var writer = VertexBufferWriter.tryOf(vertexConsumer);
+        var writer = VertexConsumerUtils.convertOrLog(vertexConsumer);
 
-        if (writer == null)
+        if (writer == null) {
             return;
+        }
 
         ci.cancel();
 

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/render/gui/outlines/WorldRendererMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/render/gui/outlines/WorldRendererMixin.java
@@ -32,8 +32,9 @@ public class WorldRendererMixin {
                                     float xAxisRed, float yAxisGreen, float zAxisBlue, CallbackInfo ci) {
         var writer = VertexConsumerUtils.convertOrLog(vertexConsumer);
 
-        if (writer == null)
+        if (writer == null) {
             return;
+        }
 
         ci.cancel();
 

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/render/gui/outlines/WorldRendererMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/render/gui/outlines/WorldRendererMixin.java
@@ -1,5 +1,6 @@
 package me.jellysquid.mods.sodium.mixin.features.render.gui.outlines;
 
+import me.jellysquid.mods.sodium.client.render.vertex.VertexConsumerUtils;
 import net.caffeinemc.mods.sodium.api.vertex.format.common.LineVertex;
 import net.caffeinemc.mods.sodium.api.vertex.buffer.VertexBufferWriter;
 import net.caffeinemc.mods.sodium.api.util.NormI8;
@@ -29,7 +30,7 @@ public class WorldRendererMixin {
     private static void drawBoxFast(MatrixStack matrices, VertexConsumer vertexConsumer, double x1, double y1, double z1,
                                     double x2, double y2, double z2, float red, float green, float blue, float alpha,
                                     float xAxisRed, float yAxisGreen, float zAxisBlue, CallbackInfo ci) {
-        var writer = VertexBufferWriter.tryOf(vertexConsumer);
+        var writer = VertexConsumerUtils.convertOrLog(vertexConsumer);
 
         if (writer == null)
             return;


### PR DESCRIPTION
This PR implements two changes:

* Expanded usage of the `VertexBufferWriter.tryOf` construct to more of Sodium's mixins, to prevent crashes with mods that call vanilla methods with a class only implementing `VertexConsumer` and not `VertexBufferWriter`.
* Add API hooks to allow delegating `VertexBufferWriter`s (e.g. `VertexConsumer.Dual`) to verify that their delegate is also a `VertexBufferWriter`. Without this `tryOf` does not work correctly with mods that wrap their own VC with one of the delegating types.