### PR TITLE
Fix biome colors being retrieved differently from vanilla

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/world/biome/BiomeColorCache.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/biome/BiomeColorCache.java
@@ -3,6 +3,7 @@ package me.jellysquid.mods.sodium.client.world.biome;
 import me.jellysquid.mods.sodium.client.util.color.BoxBlur;
 import me.jellysquid.mods.sodium.client.util.color.BoxBlur.ColorBuffer;
 import me.jellysquid.mods.sodium.client.world.cloned.ChunkRenderContext;
+import net.minecraft.client.color.world.BiomeColors;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.biome.Biome;
 
@@ -78,9 +79,9 @@ public class BiomeColorCache {
                 int relativeX = worldX - this.minX;
                 int relativeZ = worldZ - this.minZ;
 
-                slice.grass.set(relativeX, relativeZ, biome.getGrassColorAt(worldX, worldZ));
-                slice.foliage.set(relativeX, relativeZ, biome.getFoliageColor());
-                slice.water.set(relativeX, relativeZ, biome.getWaterColor());
+                slice.grass.set(relativeX, relativeZ, BiomeColors.GRASS_COLOR.getColor(biome, worldX, worldZ));
+                slice.foliage.set(relativeX, relativeZ, BiomeColors.FOLIAGE_COLOR.getColor(biome, worldX, worldZ));
+                slice.water.set(relativeX, relativeZ, BiomeColors.WATER_COLOR.getColor(biome, worldX, worldZ));
             }
         }
 


### PR DESCRIPTION
This PR fixes a parity issue with how biome colors are retrieved compared to vanilla. Vanilla uses the lambdas in the `static final` fields of `BiomeColors` in order to call the appropriate methods on the biome, while Sodium just calls them directly. This causes compatibility issues with mods that use an AT/AW and replace the lambda in those fields to add custom logic.

In the case where no mod has replaced the lambda, the behavior of this patch should be exactly the same as Sodium 0.5.3, as the lambda delegates to the same method Sodium would have called.