### PR TITLE
Change BlockRenderType check to match vanilla

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderMeshingTask.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderMeshingTask.java
@@ -92,7 +92,7 @@ public class ChunkBuilderMeshingTask extends ChunkBuilderTask<ChunkBuildOutput> 
                         blockPos.set(x, y, z);
                         modelOffset.set(x & 15, y & 15, z & 15);
 
-                        if (blockState.getRenderType() == BlockRenderType.MODEL) {
+                        if (blockState.getRenderType() != BlockRenderType.INVISIBLE) {
                             BakedModel model = cache.getBlockModels()
                                 .getModel(blockState);
 


### PR DESCRIPTION
Does what it says on the tin, vanilla only requires that the type is not INVISIBLE.