### PR TITLE
Fix incorrect pointer math in SpriteContentsInterpolationMixin

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/textures/animations/upload/SpriteContentsInterpolationMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/textures/animations/upload/SpriteContentsInterpolationMixin.java
@@ -72,27 +72,29 @@ public class SpriteContentsInterpolationMixin {
             long ppSrcPixel = NativeImageHelper.getPointerRGBA(src);
             long ppDstPixel = NativeImageHelper.getPointerRGBA(dst);
 
-            // Pointers to the pixel array for the current and next frame
-            long pRgba1 = ppSrcPixel + (curX + (long) curY * src.getWidth() * STRIDE);
-            long pRgba2 = ppSrcPixel + (nextX + (long) nextY * src.getWidth() * STRIDE);
+            for (int layerY = 0; layerY < height; layerY++) {
+                // Pointers to the pixel array for the current and next frame
+                long pRgba1 = ppSrcPixel + (curX + (long) (curY + layerY) * src.getWidth()) * STRIDE;
+                long pRgba2 = ppSrcPixel + (nextX + (long) (nextY + layerY) * src.getWidth()) * STRIDE;
 
-            for (int pixelIndex = 0, pixelCount = width * height; pixelIndex < pixelCount; pixelIndex++) {
-                int rgba1 = MemoryUtil.memGetInt(pRgba1);
-                int rgba2 = MemoryUtil.memGetInt(pRgba2);
+                for (int layerX = 0; layerX < width; layerX++) {
+                    int rgba1 = MemoryUtil.memGetInt(pRgba1);
+                    int rgba2 = MemoryUtil.memGetInt(pRgba2);
 
-                // Mix the RGB components and truncate the A component
-                int mixedRgb = ColorMixer.mix(rgba1, rgba2, mix) & 0x00FFFFFF;
+                    // Mix the RGB components and truncate the A component
+                    int mixedRgb = ColorMixer.mix(rgba1, rgba2, mix) & 0x00FFFFFF;
 
-                // Take the A component from the source pixel
-                int alpha = rgba1 & 0xFF000000;
+                    // Take the A component from the source pixel
+                    int alpha = rgba1 & 0xFF000000;
 
-                // Update the pixel within the interpolated frame using the combined RGB and A components
-                MemoryUtil.memPutInt(ppDstPixel, mixedRgb | alpha);
+                    // Update the pixel within the interpolated frame using the combined RGB and A components
+                    MemoryUtil.memPutInt(ppDstPixel, mixedRgb | alpha);
 
-                pRgba1 += STRIDE;
-                pRgba2 += STRIDE;
+                    pRgba1 += STRIDE;
+                    pRgba2 += STRIDE;
 
-                ppDstPixel += STRIDE;
+                    ppDstPixel += STRIDE;
+                }
             }
         }
 


### PR DESCRIPTION
The pointer math in `SpriteContentsInterpolationMixin` doesn't correctly handle textures where `src.getWidth() > width` or `curX, nextX > 0`. This PR fixes that by calculating the pointer for each line of the image instead of just once outside the main mixing loop. As a side effect, the code is a bit easier to reason about.

A test resource pack is attached that reproduces the issue with the `minecraft:paper` item.
[testpack.zip](https://github.com/CaffeineMC/sodium-fabric/files/13469344/testpack.zip)

