### PR TITLE
Prevent `scheduleRebuild` from being called off-thread

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -27,6 +27,7 @@ import me.jellysquid.mods.sodium.client.render.chunk.region.RenderRegionManager;
 import me.jellysquid.mods.sodium.client.render.chunk.terrain.TerrainRenderPass;
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkMeshFormats;
 import me.jellysquid.mods.sodium.client.render.texture.SpriteUtil;
+import me.jellysquid.mods.sodium.client.render.util.RenderAsserts;
 import me.jellysquid.mods.sodium.client.render.viewport.CameraTransform;
 import me.jellysquid.mods.sodium.client.render.viewport.Viewport;
 import me.jellysquid.mods.sodium.client.util.MathUtil;
@@ -434,6 +435,8 @@ public class RenderSectionManager {
     }
 
     public void scheduleRebuild(int x, int y, int z, boolean important) {
+        RenderAsserts.validateCurrentThread();
+
         this.sectionCache.invalidate(x, y, z);
 
         RenderSection section = this.sectionByPosition.get(ChunkSectionPos.asLong(x, y, z));


### PR DESCRIPTION
Some mods try to schedule chunks to be rebuilt on background threads. In vanilla, this pattern generally manages to work due to how the chunk data structures are built, however, Sodium is much more sensitive to concurrency errors & crashes. To avoid undefined behavior, we simply throw an exception when `scheduleRebuild` is not called on the main thread.