### PR TITLE
Fix parity issue in Sodium's getFacing optimization

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/render/immediate/DirectionMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/render/immediate/DirectionMixin.java
@@ -30,6 +30,10 @@ public class DirectionMixin {
     @SuppressWarnings({ "StatementWithEmptyBody", "JavadocReference" })
     @Overwrite
     public static Direction getFacing(float x, float y, float z) {
+        // Vanilla quirk: return NORTH if all coordinates are zero
+        if (x == 0 && y == 0 && z == 0)
+            return Direction.NORTH;
+
         // First choice in ties: negative, positive; Y, Z, X
         var yM = Math.abs(y);
         var zM = Math.abs(z);


### PR DESCRIPTION
The optimization introduced in https://github.com/CaffeineMC/sodium-fabric/pull/1587 has a subtle parity issue: if `x, y, z` are all zero, Sodium's `Direction.getFacing` implementation returns `Direction.DOWN`, while vanilla returns `Direction.NORTH`. This could potentially cause modded code to crash if it implicitly assumed that the returned direction was horizontal in this case (I believe this caused https://github.com/AlexModGuy/Ice_and_Fire/issues/4767).

This PR fixes that by checking for this corner case and returning the same value as vanilla. An alternate solution would be to reorder the chain of if statements such that NORTH would end up being selected.