### PR TITLE
Implement fast clouds option

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -13,7 +13,6 @@ import me.jellysquid.mods.sodium.client.gui.options.storage.MinecraftOptionsStor
 import me.jellysquid.mods.sodium.client.gui.options.storage.SodiumOptionsStorage;
 import me.jellysquid.mods.sodium.client.compatibility.workarounds.Workarounds;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gl.Framebuffer;
 import net.minecraft.client.option.*;
 import net.minecraft.client.util.Window;
 import net.minecraft.text.Text;
@@ -144,20 +143,11 @@ public class SodiumGameOptionPages {
                 .build());
 
         groups.add(OptionGroup.createBuilder()
-                .add(OptionImpl.createBuilder(boolean.class, vanillaOpts)
+                .add(OptionImpl.createBuilder(CloudRenderMode.class, vanillaOpts)
                         .setName(Text.translatable("options.renderClouds"))
                         .setTooltip(Text.translatable("sodium.options.clouds_quality.tooltip"))
-                        .setControl(TickBoxControl::new)
-                        .setBinding((opts, value) -> {
-                            opts.getCloudRenderMode().setValue(value ? CloudRenderMode.FANCY : CloudRenderMode.OFF);
-
-                            if (MinecraftClient.isFabulousGraphicsOrBetter()) {
-                                Framebuffer framebuffer = MinecraftClient.getInstance().worldRenderer.getCloudsFramebuffer();
-                                if (framebuffer != null) {
-                                    framebuffer.clear(MinecraftClient.IS_SYSTEM_MAC);
-                                }
-                            }
-                        }, opts -> opts.getCloudRenderMode().getValue() == CloudRenderMode.FANCY)
+                        .setControl(option -> new CyclingControl<>(option, CloudRenderMode.class, new Text[] { Text.translatable("options.off"), Text.translatable("options.clouds.fast"), Text.translatable("options.clouds.fancy") }))
+                        .setBinding((opts, value) -> opts.getCloudRenderMode().setValue(value), opts -> opts.getCloudRenderMode().getValue())
                         .setImpact(OptionImpact.LOW)
                         .build())
                 .add(OptionImpl.createBuilder(SodiumGameOptions.GraphicsQuality.class, sodiumOpts)

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/immediate/CloudRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/immediate/CloudRenderer.java
@@ -244,12 +244,12 @@ public class CloudRenderer {
 
                     // -Y
                     if ((connectedEdges & DIR_NEG_Y) != 0) {
-                        int mixedColor2 = ColorMixer.mul(texel, CLOUD_COLOR_NEG_Y);
+                        int mixedColor = ColorMixer.mul(texel, CLOUD_COLOR_NEG_Y);
 
-                        ptr = writeVertex(ptr, x + 12, 0.0f, z + 12, mixedColor2);
-                        ptr = writeVertex(ptr, x + 0.0f, 0.0f, z + 12, mixedColor2);
-                        ptr = writeVertex(ptr, x + 0.0f, 0.0f, z + 0.0f, mixedColor2);
-                        ptr = writeVertex(ptr, x + 12, 0.0f, z + 0.0f, mixedColor2);
+                        ptr = writeVertex(ptr, x + 12, 0.0f, z + 12, mixedColor);
+                        ptr = writeVertex(ptr, x + 0.0f, 0.0f, z + 12, mixedColor);
+                        ptr = writeVertex(ptr, x + 0.0f, 0.0f, z + 0.0f, mixedColor);
+                        ptr = writeVertex(ptr, x + 12, 0.0f, z + 0.0f, mixedColor);
 
                         count += 4;
                     }


### PR DESCRIPTION
Addresses #2107 

There is an issue where the fast clouds disappear when you view them from more than a few blocks above, so I marked this as a draft. Additionally, the setting does not apply instantly because `rebuildGeometry` is not called. I'd appreciate some guidance on these two issues.