### PR TITLE
Round lightmap coordinates in compact chunk vertex encoder

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/impl/CompactChunkVertex.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/impl/CompactChunkVertex.java
@@ -62,6 +62,14 @@ public class CompactChunkVertex implements ChunkVertexType {
         int block = (light >> 4) & 0xF;
         int sky = (light >> 20) & 0xF;
 
+        // Some mods/parts of vanilla use the lower 4 bits, so round if needed.
+        if(((light >> 0) & 0xF) > 0x7 && block < 0xF) {
+            block++;
+        }
+        if(((light >> 16) & 0xF) > 0x7 && sky < 0xF) {
+            sky++;
+        }
+
         return ((block << 0) | (sky << 4));
     }
 


### PR DESCRIPTION
Vanilla and mods can generate lightmap coordinates with the bottom 4 bits nonzero. We cannot store these with perfect precision with the CVF as it only has space for the top 4 bits, however rounding is a more accurate/correct way to handle the issue than simply discarding the bits.

Fixes https://github.com/CaffeineMC/sodium-fabric/issues/2052 in my testing.