### PR TITLE
Sort render regions by distance from camera

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -122,7 +122,7 @@ public class RenderSectionManager {
 
         this.occlusionCuller.findVisible(visitor, viewport, searchDistance, useOcclusionCulling, frame);
 
-        this.renderLists = visitor.createRenderLists();
+        this.renderLists = visitor.createRenderLists(camera.getPos());
         this.rebuildLists = visitor.getRebuildLists();
     }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/lists/ChunkRenderList.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/lists/ChunkRenderList.java
@@ -24,6 +24,8 @@ public class ChunkRenderList {
 
     private int lastVisibleFrame;
 
+    private double distanceFromCamera;
+
     public ChunkRenderList(RenderRegion region) {
         this.region = region;
     }
@@ -101,4 +103,14 @@ public class ChunkRenderList {
         return this.region;
     }
 
+    /**
+     * Get the squared distance of this region from the camera.
+     */
+    public double getDistanceFromCamera() {
+        return this.distanceFromCamera;
+    }
+
+    public void setDistanceFromCamera(double d) {
+        this.distanceFromCamera = d;
+    }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/lists/ChunkRenderList.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/lists/ChunkRenderList.java
@@ -24,7 +24,7 @@ public class ChunkRenderList {
 
     private int lastVisibleFrame;
 
-    private double distanceFromCamera;
+    private double sqrDistanceFromCamera;
 
     public ChunkRenderList(RenderRegion region) {
         this.region = region;
@@ -106,11 +106,11 @@ public class ChunkRenderList {
     /**
      * Get the squared distance of this region from the camera.
      */
-    public double getDistanceFromCamera() {
-        return this.distanceFromCamera;
+    public double getSqrDistanceFromCamera() {
+        return this.sqrDistanceFromCamera;
     }
 
-    public void setDistanceFromCamera(double d) {
-        this.distanceFromCamera = d;
+    public void setSqrDistanceFromCamera(double d) {
+        this.sqrDistanceFromCamera = d;
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/lists/SortedRenderLists.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/lists/SortedRenderLists.java
@@ -4,6 +4,9 @@ import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import me.jellysquid.mods.sodium.client.render.chunk.RenderSection;
 import me.jellysquid.mods.sodium.client.util.iterator.ReversibleObjectArrayIterator;
 import me.jellysquid.mods.sodium.client.render.chunk.region.RenderRegion;
+import net.minecraft.util.math.Vec3d;
+
+import java.util.Comparator;
 
 public class SortedRenderLists implements ChunkRenderListIterable {
     private static final SortedRenderLists EMPTY = new SortedRenderLists(ObjectArrayList.of());
@@ -24,6 +27,7 @@ public class SortedRenderLists implements ChunkRenderListIterable {
     }
 
     public static class Builder {
+        private static final Comparator<ChunkRenderList> LIST_DISTANCE_COMPARATOR = Comparator.comparingDouble(ChunkRenderList::getDistanceFromCamera);
         private final ObjectArrayList<ChunkRenderList> lists = new ObjectArrayList<>();
         private final int frame;
 
@@ -44,7 +48,17 @@ public class SortedRenderLists implements ChunkRenderListIterable {
             list.add(section);
         }
 
-        public SortedRenderLists build() {
+        public SortedRenderLists build(Vec3d cameraPos) {
+            //noinspection ForLoopReplaceableByForEach
+            for (int i = 0; i < this.lists.size(); i++) {
+                ChunkRenderList renderList = this.lists.get(i);
+                RenderRegion region = renderList.getRegion();
+                double dx = cameraPos.x - region.getOriginX();
+                double dy = cameraPos.y - region.getOriginY();
+                double dz = cameraPos.z - region.getOriginZ();
+                renderList.setDistanceFromCamera((dx * dx) + (dy * dy) + (dz * dz));
+            }
+            this.lists.sort(LIST_DISTANCE_COMPARATOR);
             return new SortedRenderLists(this.lists);
         }
     }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/lists/SortedRenderLists.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/lists/SortedRenderLists.java
@@ -27,7 +27,7 @@ public class SortedRenderLists implements ChunkRenderListIterable {
     }
 
     public static class Builder {
-        private static final Comparator<ChunkRenderList> LIST_DISTANCE_COMPARATOR = Comparator.comparingDouble(ChunkRenderList::getDistanceFromCamera);
+        private static final Comparator<ChunkRenderList> LIST_DISTANCE_COMPARATOR = Comparator.comparingDouble(ChunkRenderList::getSqrDistanceFromCamera);
         private final ObjectArrayList<ChunkRenderList> lists = new ObjectArrayList<>();
         private final int frame;
 
@@ -56,7 +56,7 @@ public class SortedRenderLists implements ChunkRenderListIterable {
                 double dx = cameraPos.x - region.getCenterX();
                 double dy = cameraPos.y - region.getCenterY();
                 double dz = cameraPos.z - region.getCenterZ();
-                renderList.setDistanceFromCamera((dx * dx) + (dy * dy) + (dz * dz));
+                renderList.setSqrDistanceFromCamera((dx * dx) + (dy * dy) + (dz * dz));
             }
             this.lists.sort(LIST_DISTANCE_COMPARATOR);
             return new SortedRenderLists(this.lists);

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/lists/SortedRenderLists.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/lists/SortedRenderLists.java
@@ -53,9 +53,9 @@ public class SortedRenderLists implements ChunkRenderListIterable {
             for (int i = 0; i < this.lists.size(); i++) {
                 ChunkRenderList renderList = this.lists.get(i);
                 RenderRegion region = renderList.getRegion();
-                double dx = cameraPos.x - region.getOriginX();
-                double dy = cameraPos.y - region.getOriginY();
-                double dz = cameraPos.z - region.getOriginZ();
+                double dx = cameraPos.x - region.getCenterX();
+                double dy = cameraPos.y - region.getCenterY();
+                double dz = cameraPos.z - region.getCenterZ();
                 renderList.setDistanceFromCamera((dx * dx) + (dy * dy) + (dz * dz));
             }
             this.lists.sort(LIST_DISTANCE_COMPARATOR);

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/lists/VisibleChunkCollector.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/lists/VisibleChunkCollector.java
@@ -2,6 +2,7 @@ package me.jellysquid.mods.sodium.client.render.chunk.lists;
 
 import me.jellysquid.mods.sodium.client.render.chunk.ChunkUpdateType;
 import me.jellysquid.mods.sodium.client.render.chunk.RenderSection;
+import net.minecraft.util.math.Vec3d;
 
 import java.util.ArrayDeque;
 import java.util.EnumMap;
@@ -43,8 +44,8 @@ public class VisibleChunkCollector implements Consumer<RenderSection> {
         }
     }
 
-    public SortedRenderLists createRenderLists() {
-        return this.sortedRenderLists.build();
+    public SortedRenderLists createRenderLists(Vec3d cameraPos) {
+        return this.sortedRenderLists.build(cameraPos);
     }
 
     public Map<ChunkUpdateType, ArrayDeque<RenderSection>> getRebuildLists() {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/region/RenderRegion.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/region/RenderRegion.java
@@ -87,6 +87,18 @@ public class RenderRegion {
         return this.getChunkZ() << 4;
     }
 
+    public int getCenterX() {
+        return (this.getChunkX() + REGION_WIDTH / 2) << 4;
+    }
+
+    public int getCenterY() {
+        return (this.getChunkY() + REGION_HEIGHT / 2) << 4;
+    }
+
+    public int getCenterZ() {
+        return (this.getChunkZ() + REGION_LENGTH / 2) << 4;
+    }
+
     public void delete(CommandList commandList) {
         for (var storage : this.sectionRenderData.values()) {
             storage.delete();


### PR DESCRIPTION
Fixes https://github.com/CaffeineMC/sodium-fabric/issues/2132 by ensuring the list of render regions is always sorted by distance from the camera.