### PR TITLE
Fix clouds still being rendered if height is NaN

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/immediate/CloudRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/immediate/CloudRenderer.java
@@ -69,6 +69,7 @@ public class CloudRenderer {
 
         float cloudHeight = world.getDimensionEffects().getCloudsHeight();
 
+        // Vanilla uses NaN height as a way to disable cloud rendering
         if (Float.isNaN(cloudHeight)) {
             return;
         }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/immediate/CloudRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/immediate/CloudRenderer.java
@@ -67,9 +67,13 @@ public class CloudRenderer {
             return;
         }
 
-        Vec3d color = world.getCloudsColor(tickDelta);
-
         float cloudHeight = world.getDimensionEffects().getCloudsHeight();
+
+        if (Float.isNaN(cloudHeight)) {
+            return;
+        }
+
+        Vec3d color = world.getCloudsColor(tickDelta);
 
         double cloudTime = (ticks + tickDelta) * 0.03F;
         double cloudCenterX = (cameraX + cloudTime);


### PR DESCRIPTION
### Linked Issues

#2147

### Proposed Changes

Vanilla checks whether the cloud height is NaN and skips rendering them if so. We should do the same.

Note: the local variables were reordered, in order to bail out early if height is NaN, rather than computing the color.