### PR TITLE
Fall back to non-vertex-specific coloring if mods override color providers

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/model/color/ColorProviderRegistry.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/model/color/ColorProviderRegistry.java
@@ -2,6 +2,7 @@ package me.jellysquid.mods.sodium.client.model.color;
 
 import it.unimi.dsi.fastutil.objects.Reference2ReferenceMap;
 import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ReferenceSet;
 import me.jellysquid.mods.sodium.client.model.color.interop.BlockColorsExtended;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -17,12 +18,16 @@ public class ColorProviderRegistry {
     private final Reference2ReferenceMap<Block, ColorProvider<BlockState>> blocks = new Reference2ReferenceOpenHashMap<>();
     private final Reference2ReferenceMap<Fluid, ColorProvider<FluidState>> fluids = new Reference2ReferenceOpenHashMap<>();
 
+    private final ReferenceSet<Block> overridenBlocks;
+
     public ColorProviderRegistry(BlockColors blockColors) {
         var providers = BlockColorsExtended.getProviders(blockColors);
 
         for (var entry : providers.reference2ReferenceEntrySet()) {
             this.blocks.put(entry.getKey(), DefaultColorProviders.adapt(entry.getValue()));
         }
+
+        this.overridenBlocks = BlockColorsExtended.getOverridenVanillaBlocks(blockColors);
 
         this.installOverrides();
     }
@@ -46,6 +51,9 @@ public class ColorProviderRegistry {
 
     private void registerBlocks(ColorProvider<BlockState> resolver, Block... blocks) {
         for (var block : blocks) {
+            // Do not register our resolver if the block is overriden
+            if (this.overridenBlocks.contains(block))
+                continue;
             this.blocks.put(block, resolver);
         }
     }

--- a/src/main/java/me/jellysquid/mods/sodium/client/model/color/interop/BlockColorsExtended.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/model/color/interop/BlockColorsExtended.java
@@ -1,6 +1,7 @@
 package me.jellysquid.mods.sodium.client.model.color.interop;
 
 import it.unimi.dsi.fastutil.objects.Reference2ReferenceMap;
+import it.unimi.dsi.fastutil.objects.ReferenceSet;
 import net.minecraft.block.Block;
 import net.minecraft.client.color.block.BlockColorProvider;
 import net.minecraft.client.color.block.BlockColors;
@@ -10,5 +11,11 @@ public interface BlockColorsExtended {
         return ((BlockColorsExtended) blockColors).sodium$getProviders();
     }
 
+    static ReferenceSet<Block> getOverridenVanillaBlocks(BlockColors blockColors) {
+        return ((BlockColorsExtended) blockColors).sodium$getOverridenVanillaBlocks();
+    }
+
     Reference2ReferenceMap<Block, BlockColorProvider> sodium$getProviders();
+
+    ReferenceSet<Block> sodium$getOverridenVanillaBlocks();
 }

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/model/colors/BlockColorsMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/model/colors/BlockColorsMixin.java
@@ -22,8 +22,6 @@ public class BlockColorsMixin implements BlockColorsExtended {
     @Unique
     private final ReferenceSet<Block> overridenBlocks = new ReferenceOpenHashSet<>();
 
-
-
     @Inject(method = "registerColorProvider", at = @At("HEAD"))
     private void preRegisterColorProvider(BlockColorProvider provider, Block[] blocks, CallbackInfo ci) {
         for (Block block : blocks) {
@@ -31,7 +29,7 @@ public class BlockColorsMixin implements BlockColorsExtended {
             // it means a mod is using custom logic and we need to disable per-vertex coloring
             if (this.blocksToColor.put(block, provider) != null) {
                 this.overridenBlocks.add(block);
-                SodiumClientMod.logger().info("Block {} had its color provider replaced and will not use per-vertex coloring", Registries.BLOCK.getId(block));
+                SodiumClientMod.logger().info("Block {} had its color provider replaced with {} and will not use per-vertex coloring", Registries.BLOCK.getId(block), provider.toString());
             }
         }
     }

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/model/colors/BlockColorsMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/model/colors/BlockColorsMixin.java
@@ -1,12 +1,12 @@
 package me.jellysquid.mods.sodium.mixin.core.model.colors;
 
-import it.unimi.dsi.fastutil.objects.Reference2ReferenceMap;
-import it.unimi.dsi.fastutil.objects.Reference2ReferenceMaps;
-import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
+import it.unimi.dsi.fastutil.objects.*;
+import me.jellysquid.mods.sodium.client.SodiumClientMod;
 import me.jellysquid.mods.sodium.client.model.color.interop.BlockColorsExtended;
 import net.minecraft.block.Block;
 import net.minecraft.client.color.block.BlockColorProvider;
 import net.minecraft.client.color.block.BlockColors;
+import net.minecraft.registry.Registries;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -19,15 +19,30 @@ public class BlockColorsMixin implements BlockColorsExtended {
     @Unique
     private final Reference2ReferenceMap<Block, BlockColorProvider> blocksToColor = new Reference2ReferenceOpenHashMap<>();
 
+    @Unique
+    private final ReferenceSet<Block> overridenBlocks = new ReferenceOpenHashSet<>();
+
+
+
     @Inject(method = "registerColorProvider", at = @At("HEAD"))
     private void preRegisterColorProvider(BlockColorProvider provider, Block[] blocks, CallbackInfo ci) {
         for (Block block : blocks) {
-            this.blocksToColor.put(block, provider);
+            // There will be one provider already registered for vanilla blocks, if we are replacing it,
+            // it means a mod is using custom logic and we need to disable per-vertex coloring
+            if (this.blocksToColor.put(block, provider) != null) {
+                this.overridenBlocks.add(block);
+                SodiumClientMod.logger().info("Block {} had its color provider replaced and will not use per-vertex coloring", Registries.BLOCK.getId(block));
+            }
         }
     }
 
     @Override
     public Reference2ReferenceMap<Block, BlockColorProvider> sodium$getProviders() {
         return Reference2ReferenceMaps.unmodifiable(this.blocksToColor);
+    }
+
+    @Override
+    public ReferenceSet<Block> sodium$getOverridenVanillaBlocks() {
+        return ReferenceSets.unmodifiable(this.overridenBlocks);
     }
 }


### PR DESCRIPTION
Currently the Sodium color provider registry unconditionally replaces the color providers on blended vanilla blocks (e.g. leaves). That causes mods replacing vanilla color providers to have their changes ignored. To address this, we only replace the color provider if it wasn't already overriden by a mod. The block in question will no longer use per-vertex blending, but the mod's logic will run as it does in vanilla.