### PR TITLE
fix: don't check entities if it requires iterating too many sections

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -371,6 +371,8 @@ public class SodiumWorldRenderer {
         matrices.pop();
     }
 
+    // the volume of a section multiplied by the number of sections to be checked at most
+    private static final double MAX_ENTITY_CHECK_VOLUME = 16 * 16 * 16 * 15;
 
     /**
      * Returns whether or not the entity intersects with any visible chunks in the graph.
@@ -387,6 +389,12 @@ public class SodiumWorldRenderer {
         }
 
         Box box = entity.getVisibilityBoundingBox();
+
+        // bail on very large entities to avoid checking many sections
+        double entityVolume = (box.maxX - box.minX) * (box.maxY - box.minY) * (box.maxZ - box.minZ);
+        if (entityVolume > MAX_ENTITY_CHECK_VOLUME) {
+            return true;
+        }
 
         return this.isBoxVisible(box.minX, box.minY, box.minZ, box.maxX, box.maxY, box.maxZ);
     }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -393,6 +393,7 @@ public class SodiumWorldRenderer {
         // bail on very large entities to avoid checking many sections
         double entityVolume = (box.maxX - box.minX) * (box.maxY - box.minY) * (box.maxZ - box.minZ);
         if (entityVolume > MAX_ENTITY_CHECK_VOLUME) {
+            // TODO: do a frustum check instead, even large entities aren't visible if they're outside the frustum
             return true;
         }
 


### PR DESCRIPTION
Closes #2114

Works by calculating the volume of each entity and checking if it's too large. Too large entities are just always rendered because checking all sections they touch for visibility is too expensive. The threshold of 15 sections can be adjusted if necessary.

Based on the suggestion embeddedt made here: https://github.com/CaffeineMC/sodium-fabric/issues/2114#issuecomment-1755555960