### PR TITLE
Use pointer types when calling into Kernel32.SetEnvironmentVariableW

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/util/workarounds/platform/windows/Kernel32.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/util/workarounds/platform/windows/Kernel32.java
@@ -28,7 +28,7 @@ public class Kernel32 {
                 MemoryUtil.memUTF16(value, true, lpValueBuf);
             }
 
-            JNI.callJJI(MemoryUtil.memAddress0(lpNameBuf), MemoryUtil.memAddressSafe(lpValueBuf), PFN_SetEnvironmentVariableW);
+            JNI.callPPI(MemoryUtil.memAddress0(lpNameBuf), MemoryUtil.memAddressSafe(lpValueBuf), PFN_SetEnvironmentVariableW);
         }
     }
 


### PR DESCRIPTION
This fixes the target signature to be pointer-pointer-int instead of long-long-int, which fixes a crash in 32-bit environments.

Fixes #2142.