### PR TITLE
Keep times of animated sprites in sync

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/textures/animations/tracking/SpriteContentsAnimationAccessor.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/textures/animations/tracking/SpriteContentsAnimationAccessor.java
@@ -1,0 +1,13 @@
+package me.jellysquid.mods.sodium.mixin.features.textures.animations.tracking;
+
+import net.minecraft.client.texture.SpriteContents;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.List;
+
+@Mixin(SpriteContents.Animation.class)
+public interface SpriteContentsAnimationAccessor {
+    @Accessor("frames")
+    List<SpriteContents.AnimationFrame> getFrames();
+}

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/textures/animations/tracking/SpriteContentsAnimationFrameAccessor.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/textures/animations/tracking/SpriteContentsAnimationFrameAccessor.java
@@ -1,0 +1,11 @@
+package me.jellysquid.mods.sodium.mixin.features.textures.animations.tracking;
+
+import net.minecraft.client.texture.SpriteContents;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(SpriteContents.AnimationFrame.class)
+public interface SpriteContentsAnimationFrameAccessor {
+    @Accessor("time")
+    int getTime();
+}

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/textures/animations/tracking/SpriteContentsAnimatorImplMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/textures/animations/tracking/SpriteContentsAnimatorImplMixin.java
@@ -3,14 +3,26 @@ package me.jellysquid.mods.sodium.mixin.features.textures.animations.tracking;
 import me.jellysquid.mods.sodium.client.SodiumClientMod;
 import me.jellysquid.mods.sodium.client.render.texture.SpriteContentsExtended;
 import net.minecraft.client.texture.SpriteContents;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.List;
+
 @Mixin(SpriteContents.AnimatorImpl.class)
 public class SpriteContentsAnimatorImplMixin {
+    @Shadow
+    int currentTime;
+    @Shadow
+    @Final
+    SpriteContents.Animation animation;
+    @Shadow
+    int frame;
+
     @Unique
     private SpriteContents parent;
 
@@ -30,6 +42,12 @@ public class SpriteContentsAnimatorImplMixin {
         boolean onDemand = SodiumClientMod.options().performance.animateOnlyVisibleTextures;
 
         if (onDemand && !parent.sodium$isActive()) {
+            this.currentTime++;
+            List<SpriteContents.AnimationFrame> frames = ((SpriteContentsAnimationAccessor)this.animation).getFrames();
+            if (this.currentTime >= ((SpriteContentsAnimationFrameAccessor)frames.get(this.frame)).getTime()) {
+                this.frame = (this.frame + 1) % frames.size();
+                this.currentTime = 0;
+            }
             ci.cancel();
         }
     }

--- a/src/main/resources/sodium.mixins.json
+++ b/src/main/resources/sodium.mixins.json
@@ -86,6 +86,8 @@
     "features.textures.animations.tracking.DrawContextMixin",
     "features.textures.animations.tracking.SpriteAtlasTextureMixin",
     "features.textures.animations.tracking.SpriteBillboardParticleMixin",
+    "features.textures.animations.tracking.SpriteContentsAnimationAccessor",
+    "features.textures.animations.tracking.SpriteContentsAnimationFrameAccessor",
     "features.textures.animations.tracking.SpriteContentsAnimatorImplMixin",
     "features.textures.animations.tracking.SpriteContentsMixin",
     "features.textures.animations.upload.SpriteContentsAccessor",


### PR DESCRIPTION
This PR largely fixes #1479, it is just a modernized version of https://github.com/FlashyReese/sodium-fabric/commit/68b0e0de236f47860559f4df10aec63a8c42cc37.

Note: there is still a minor issue where since the sprite is not uploaded again till the start of the next frame, it might be desynced from other animated sprites on the initial frame where it becomes active. Addressing this would probably be more complex and so I deemed it out of scope of the PR.