### PR TITLE
Fix MatrixHelper producing slightly different results from vanilla

### DIFF
--- a/src/api/java/net/caffeinemc/mods/sodium/api/math/MatrixHelper.java
+++ b/src/api/java/net/caffeinemc/mods/sodium/api/math/MatrixHelper.java
@@ -45,7 +45,7 @@ public class MatrixHelper {
      * @return The transformed X-coordinate for the normal vector
      */
     public static float transformNormalX(Matrix3f mat, float x, float y, float z) {
-        return (mat.m00() * x) + (mat.m10() * y) + (mat.m20() * z);
+        return (mat.m00() * x) + ((mat.m10() * y) + (mat.m20() * z));
     }
 
     /**
@@ -56,7 +56,7 @@ public class MatrixHelper {
      * @return The transformed Y-coordinate for the normal vector
      */
     public static float transformNormalY(Matrix3f mat, float x, float y, float z) {
-        return (mat.m01() * x) + (mat.m11() * y) + (mat.m21() * z);
+        return (mat.m01() * x) + ((mat.m11() * y) + (mat.m21() * z));
     }
 
     /**
@@ -67,7 +67,7 @@ public class MatrixHelper {
      * @return The transformed Z-coordinate for the normal vector
      */
     public static float transformNormalZ(Matrix3f mat, float x, float y, float z) {
-        return (mat.m02() * x) + (mat.m12() * y) + (mat.m22() * z);
+        return (mat.m02() * x) + ((mat.m12() * y) + (mat.m22() * z));
     }
 
     /**
@@ -78,7 +78,7 @@ public class MatrixHelper {
      * @return The transformed X-coordinate for the vertex position
      */
     public static float transformPositionX(Matrix4f mat, float x, float y, float z) {
-        return (mat.m00() * x) + (mat.m10() * y) + (mat.m20() * z) + mat.m30();
+        return (mat.m00() * x) + ((mat.m10() * y) + ((mat.m20() * z) + mat.m30()));
     }
 
     /**
@@ -89,7 +89,7 @@ public class MatrixHelper {
      * @return The transformed Y-coordinate for the vertex position
      */
     public static float transformPositionY(Matrix4f mat, float x, float y, float z) {
-        return (mat.m01() * x) + (mat.m11() * y) + (mat.m21() * z) + mat.m31();
+        return (mat.m01() * x) + ((mat.m11() * y) + ((mat.m21() * z) + mat.m31()));
     }
 
     /**
@@ -100,7 +100,7 @@ public class MatrixHelper {
      * @return The transformed Z-coordinate for the vertex position
      */
     public static float transformPositionZ(Matrix4f mat, float x, float y, float z) {
-        return (mat.m02() * x) + (mat.m12() * y) + (mat.m22() * z) + mat.m32();
+        return (mat.m02() * x) + ((mat.m12() * y) + ((mat.m22() * z) + mat.m32()));
     }
 
     /**

--- a/src/api/java/net/caffeinemc/mods/sodium/api/math/MatrixHelper.java
+++ b/src/api/java/net/caffeinemc/mods/sodium/api/math/MatrixHelper.java
@@ -6,6 +6,12 @@ import org.joml.Math;
 import org.joml.Matrix3f;
 import org.joml.Matrix4f;
 
+/**
+ * Implements optimized utilities for transforming vectors with a given matrix.
+ *
+ * Note: Brackets must be used carefully in the transform functions to ensure that floating-point errors are
+ * the same as those produced by JOML, otherwise Z-fighting will occur.
+ */
 public class MatrixHelper {
     /**
      * @param mat The transformation matrix to apply to the normal


### PR DESCRIPTION
Vanilla uses JOML's `Vector4f#mul` or `Vector3f#mul` methods to apply matrix transformations to vectors. The implementation of these methods uses calls like
```java
dest.x = Math.fma(mat.m00(), x, Math.fma(mat.m10(), y, Math.fma(mat.m20(), z, mat.m30() * w)));
```

and the `Math.fma` wrappers have the effect of doing the final additions right-to-left, rather than left-to-right. Since Sodium's `MatrixHelper` uses left-to-right addition, the value it produces might differ very slightly from JOML's as a result of floating-point precision errors. This can cause Z-fighting.

The solution I used is to simply add brackets to force the additions to be performed in the same order as JOML.

Discord thread where the issue was reported: https://discord.com/channels/602796788608401408/1174666147828879400

The user and I both tested & confirmed this fixes their issue.