### PR TITLE
Fix air blocks with block entity renderers not rendering

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderMeshingTask.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderMeshingTask.java
@@ -85,7 +85,7 @@ public class ChunkBuilderMeshingTask extends ChunkBuilderTask<ChunkBuildOutput> 
                     for (int x = minX; x < maxX; x++) {
                         BlockState blockState = slice.getBlockState(x, y, z);
 
-                        if (blockState.isAir()) {
+                        if (blockState.isAir() && !blockState.hasBlockEntity()) {
                             continue;
                         }
 


### PR DESCRIPTION
Mods can create blocks that extend `AirBlock` but still have a block entity ([Forge example](https://github.com/MinecraftschurliMods/Ars-Magica-Legacy/blob/f97b66ee06e21f78640a7607679b75a439dad9c5/src/main/java/com/github/minecraftschurlimods/arsmagicalegacy/common/block/altar/AltarViewBlock.java)). Vanilla will render these block entities, but Sodium does not because it skips the entire render loop for a block if `isAir` returns true.

The simplest solution is to only skip the full loop if the block is air and also does not have a block entity. The model code will still be skipped since air blocks return `BlockRenderType.INVISIBLE`, but the block entity will correctly be processed & added to the section's list.