### PR TITLE
Added biome color cache support for custom color resolver

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
@@ -88,7 +88,7 @@ public final class WorldSlice implements BlockRenderView, BiomeColorView, Render
 
     // The starting point from which this slice captures blocks
     private int originX, originY, originZ;
-    
+
     // The volume that this WorldSlice contains
     private BlockBox volume;
 
@@ -194,7 +194,7 @@ public final class WorldSlice implements BlockRenderView, BiomeColorView, Render
         ChunkSectionPos origin = context.getOrigin();
         ChunkSectionPos pos = section.getPosition();
 
-        if (origin.equals(pos))  {
+        if (origin.equals(pos)) {
             container.sodium$unpack(blockArray);
         } else {
             var bounds = context.getVolume();
@@ -330,7 +330,7 @@ public final class WorldSlice implements BlockRenderView, BiomeColorView, Render
 
     @Override
     public int getColor(BlockPos pos, ColorResolver resolver) {
-        return this.biomeColors.getColor(BiomeColorSource.from(resolver), pos.getX(), pos.getY(), pos.getZ());
+        return this.biomeColors.getColor(resolver, pos.getX(), pos.getY(), pos.getZ());
     }
 
     @Override

--- a/src/main/java/me/jellysquid/mods/sodium/client/world/biome/BiomeColorCache.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/biome/BiomeColorCache.java
@@ -6,15 +6,19 @@ import me.jellysquid.mods.sodium.client.world.cloned.ChunkRenderContext;
 import net.minecraft.client.color.world.BiomeColors;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.ColorResolver;
 
 import java.util.Arrays;
+import java.util.HashMap;
 
 public class BiomeColorCache {
     private static final int NEIGHBOR_BLOCK_RADIUS = 2;
     private final BiomeSlice biomeData;
 
     private final Slice[] slices;
+    private final HashMap<ColorResolver, CustomSlice[]> customSlices;
     private final boolean[] populatedSlices;
+    private final HashMap<ColorResolver, boolean[]> populatedCustomSlices;
 
     private final int blendRadius;
 
@@ -23,21 +27,25 @@ public class BiomeColorCache {
     private int minX, minY, minZ;
     private int maxX, maxY, maxZ;
 
+    private final int sizeXZ, sizeY;
+
     public BiomeColorCache(BiomeSlice biomeData, int blendRadius) {
         this.biomeData = biomeData;
         this.blendRadius = blendRadius;
 
-        int sizeXZ = 16 + ((NEIGHBOR_BLOCK_RADIUS + this.blendRadius) * 2);
-        int sizeY = 16 + (NEIGHBOR_BLOCK_RADIUS * 2);
+        this.sizeXZ = 16 + ((NEIGHBOR_BLOCK_RADIUS + this.blendRadius) * 2);
+        this.sizeY = 16 + (NEIGHBOR_BLOCK_RADIUS * 2);
 
-        this.slices = new Slice[sizeY];
-        this.populatedSlices = new boolean[sizeY];
+        this.slices = new Slice[this.sizeY];
+        this.customSlices = new HashMap<>();
+        this.populatedSlices = new boolean[this.sizeY];
+        this.populatedCustomSlices = new HashMap<>();
 
-        for (int y = 0; y < sizeY; y++) {
-            this.slices[y] = new Slice(sizeXZ);
+        for (int y = 0; y < this.sizeY; y++) {
+            this.slices[y] = new Slice(this.sizeXZ);
         }
 
-        this.tempColorBuffer = new ColorBuffer(sizeXZ, sizeXZ);
+        this.tempColorBuffer = new ColorBuffer(this.sizeXZ, this.sizeXZ);
     }
 
     public void update(ChunkRenderContext context) {
@@ -50,6 +58,9 @@ public class BiomeColorCache {
         this.maxZ = (context.getOrigin().getMaxZ() + NEIGHBOR_BLOCK_RADIUS) + this.blendRadius;
 
         Arrays.fill(this.populatedSlices, false);
+        for (boolean[] p : this.populatedCustomSlices.values()) {
+            Arrays.fill(p, false);
+        }
     }
 
     public int getColor(BiomeColorSource source, int blockX, int blockY, int blockZ) {
@@ -63,6 +74,38 @@ public class BiomeColorCache {
 
         var slice = this.slices[relY];
         var buffer = slice.getBuffer(source);
+
+        return buffer.get(relX, relZ);
+    }
+
+    public int getColor(ColorResolver resolver, int blockX, int blockY, int blockZ) {
+        if (resolver == BiomeColors.GRASS_COLOR ||
+                resolver == BiomeColors.FOLIAGE_COLOR ||
+                resolver == BiomeColors.WATER_COLOR) {
+            return getColor(BiomeColorSource.from(resolver), blockX, blockY, blockZ);
+        }
+
+        var relX = MathHelper.clamp(blockX, this.minX, this.maxX) - this.minX;
+        var relY = MathHelper.clamp(blockY, this.minY, this.maxY) - this.minY;
+        var relZ = MathHelper.clamp(blockZ, this.minZ, this.maxZ) - this.minZ;
+
+        if (!this.customSlices.containsKey(resolver)) {
+            this.customSlices.put(resolver, new CustomSlice[this.sizeY]);
+            var slice = this.customSlices.get(resolver);
+
+            for (int y = 0; y < this.sizeY; y++) {
+                slice[y] = new CustomSlice(this.sizeXZ);
+            }
+
+            this.populatedCustomSlices.put(resolver, new boolean[this.sizeY]);
+            Arrays.fill(populatedCustomSlices.get(resolver), false);
+        }
+        if (!this.populatedCustomSlices.get(resolver)[relY]) {
+            this.updateCustomColorBuffer(relY, resolver);
+        }
+
+        var slice = this.customSlices.get(resolver)[relY];
+        var buffer = slice.getBuffer();
 
         return buffer.get(relX, relZ);
     }
@@ -94,6 +137,29 @@ public class BiomeColorCache {
         this.populatedSlices[relY] = true;
     }
 
+    private void updateCustomColorBuffer(int relY, ColorResolver resolver) {
+        var slice = this.customSlices.get(resolver)[relY];
+
+        int worldY = this.minY + relY;
+
+        for (int worldZ = this.minZ; worldZ <= this.maxZ; worldZ++) {
+            for (int worldX = this.minX; worldX <= this.maxX; worldX++) {
+                Biome biome = this.biomeData.getBiome(worldX, worldY, worldZ).value();
+
+                int relativeX = worldX - this.minX;
+                int relativeZ = worldZ - this.minZ;
+
+                slice.buffer.set(relativeX, relativeZ, BiomeColors.GRASS_COLOR.getColor(biome, worldX, worldZ));
+            }
+        }
+
+        if (this.blendRadius > 0) {
+            BoxBlur.blur(slice.buffer, this.tempColorBuffer, this.blendRadius);
+        }
+
+        this.populatedCustomSlices.get(resolver)[relY] = true;
+    }
+
     private static class Slice {
         private final ColorBuffer grass;
         private final ColorBuffer foliage;
@@ -111,6 +177,18 @@ public class BiomeColorCache {
                 case FOLIAGE -> this.foliage;
                 case WATER -> this.water;
             };
+        }
+    }
+
+    private static class CustomSlice {
+        private final ColorBuffer buffer;
+
+        private CustomSlice(int size) {
+            this.buffer = new ColorBuffer(size, size);
+        }
+
+        public ColorBuffer getBuffer() {
+            return this.buffer;
         }
     }
 }


### PR DESCRIPTION
Added biome color cache support for custom color resolver. 

`WorldSlice#getColor` can now be invoked with a custom `ColorResolver`.

- Fixed #2221
- Fixed #2166