### PR TITLE
Reintroduce optional full-precision vertex format

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gl/tessellation/TessellationBinding.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gl/tessellation/TessellationBinding.java
@@ -4,10 +4,13 @@ import me.jellysquid.mods.sodium.client.gl.attribute.GlVertexAttributeBinding;
 import me.jellysquid.mods.sodium.client.gl.buffer.GlBuffer;
 import me.jellysquid.mods.sodium.client.gl.buffer.GlBufferTarget;
 
+import java.util.Objects;
+
 public record TessellationBinding(GlBufferTarget target,
                                   GlBuffer buffer,
                                   GlVertexAttributeBinding[] attributeBindings) {
     public static TessellationBinding forVertexBuffer(GlBuffer buffer, GlVertexAttributeBinding[] attributes) {
+        Objects.requireNonNull(attributes);
         return new TessellationBinding(GlBufferTarget.ARRAY_BUFFER, buffer, attributes);
     }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -1,6 +1,7 @@
 package me.jellysquid.mods.sodium.client.gui;
 
 import com.google.common.collect.ImmutableList;
+import me.jellysquid.mods.sodium.client.SodiumClientMod;
 import me.jellysquid.mods.sodium.client.gl.arena.staging.MappedStagingBuffer;
 import me.jellysquid.mods.sodium.client.gl.device.RenderDevice;
 import me.jellysquid.mods.sodium.client.gui.options.*;
@@ -270,6 +271,17 @@ public class SodiumGameOptionPages {
                         .setControl(TickBoxControl::new)
                         .setImpact(OptionImpact.MEDIUM)
                         .setBinding((opts, value) -> opts.performance.useBlockFaceCulling = value, opts -> opts.performance.useBlockFaceCulling)
+                        .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)
+                        .build()
+                )
+                .add(OptionImpl.createBuilder(boolean.class, sodiumOpts)
+                        .setName(Text.translatable("sodium.options.use_compact_vertex_format.name"))
+                        .setTooltip(Text.translatable("sodium.options.use_compact_vertex_format.tooltip"))
+                        .setControl(TickBoxControl::new)
+                        .setImpact(OptionImpact.MEDIUM)
+                        .setBinding((opts, value) -> {
+                            opts.performance.useCompactVertexFormat = value;
+                        }, opts -> opts.performance.useCompactVertexFormat)
                         .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)
                         .build()
                 )

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -44,6 +44,7 @@ public class SodiumGameOptions {
         public boolean useEntityCulling = true;
         public boolean useFogOcclusion = true;
         public boolean useBlockFaceCulling = true;
+        public boolean useCompactVertexFormat = true;
         public boolean useNoErrorGLContext = true;
     }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/DefaultChunkRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/DefaultChunkRenderer.java
@@ -23,7 +23,7 @@ import me.jellysquid.mods.sodium.client.render.chunk.terrain.TerrainRenderPass;
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkMeshAttribute;
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkMeshFormats;
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexType;
-import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.VanillaLikeChunkMeshAttribute;
+import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.StandardChunkMeshAttribute;
 import me.jellysquid.mods.sodium.client.render.viewport.CameraTransform;
 import me.jellysquid.mods.sodium.client.util.BitwiseMath;
 import org.lwjgl.system.MemoryUtil;
@@ -232,16 +232,16 @@ public class DefaultChunkRenderer extends ShaderChunkRenderer {
                             compactFormat.getAttribute(ChunkMeshAttribute.VERTEX_DATA))
             };
         } else if (this.vertexType == ChunkMeshFormats.VANILLA_LIKE) {
-            GlVertexFormat<VanillaLikeChunkMeshAttribute> vanillaFormat = (GlVertexFormat<VanillaLikeChunkMeshAttribute>)this.vertexFormat;
+            GlVertexFormat<StandardChunkMeshAttribute> vanillaFormat = (GlVertexFormat<StandardChunkMeshAttribute>)this.vertexFormat;
             return new GlVertexAttributeBinding[] {
                     new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_POSITION,
-                            vanillaFormat.getAttribute(VanillaLikeChunkMeshAttribute.POSITION)),
+                            vanillaFormat.getAttribute(StandardChunkMeshAttribute.POSITION)),
                     new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_COLOR,
-                            vanillaFormat.getAttribute(VanillaLikeChunkMeshAttribute.COLOR)),
+                            vanillaFormat.getAttribute(StandardChunkMeshAttribute.COLOR)),
                     new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_TEXTURE_UV,
-                            vanillaFormat.getAttribute(VanillaLikeChunkMeshAttribute.TEXTURE_UV)),
+                            vanillaFormat.getAttribute(StandardChunkMeshAttribute.TEXTURE_UV)),
                     new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_DRAW_PARAMS_LIGHT,
-                            vanillaFormat.getAttribute(VanillaLikeChunkMeshAttribute.DRAW_PARAMS_LIGHT)),
+                            vanillaFormat.getAttribute(StandardChunkMeshAttribute.DRAW_PARAMS_LIGHT)),
             };
         } else {
             return null; // assume Oculus/Iris will take over

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/DefaultChunkRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/DefaultChunkRenderer.java
@@ -240,10 +240,8 @@ public class DefaultChunkRenderer extends ShaderChunkRenderer {
                             vanillaFormat.getAttribute(VanillaLikeChunkMeshAttribute.COLOR)),
                     new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_TEXTURE_UV,
                             vanillaFormat.getAttribute(VanillaLikeChunkMeshAttribute.TEXTURE_UV)),
-                    new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_DRAW_PARAMS,
-                            vanillaFormat.getAttribute(VanillaLikeChunkMeshAttribute.DRAW_PARAMS)),
-                    new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_LIGHT,
-                            vanillaFormat.getAttribute(VanillaLikeChunkMeshAttribute.LIGHT))
+                    new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_DRAW_PARAMS_LIGHT,
+                            vanillaFormat.getAttribute(VanillaLikeChunkMeshAttribute.DRAW_PARAMS_LIGHT)),
             };
         } else
             return null; // assume Oculus/Iris will take over

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/DefaultChunkRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/DefaultChunkRenderer.java
@@ -225,13 +225,13 @@ public class DefaultChunkRenderer extends ShaderChunkRenderer {
     }
 
     private GlVertexAttributeBinding[] getBindingsForType() {
-        if(this.vertexType == ChunkMeshFormats.COMPACT) {
+        if (this.vertexType == ChunkMeshFormats.COMPACT) {
             GlVertexFormat<ChunkMeshAttribute> compactFormat = (GlVertexFormat<ChunkMeshAttribute>)this.vertexFormat;
             return new GlVertexAttributeBinding[] {
                     new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_PACKED_DATA,
                             compactFormat.getAttribute(ChunkMeshAttribute.VERTEX_DATA))
             };
-        } else if(this.vertexType == ChunkMeshFormats.VANILLA_LIKE) {
+        } else if (this.vertexType == ChunkMeshFormats.VANILLA_LIKE) {
             GlVertexFormat<VanillaLikeChunkMeshAttribute> vanillaFormat = (GlVertexFormat<VanillaLikeChunkMeshAttribute>)this.vertexFormat;
             return new GlVertexAttributeBinding[] {
                     new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_POSITION,
@@ -243,8 +243,9 @@ public class DefaultChunkRenderer extends ShaderChunkRenderer {
                     new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_DRAW_PARAMS_LIGHT,
                             vanillaFormat.getAttribute(VanillaLikeChunkMeshAttribute.DRAW_PARAMS_LIGHT)),
             };
-        } else
+        } else {
             return null; // assume Oculus/Iris will take over
+        }
     }
 
     private GlTessellation createRegionTessellation(CommandList commandList, RenderRegion.DeviceResources resources) {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/DefaultChunkRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/DefaultChunkRenderer.java
@@ -236,12 +236,14 @@ public class DefaultChunkRenderer extends ShaderChunkRenderer {
             return new GlVertexAttributeBinding[] {
                     new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_POSITION,
                             vanillaFormat.getAttribute(VanillaLikeChunkMeshAttribute.POSITION)),
-                    new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_COLOR_LIGHT,
-                            vanillaFormat.getAttribute(VanillaLikeChunkMeshAttribute.COLOR_LIGHT)),
+                    new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_COLOR,
+                            vanillaFormat.getAttribute(VanillaLikeChunkMeshAttribute.COLOR)),
                     new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_TEXTURE_UV,
                             vanillaFormat.getAttribute(VanillaLikeChunkMeshAttribute.TEXTURE_UV)),
                     new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_DRAW_PARAMS,
                             vanillaFormat.getAttribute(VanillaLikeChunkMeshAttribute.DRAW_PARAMS)),
+                    new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_LIGHT,
+                            vanillaFormat.getAttribute(VanillaLikeChunkMeshAttribute.LIGHT))
             };
         } else
             return null; // assume Oculus/Iris will take over

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -26,6 +26,7 @@ import me.jellysquid.mods.sodium.client.render.chunk.region.RenderRegion;
 import me.jellysquid.mods.sodium.client.render.chunk.region.RenderRegionManager;
 import me.jellysquid.mods.sodium.client.render.chunk.terrain.TerrainRenderPass;
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkMeshFormats;
+import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexType;
 import me.jellysquid.mods.sodium.client.render.texture.SpriteUtil;
 import me.jellysquid.mods.sodium.client.render.viewport.CameraTransform;
 import me.jellysquid.mods.sodium.client.render.viewport.Viewport;
@@ -69,6 +70,8 @@ public class RenderSectionManager {
 
     private final int renderDistance;
 
+    private final ChunkVertexType vertexType;
+
     @NotNull
     private SortedRenderLists renderLists;
 
@@ -82,10 +85,14 @@ public class RenderSectionManager {
     private @Nullable BlockPos lastCameraPosition;
 
     public RenderSectionManager(ClientWorld world, int renderDistance, CommandList commandList) {
-        this.chunkRenderer = new DefaultChunkRenderer(RenderDevice.INSTANCE, ChunkMeshFormats.COMPACT);
+        ChunkVertexType vertexType = SodiumClientMod.options().performance.useCompactVertexFormat ? ChunkMeshFormats.COMPACT : ChunkMeshFormats.VANILLA_LIKE;
+
+        this.chunkRenderer = new DefaultChunkRenderer(RenderDevice.INSTANCE, vertexType);
+
+        this.vertexType = vertexType;
 
         this.world = world;
-        this.builder = new ChunkBuilder(world, ChunkMeshFormats.COMPACT);
+        this.builder = new ChunkBuilder(world, vertexType);
 
         this.needsUpdate = true;
         this.renderDistance = renderDistance;
@@ -574,5 +581,9 @@ public class RenderSectionManager {
 
     public Collection<RenderSection> getSectionsWithGlobalEntities() {
         return ReferenceSets.unmodifiable(this.sectionsWithGlobalEntities);
+    }
+
+    public ChunkVertexType getVertexType() {
+        return this.vertexType;
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ShaderChunkRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ShaderChunkRenderer.java
@@ -39,11 +39,11 @@ public abstract class ShaderChunkRenderer implements ChunkRenderer {
         return program;
     }
 
-    private GlProgram.Builder bindAttributesForType(GlProgram.Builder builder) {
+    private void bindAttributesForType(GlProgram.Builder builder) {
         if (this.vertexType == ChunkMeshFormats.COMPACT) {
-            return builder.bindAttribute("in_VertexData", ChunkShaderBindingPoints.ATTRIBUTE_PACKED_DATA);
+            builder.bindAttribute("in_VertexData", ChunkShaderBindingPoints.ATTRIBUTE_PACKED_DATA);
         } else if (this.vertexType == ChunkMeshFormats.VANILLA_LIKE) {
-            return builder
+            builder
                     .bindAttribute("in_Pos", ChunkShaderBindingPoints.ATTRIBUTE_POSITION)
                     .bindAttribute("in_Color", ChunkShaderBindingPoints.ATTRIBUTE_COLOR)
                     .bindAttribute("in_TextureUv", ChunkShaderBindingPoints.ATTRIBUTE_TEXTURE_UV)
@@ -63,9 +63,12 @@ public abstract class ShaderChunkRenderer implements ChunkRenderer {
                 new Identifier("sodium", path + ".fsh"), constants);
 
         try {
-            return bindAttributesForType(GlProgram.builder(new Identifier("sodium", "chunk_shader"))
+            var builder = GlProgram.builder(new Identifier("sodium", "chunk_shader"))
                     .attachShader(vertShader)
-                    .attachShader(fragShader))
+                    .attachShader(fragShader);
+            bindAttributesForType(builder);
+
+            return builder
                     .bindFragmentData("out_FragColor", ChunkShaderBindingPoints.FRAG_COLOR)
                     .link((shader) -> new ChunkShaderInterface(shader, options));
         } finally {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ShaderChunkRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ShaderChunkRenderer.java
@@ -45,9 +45,10 @@ public abstract class ShaderChunkRenderer implements ChunkRenderer {
         } else if (this.vertexType == ChunkMeshFormats.VANILLA_LIKE) {
             return builder
                     .bindAttribute("in_Pos", ChunkShaderBindingPoints.ATTRIBUTE_POSITION)
-                    .bindAttribute("in_ColorLight", ChunkShaderBindingPoints.ATTRIBUTE_COLOR_LIGHT)
+                    .bindAttribute("in_Color", ChunkShaderBindingPoints.ATTRIBUTE_COLOR)
                     .bindAttribute("in_TextureUv", ChunkShaderBindingPoints.ATTRIBUTE_TEXTURE_UV)
-                    .bindAttribute("in_DrawParams", ChunkShaderBindingPoints.ATTRIBUTE_DRAW_PARAMS);
+                    .bindAttribute("in_DrawParams", ChunkShaderBindingPoints.ATTRIBUTE_DRAW_PARAMS)
+                    .bindAttribute("in_Light", ChunkShaderBindingPoints.ATTRIBUTE_LIGHT);
         } else
             throw new IllegalArgumentException("Unexpected vertex type");
     }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ShaderChunkRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ShaderChunkRenderer.java
@@ -48,8 +48,9 @@ public abstract class ShaderChunkRenderer implements ChunkRenderer {
                     .bindAttribute("in_Color", ChunkShaderBindingPoints.ATTRIBUTE_COLOR)
                     .bindAttribute("in_TextureUv", ChunkShaderBindingPoints.ATTRIBUTE_TEXTURE_UV)
                     .bindAttribute("in_DrawParamsLight", ChunkShaderBindingPoints.ATTRIBUTE_DRAW_PARAMS_LIGHT);
-        } else
+        } else {
             throw new IllegalArgumentException("Unexpected vertex type");
+        }
     }
 
     private GlProgram<ChunkShaderInterface> createShader(String path, ChunkShaderOptions options) {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ShaderChunkRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/ShaderChunkRenderer.java
@@ -47,8 +47,7 @@ public abstract class ShaderChunkRenderer implements ChunkRenderer {
                     .bindAttribute("in_Pos", ChunkShaderBindingPoints.ATTRIBUTE_POSITION)
                     .bindAttribute("in_Color", ChunkShaderBindingPoints.ATTRIBUTE_COLOR)
                     .bindAttribute("in_TextureUv", ChunkShaderBindingPoints.ATTRIBUTE_TEXTURE_UV)
-                    .bindAttribute("in_DrawParams", ChunkShaderBindingPoints.ATTRIBUTE_DRAW_PARAMS)
-                    .bindAttribute("in_Light", ChunkShaderBindingPoints.ATTRIBUTE_LIGHT);
+                    .bindAttribute("in_DrawParamsLight", ChunkShaderBindingPoints.ATTRIBUTE_DRAW_PARAMS_LIGHT);
         } else
             throw new IllegalArgumentException("Unexpected vertex type");
     }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/region/RenderRegion.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/region/RenderRegion.java
@@ -1,11 +1,13 @@
 package me.jellysquid.mods.sodium.client.render.chunk.region;
 
 import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
+import me.jellysquid.mods.sodium.client.SodiumClientMod;
 import me.jellysquid.mods.sodium.client.gl.arena.GlBufferArena;
 import me.jellysquid.mods.sodium.client.gl.arena.staging.StagingBuffer;
 import me.jellysquid.mods.sodium.client.gl.buffer.GlBuffer;
 import me.jellysquid.mods.sodium.client.gl.device.CommandList;
 import me.jellysquid.mods.sodium.client.gl.tessellation.GlTessellation;
+import me.jellysquid.mods.sodium.client.render.SodiumWorldRenderer;
 import me.jellysquid.mods.sodium.client.render.chunk.RenderSection;
 import me.jellysquid.mods.sodium.client.render.chunk.data.SectionRenderDataStorage;
 import me.jellysquid.mods.sodium.client.render.chunk.lists.ChunkRenderList;
@@ -192,7 +194,15 @@ public class RenderRegion {
         private GlTessellation tessellation;
 
         public DeviceResources(CommandList commandList, StagingBuffer stagingBuffer) {
-            int stride = ChunkMeshFormats.COMPACT.getVertexFormat().getStride();
+            int stride;
+            if(SodiumClientMod.options().performance.useCompactVertexFormat) {
+                // this line must be left unchanged for
+                // https://github.com/IrisShaders/Iris/blob/1.20.1/src/sodiumCompatibility/java/net/coderbot/iris/compat/sodium/mixin/vertex_format/MixinRenderRegionArenas.java
+                // to apply without an error
+                stride = ChunkMeshFormats.COMPACT.getVertexFormat().getStride();
+            } else {
+                stride = ChunkMeshFormats.VANILLA_LIKE.getVertexFormat().getStride();
+            }
             this.geometryArena = new GlBufferArena(commandList, REGION_SIZE * 756, stride, stagingBuffer);
         }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/shader/ChunkShaderBindingPoints.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/shader/ChunkShaderBindingPoints.java
@@ -6,9 +6,10 @@ public class ChunkShaderBindingPoints {
 
     // full
     public static final int ATTRIBUTE_POSITION = 1;
-    public static final int ATTRIBUTE_COLOR_LIGHT = 2;
+    public static final int ATTRIBUTE_COLOR = 2;
     public static final int ATTRIBUTE_TEXTURE_UV = 3;
     public static final int ATTRIBUTE_DRAW_PARAMS = 4;
+    public static final int ATTRIBUTE_LIGHT = 5;
 
     public static final int FRAG_COLOR = 0;
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/shader/ChunkShaderBindingPoints.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/shader/ChunkShaderBindingPoints.java
@@ -1,7 +1,14 @@
 package me.jellysquid.mods.sodium.client.render.chunk.shader;
 
 public class ChunkShaderBindingPoints {
+    // compact
     public static final int ATTRIBUTE_PACKED_DATA = 1;
+
+    // full
+    public static final int ATTRIBUTE_POSITION = 1;
+    public static final int ATTRIBUTE_COLOR_LIGHT = 2;
+    public static final int ATTRIBUTE_TEXTURE_UV = 3;
+    public static final int ATTRIBUTE_DRAW_PARAMS = 4;
 
     public static final int FRAG_COLOR = 0;
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/shader/ChunkShaderBindingPoints.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/shader/ChunkShaderBindingPoints.java
@@ -8,8 +8,7 @@ public class ChunkShaderBindingPoints {
     public static final int ATTRIBUTE_POSITION = 1;
     public static final int ATTRIBUTE_COLOR = 2;
     public static final int ATTRIBUTE_TEXTURE_UV = 3;
-    public static final int ATTRIBUTE_DRAW_PARAMS = 4;
-    public static final int ATTRIBUTE_LIGHT = 5;
+    public static final int ATTRIBUTE_DRAW_PARAMS_LIGHT = 4;
 
     public static final int FRAG_COLOR = 0;
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/shader/ChunkShaderOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/shader/ChunkShaderOptions.java
@@ -2,19 +2,9 @@ package me.jellysquid.mods.sodium.client.render.chunk.shader;
 
 import me.jellysquid.mods.sodium.client.gl.shader.ShaderConstants;
 import me.jellysquid.mods.sodium.client.render.chunk.terrain.TerrainRenderPass;
-import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkMeshFormats;
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexType;
 
 public record ChunkShaderOptions(ChunkFogMode fog, TerrainRenderPass pass, ChunkVertexType type) {
-    /**
-     * @deprecated Only kept for Iris/Oculus compatibility, do not use
-     */
-    @Deprecated
-    @SuppressWarnings("unused")
-    public ChunkShaderOptions(ChunkFogMode fog, TerrainRenderPass pass) {
-        this(fog, pass, ChunkMeshFormats.COMPACT);
-    }
-
     public ShaderConstants constants() {
         ShaderConstants.Builder constants = ShaderConstants.builder();
         constants.addAll(this.fog.getDefines());

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/shader/ChunkShaderOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/shader/ChunkShaderOptions.java
@@ -2,11 +2,23 @@ package me.jellysquid.mods.sodium.client.render.chunk.shader;
 
 import me.jellysquid.mods.sodium.client.gl.shader.ShaderConstants;
 import me.jellysquid.mods.sodium.client.render.chunk.terrain.TerrainRenderPass;
+import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkMeshFormats;
+import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexType;
 
-public record ChunkShaderOptions(ChunkFogMode fog, TerrainRenderPass pass) {
+public record ChunkShaderOptions(ChunkFogMode fog, TerrainRenderPass pass, ChunkVertexType type) {
+    /**
+     * @deprecated Only kept for Iris/Oculus compatibility, do not use
+     */
+    @Deprecated
+    @SuppressWarnings("unused")
+    public ChunkShaderOptions(ChunkFogMode fog, TerrainRenderPass pass) {
+        this(fog, pass, ChunkMeshFormats.COMPACT);
+    }
+
     public ShaderConstants constants() {
         ShaderConstants.Builder constants = ShaderConstants.builder();
         constants.addAll(this.fog.getDefines());
+        constants.add(this.type.getDefine());
 
         if (this.pass.supportsFragmentDiscard()) {
             constants.add("USE_FRAGMENT_DISCARD");

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/ChunkMeshAttribute.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/ChunkMeshAttribute.java
@@ -1,5 +1,8 @@
 package me.jellysquid.mods.sodium.client.render.chunk.vertex.format;
 
 public enum ChunkMeshAttribute {
+    /**
+     * Packed 16 byte (i.e. uvec4) representation of vertex data, used by CompactChunkVertex.
+     */
     VERTEX_DATA
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/ChunkMeshFormats.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/ChunkMeshFormats.java
@@ -1,9 +1,9 @@
 package me.jellysquid.mods.sodium.client.render.chunk.vertex.format;
 
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.impl.CompactChunkVertex;
-import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.impl.VanillaLikeChunkVertex;
+import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.impl.StandardChunkVertex;
 
 public class ChunkMeshFormats {
     public static final ChunkVertexType COMPACT = new CompactChunkVertex();
-    public static final ChunkVertexType VANILLA_LIKE = new VanillaLikeChunkVertex();
+    public static final ChunkVertexType VANILLA_LIKE = new StandardChunkVertex();
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/ChunkMeshFormats.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/ChunkMeshFormats.java
@@ -1,7 +1,9 @@
 package me.jellysquid.mods.sodium.client.render.chunk.vertex.format;
 
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.impl.CompactChunkVertex;
+import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.impl.VanillaLikeChunkVertex;
 
 public class ChunkMeshFormats {
     public static final ChunkVertexType COMPACT = new CompactChunkVertex();
+    public static final ChunkVertexType VANILLA_LIKE = new VanillaLikeChunkVertex();
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/ChunkVertexType.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/ChunkVertexType.java
@@ -3,7 +3,11 @@ package me.jellysquid.mods.sodium.client.render.chunk.vertex.format;
 import me.jellysquid.mods.sodium.client.gl.attribute.GlVertexFormat;
 
 public interface ChunkVertexType {
-    GlVertexFormat<ChunkMeshAttribute> getVertexFormat();
+    GlVertexFormat<?> getVertexFormat();
 
     ChunkVertexEncoder getEncoder();
+
+    default String getDefine() {
+        return "VERTEX_FORMAT_COMPACT"; // as in original Sodium all vertex formats would use this mode
+    }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/StandardChunkMeshAttribute.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/StandardChunkMeshAttribute.java
@@ -1,7 +1,7 @@
 package me.jellysquid.mods.sodium.client.render.chunk.vertex.format;
 
-public enum VanillaLikeChunkMeshAttribute {
-    // Expanded attributes, used by VanillaLikeChunkVertex
+public enum StandardChunkMeshAttribute {
+    // Expanded attributes, used by StandardChunkVertex
     POSITION,
     COLOR,
     TEXTURE_UV,

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/VanillaLikeChunkMeshAttribute.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/VanillaLikeChunkMeshAttribute.java
@@ -1,0 +1,9 @@
+package me.jellysquid.mods.sodium.client.render.chunk.vertex.format;
+
+public enum VanillaLikeChunkMeshAttribute {
+    // Expanded attributes, used by VanillaLikeChunkVertex
+    POSITION,
+    COLOR_LIGHT,
+    TEXTURE_UV,
+    DRAW_PARAMS
+}

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/VanillaLikeChunkMeshAttribute.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/VanillaLikeChunkMeshAttribute.java
@@ -3,7 +3,8 @@ package me.jellysquid.mods.sodium.client.render.chunk.vertex.format;
 public enum VanillaLikeChunkMeshAttribute {
     // Expanded attributes, used by VanillaLikeChunkVertex
     POSITION,
-    COLOR_LIGHT,
+    COLOR,
     TEXTURE_UV,
-    DRAW_PARAMS
+    DRAW_PARAMS,
+    LIGHT
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/VanillaLikeChunkMeshAttribute.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/VanillaLikeChunkMeshAttribute.java
@@ -5,6 +5,5 @@ public enum VanillaLikeChunkMeshAttribute {
     POSITION,
     COLOR,
     TEXTURE_UV,
-    DRAW_PARAMS,
-    LIGHT
+    DRAW_PARAMS_LIGHT
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/impl/StandardChunkVertex.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/impl/StandardChunkVertex.java
@@ -5,7 +5,7 @@ import me.jellysquid.mods.sodium.client.gl.attribute.GlVertexFormat;
 import me.jellysquid.mods.sodium.client.render.chunk.terrain.material.Material;
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexEncoder;
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexType;
-import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.VanillaLikeChunkMeshAttribute;
+import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.StandardChunkMeshAttribute;
 import net.caffeinemc.mods.sodium.api.util.ColorABGR;
 import net.caffeinemc.mods.sodium.api.util.ColorU8;
 import org.lwjgl.system.MemoryUtil;
@@ -14,20 +14,20 @@ import org.lwjgl.system.MemoryUtil;
  * This vertex format is less performant and uses more VRAM than {@link CompactChunkVertex}, but should be completely
  * compatible with mods & resource packs that need high precision for models.
  */
-public class VanillaLikeChunkVertex implements ChunkVertexType {
+public class StandardChunkVertex implements ChunkVertexType {
     public static final int STRIDE = 24;
 
     private static final int TEXTURE_MAX_VALUE = 65536;
 
-    public static final GlVertexFormat<VanillaLikeChunkMeshAttribute> VERTEX_FORMAT = GlVertexFormat.builder(VanillaLikeChunkMeshAttribute.class, STRIDE)
-            .addElement(VanillaLikeChunkMeshAttribute.POSITION, 0, GlVertexAttributeFormat.FLOAT, 3, false, false)
-            .addElement(VanillaLikeChunkMeshAttribute.COLOR, 12, GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true)
-            .addElement(VanillaLikeChunkMeshAttribute.TEXTURE_UV, 16, GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true)
-            .addElement(VanillaLikeChunkMeshAttribute.DRAW_PARAMS_LIGHT, 20, GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true)
+    public static final GlVertexFormat<StandardChunkMeshAttribute> VERTEX_FORMAT = GlVertexFormat.builder(StandardChunkMeshAttribute.class, STRIDE)
+            .addElement(StandardChunkMeshAttribute.POSITION, 0, GlVertexAttributeFormat.FLOAT, 3, false, false)
+            .addElement(StandardChunkMeshAttribute.COLOR, 12, GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true)
+            .addElement(StandardChunkMeshAttribute.TEXTURE_UV, 16, GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true)
+            .addElement(StandardChunkMeshAttribute.DRAW_PARAMS_LIGHT, 20, GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true)
             .build();
 
     @Override
-    public GlVertexFormat<VanillaLikeChunkMeshAttribute> getVertexFormat() {
+    public GlVertexFormat<StandardChunkMeshAttribute> getVertexFormat() {
         return VERTEX_FORMAT;
     }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/impl/VanillaLikeChunkVertex.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/impl/VanillaLikeChunkVertex.java
@@ -23,8 +23,7 @@ public class VanillaLikeChunkVertex implements ChunkVertexType {
             .addElement(VanillaLikeChunkMeshAttribute.POSITION, 0, GlVertexAttributeFormat.FLOAT, 3, false, false)
             .addElement(VanillaLikeChunkMeshAttribute.COLOR, 12, GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true)
             .addElement(VanillaLikeChunkMeshAttribute.TEXTURE_UV, 16, GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true)
-            .addElement(VanillaLikeChunkMeshAttribute.DRAW_PARAMS, 20, GlVertexAttributeFormat.UNSIGNED_SHORT, 1, false, true)
-            .addElement(VanillaLikeChunkMeshAttribute.LIGHT, 22, GlVertexAttributeFormat.UNSIGNED_SHORT, 1, false, true)
+            .addElement(VanillaLikeChunkMeshAttribute.DRAW_PARAMS_LIGHT, 20, GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true)
             .build();
 
     @Override
@@ -40,8 +39,7 @@ public class VanillaLikeChunkVertex implements ChunkVertexType {
             MemoryUtil.memPutFloat(ptr + 8, vertex.z);
             MemoryUtil.memPutInt(ptr + 12, encodeColor(vertex.color));
             MemoryUtil.memPutInt(ptr + 16, (encodeTexture(vertex.u) << 0) | (encodeTexture(vertex.v) << 16));
-            MemoryUtil.memPutShort(ptr + 20, encodeDrawParameters(material, sectionIndex));
-            MemoryUtil.memPutShort(ptr + 22, encodeLight(vertex.light));
+            MemoryUtil.memPutInt(ptr + 20, (encodeDrawParameters(material, sectionIndex) << 0) | (encodeLight(vertex.light) << 16));
 
             return ptr + STRIDE;
         };
@@ -52,8 +50,8 @@ public class VanillaLikeChunkVertex implements ChunkVertexType {
         return "VERTEX_FORMAT_FULL";
     }
 
-    private static short encodeDrawParameters(Material material, int sectionIndex) {
-        return (short)(((sectionIndex & 0xFF) << 8) | ((material.bits() & 0xFF) << 0));
+    private static int encodeDrawParameters(Material material, int sectionIndex) {
+        return (((sectionIndex & 0xFF) << 8) | ((material.bits() & 0xFF) << 0));
     }
 
     private static int encodeColor(int color) {
@@ -66,10 +64,10 @@ public class VanillaLikeChunkVertex implements ChunkVertexType {
         return ColorABGR.pack(r, g, b, 0x00);
     }
 
-    private static short encodeLight(int light) {
+    private static int encodeLight(int light) {
         int block = light & 0xFF;
         int sky = (light >> 16) & 0xFF;
-        return (short)((block << 0) | (sky << 8));
+        return ((block << 0) | (sky << 8));
     }
 
     private static int encodeTexture(float value) {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/impl/VanillaLikeChunkVertex.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/impl/VanillaLikeChunkVertex.java
@@ -21,9 +21,10 @@ public class VanillaLikeChunkVertex implements ChunkVertexType {
 
     public static final GlVertexFormat<VanillaLikeChunkMeshAttribute> VERTEX_FORMAT = GlVertexFormat.builder(VanillaLikeChunkMeshAttribute.class, STRIDE)
             .addElement(VanillaLikeChunkMeshAttribute.POSITION, 0, GlVertexAttributeFormat.FLOAT, 3, false, false)
-            .addElement(VanillaLikeChunkMeshAttribute.COLOR_LIGHT, 12, GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true)
+            .addElement(VanillaLikeChunkMeshAttribute.COLOR, 12, GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true)
             .addElement(VanillaLikeChunkMeshAttribute.TEXTURE_UV, 16, GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true)
-            .addElement(VanillaLikeChunkMeshAttribute.DRAW_PARAMS, 20, GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true)
+            .addElement(VanillaLikeChunkMeshAttribute.DRAW_PARAMS, 20, GlVertexAttributeFormat.UNSIGNED_SHORT, 1, false, true)
+            .addElement(VanillaLikeChunkMeshAttribute.LIGHT, 22, GlVertexAttributeFormat.UNSIGNED_SHORT, 1, false, true)
             .build();
 
     @Override
@@ -37,9 +38,10 @@ public class VanillaLikeChunkVertex implements ChunkVertexType {
             MemoryUtil.memPutFloat(ptr + 0, vertex.x);
             MemoryUtil.memPutFloat(ptr + 4, vertex.y);
             MemoryUtil.memPutFloat(ptr + 8, vertex.z);
-            MemoryUtil.memPutInt(ptr + 12, (encodeColor(vertex.color) << 0) | (encodeLight(vertex.light) << 24));
+            MemoryUtil.memPutInt(ptr + 12, encodeColor(vertex.color));
             MemoryUtil.memPutInt(ptr + 16, (encodeTexture(vertex.u) << 0) | (encodeTexture(vertex.v) << 16));
-            MemoryUtil.memPutInt(ptr + 20, encodeDrawParameters(material, sectionIndex));
+            MemoryUtil.memPutShort(ptr + 20, encodeDrawParameters(material, sectionIndex));
+            MemoryUtil.memPutShort(ptr + 22, encodeLight(vertex.light));
 
             return ptr + STRIDE;
         };
@@ -50,8 +52,8 @@ public class VanillaLikeChunkVertex implements ChunkVertexType {
         return "VERTEX_FORMAT_FULL";
     }
 
-    private static int encodeDrawParameters(Material material, int sectionIndex) {
-        return (((sectionIndex & 0xFF) << 8) | ((material.bits() & 0xFF) << 0));
+    private static short encodeDrawParameters(Material material, int sectionIndex) {
+        return (short)(((sectionIndex & 0xFF) << 8) | ((material.bits() & 0xFF) << 0));
     }
 
     private static int encodeColor(int color) {
@@ -64,11 +66,10 @@ public class VanillaLikeChunkVertex implements ChunkVertexType {
         return ColorABGR.pack(r, g, b, 0x00);
     }
 
-    private static int encodeLight(int light) {
-        int block = (light >> 4) & 0xF;
-        int sky = (light >> 20) & 0xF;
-
-        return ((block << 0) | (sky << 4));
+    private static short encodeLight(int light) {
+        int block = light & 0xFF;
+        int sky = (light >> 16) & 0xFF;
+        return (short)((block << 0) | (sky << 8));
     }
 
     private static int encodeTexture(float value) {

--- a/src/main/resources/assets/sodium/lang/en_us.json
+++ b/src/main/resources/assets/sodium/lang/en_us.json
@@ -33,6 +33,8 @@
   "sodium.options.mipmap_levels.tooltip": "Controls the number of mipmaps which will be used for block model textures. Higher values provide better rendering of blocks in the distance, but may adversely affect performance with many animated textures.",
   "sodium.options.use_block_face_culling.name": "Use Block Face Culling",
   "sodium.options.use_block_face_culling.tooltip": "If enabled, only the sides of blocks which are facing the camera will be submitted for rendering. This can eliminate a large number of block faces very early in the rendering process, saving memory bandwidth and time on the GPU. Some resource packs may have issues with this option, so try disabling it if you're seeing holes in blocks.",
+  "sodium.options.use_compact_vertex_format.name": "Use Compact Vertex Format",
+  "sodium.options.use_compact_vertex_format.tooltip": "If enabled, a more compact vertex format will be used for rendering chunks. This can reduce graphics memory usage and bandwidth requirements significantly, especially for integrated graphics cards, but can cause z-fighting with some resource packs due to how it reduces the precision of position and texture coordinate attributes.",
   "sodium.options.use_fog_occlusion.name": "Use Fog Occlusion",
   "sodium.options.use_fog_occlusion.tooltip": "If enabled, chunks which are determined to be fully hidden by fog effects will not be rendered, helping to improve performance. The improvement can be more dramatic when fog effects are heavier (such as while underwater), but it may cause undesirable visual artifacts between the sky and fog in some scenarios.",
   "sodium.options.use_entity_culling.name": "Use Entity Culling",

--- a/src/main/resources/assets/sodium/shaders/blocks/block_layer_opaque.vsh
+++ b/src/main/resources/assets/sodium/shaders/blocks/block_layer_opaque.vsh
@@ -20,9 +20,19 @@ uniform vec3 u_RegionOffset;
 
 uniform sampler2D u_LightTex; // The light map texture
 
+#if defined(VERTEX_FORMAT_COMPACT)
+// expect 0-15 as inputs, Sodium 0.5 logic
 vec3 _sample_lightmap(uvec2 coord) {
     return texelFetch(u_LightTex, ivec2(coord), 0).rgb;
 }
+#elif defined(VERTEX_FORMAT_FULL)
+// expect UV coords as inputs
+vec3 _sample_lightmap(uvec2 uv) {
+    return texture(u_LightTex, clamp((ivec2(uv) / 256.0), vec2(0.5 / 16.0), vec2(15.5 / 16.0))).rgb;
+}
+#else
+#error Unexpected format
+#endif
 
 uvec3 _get_relative_chunk_coord(uint pos) {
     // Packing scheme is defined by LocalSectionIndex

--- a/src/main/resources/assets/sodium/shaders/include/chunk_vertex.glsl
+++ b/src/main/resources/assets/sodium/shaders/include/chunk_vertex.glsl
@@ -1,12 +1,26 @@
+#define TEX_COORD_SCALE    1.0 / 65536.0
+#define COLOR_SCALE        1.0 / 255.0
+
+#if defined(VERTEX_FORMAT_COMPACT)
+
 #define MODEL_SCALE        32.0 / 65536.0
 #define MODEL_ORIGIN       8.0
 
-#define COLOR_SCALE        1.0 / 255.0
-
-#define TEX_COORD_SCALE    1.0 / 65536.0
-
 // The packed vertex data which is read from the vertex buffer
 in uvec4 in_VertexData;
+
+#elif defined(VERTEX_FORMAT_FULL)
+
+in vec3 in_Pos;
+in uint in_ColorLight;
+in uint in_TextureUv;
+in uint in_DrawParams;
+
+#else
+#error Unsupported vertex format
+#endif
+
+
 
 // The position of the vertex around the model origin
 vec3 _vert_position;
@@ -27,6 +41,7 @@ uint _vert_material;
 uint _vert_mesh_id;
 
 void _vert_init() {
+#if defined(VERTEX_FORMAT_COMPACT)
     // Vertex Position
     uvec3 packed_position = uvec3(
         (in_VertexData[0] >>  0) & 0xFFFFu,
@@ -52,4 +67,25 @@ void _vert_init() {
     // Vertex Texture Coords
     uvec2 packed_tex_coord = (uvec2(in_VertexData[3]) >> uvec2(0, 16)) & uvec2(0xFFFFu);
     _vert_tex_coord = vec2(packed_tex_coord) * TEX_COORD_SCALE;
+#elif defined(VERTEX_FORMAT_FULL)
+    _vert_position = in_Pos;
+
+    // Vertex Material
+    _vert_material = (in_DrawParams) & 0xFFu;
+
+    // Vertex Mesh ID
+    _vert_mesh_id  = (in_DrawParams >> 8) & 0xFFu;
+
+    // Vertex Color
+    uvec3 packed_color = (uvec3(in_ColorLight) >> uvec3(0, 8, 16)) & uvec3(0xFFu);
+    _vert_color = vec3(packed_color) * COLOR_SCALE;
+
+    // Vertex Light
+    uvec2 packed_light = (uvec2(in_ColorLight) >> uvec2(24, 28)) & uvec2(0xFu);
+    _vert_light = packed_light;
+
+    // Vertex Texture Coords
+    uvec2 packed_tex_coord = (uvec2(in_TextureUv) >> uvec2(0, 16)) & uvec2(0xFFFFu);
+    _vert_tex_coord = vec2(packed_tex_coord) * TEX_COORD_SCALE;
+#endif
 }

--- a/src/main/resources/assets/sodium/shaders/include/chunk_vertex.glsl
+++ b/src/main/resources/assets/sodium/shaders/include/chunk_vertex.glsl
@@ -14,8 +14,7 @@ in uvec4 in_VertexData;
 in vec3 in_Pos;
 in uint in_Color;
 in uint in_TextureUv;
-in uint in_DrawParams;
-in uint in_Light;
+in uint in_DrawParamsLight;
 
 #else
 #error Unsupported vertex format
@@ -71,18 +70,19 @@ void _vert_init() {
 #elif defined(VERTEX_FORMAT_FULL)
     _vert_position = in_Pos;
 
+    uint packed_draw_params = (in_DrawParamsLight & 0xFFFFu);
     // Vertex Material
-    _vert_material = (in_DrawParams) & 0xFFu;
+    _vert_material = (packed_draw_params) & 0xFFu;
 
     // Vertex Mesh ID
-    _vert_mesh_id  = (in_DrawParams >> 8) & 0xFFu;
+    _vert_mesh_id  = (packed_draw_params >> 8) & 0xFFu;
 
     // Vertex Color
     uvec3 packed_color = (uvec3(in_Color) >> uvec3(0, 8, 16)) & uvec3(0xFFu);
     _vert_color = vec3(packed_color) * COLOR_SCALE;
 
     // Vertex Light
-    _vert_light = (uvec2(in_Light) >> uvec2(0, 8)) & uvec2(0xFFu);
+    _vert_light = (uvec2((in_DrawParamsLight >> 16) & 0xFFFFu) >> uvec2(0, 8)) & uvec2(0xFFu);
 
     // Vertex Texture Coords
     uvec2 packed_tex_coord = (uvec2(in_TextureUv) >> uvec2(0, 16)) & uvec2(0xFFFFu);

--- a/src/main/resources/assets/sodium/shaders/include/chunk_vertex.glsl
+++ b/src/main/resources/assets/sodium/shaders/include/chunk_vertex.glsl
@@ -12,9 +12,10 @@ in uvec4 in_VertexData;
 #elif defined(VERTEX_FORMAT_FULL)
 
 in vec3 in_Pos;
-in uint in_ColorLight;
+in uint in_Color;
 in uint in_TextureUv;
 in uint in_DrawParams;
+in uint in_Light;
 
 #else
 #error Unsupported vertex format
@@ -77,12 +78,11 @@ void _vert_init() {
     _vert_mesh_id  = (in_DrawParams >> 8) & 0xFFu;
 
     // Vertex Color
-    uvec3 packed_color = (uvec3(in_ColorLight) >> uvec3(0, 8, 16)) & uvec3(0xFFu);
+    uvec3 packed_color = (uvec3(in_Color) >> uvec3(0, 8, 16)) & uvec3(0xFFu);
     _vert_color = vec3(packed_color) * COLOR_SCALE;
 
     // Vertex Light
-    uvec2 packed_light = (uvec2(in_ColorLight) >> uvec2(24, 28)) & uvec2(0xFu);
-    _vert_light = packed_light;
+    _vert_light = (uvec2(in_Light) >> uvec2(0, 8)) & uvec2(0xFFu);
 
     // Vertex Texture Coords
     uvec2 packed_tex_coord = (uvec2(in_TextureUv) >> uvec2(0, 16)) & uvec2(0xFFFFu);


### PR DESCRIPTION
This PR fixes #2004 and the remaining compact vertex format issues on the tracker by reintroducing a full-precision vertex format, similar to what was available in Sodium 0.2.0. To do this some fairly substantial changes had to be made to the shader binding code, since the old logic had hardcoded attribute/tessellation bindings.

Notably, the new format:

* Uses full 32-bit single-precision floats for vertex positions.
* Uses full 8-bit coordinates for lighting, as the compression trick used by Sodium 0.5 causes artifacts in some cases.

There is likely cleanup that can be done to the code, but this seems to be completely functional and stable in its current state.