### PR TITLE
Apply BufferBuilder optimizations via delegate

### DIFF
--- a/src/api/java/net/caffeinemc/mods/sodium/api/vertex/format/VertexFormatDescription.java
+++ b/src/api/java/net/caffeinemc/mods/sodium/api/vertex/format/VertexFormatDescription.java
@@ -28,4 +28,9 @@ public interface VertexFormatDescription {
      * start at the byte offset (index * stride).
      */
     int stride();
+
+    /**
+     * Returns whether or not the format is "simple" (has no duplicate elements).
+     */
+    boolean isSimpleFormat();
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/vertex/VertexFormatDescriptionImpl.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/vertex/VertexFormatDescriptionImpl.java
@@ -6,6 +6,7 @@ import net.caffeinemc.mods.sodium.api.vertex.format.VertexFormatDescription;
 import net.minecraft.client.render.VertexFormat;
 
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.NoSuchElementException;
 
 public class VertexFormatDescriptionImpl implements VertexFormatDescription {
@@ -14,11 +15,28 @@ public class VertexFormatDescriptionImpl implements VertexFormatDescription {
 
     private final int[] offsets;
 
+    private final boolean isSimple;
+
     public VertexFormatDescriptionImpl(VertexFormat format, int id) {
         this.id = id;
         this.stride = format.getVertexSizeByte();
 
         this.offsets = getOffsets(format);
+        this.isSimple = checkSimple(format);
+    }
+
+    private static boolean checkSimple(VertexFormat format) {
+        EnumSet<CommonVertexAttribute> attributeSet = EnumSet.noneOf(CommonVertexAttribute.class);
+        var elementList = format.getElements();
+
+        for (int elementIndex = 0; elementIndex < elementList.size(); elementIndex++) {
+            var element = elementList.get(elementIndex);
+            if (!attributeSet.add(CommonVertexAttribute.getCommonType(element))) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public static int[] getOffsets(VertexFormat format) {
@@ -65,5 +83,10 @@ public class VertexFormatDescriptionImpl implements VertexFormatDescription {
     @Override
     public int stride() {
         return this.stride;
+    }
+
+    @Override
+    public boolean isSimpleFormat() {
+        return this.isSimple;
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/vertex/VertexFormatDescriptionImpl.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/vertex/VertexFormatDescriptionImpl.java
@@ -4,6 +4,7 @@ import me.jellysquid.mods.sodium.mixin.core.render.VertexFormatAccessor;
 import net.caffeinemc.mods.sodium.api.vertex.attributes.CommonVertexAttribute;
 import net.caffeinemc.mods.sodium.api.vertex.format.VertexFormatDescription;
 import net.minecraft.client.render.VertexFormat;
+import net.minecraft.client.render.VertexFormats;
 
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -31,7 +32,8 @@ public class VertexFormatDescriptionImpl implements VertexFormatDescription {
 
         for (int elementIndex = 0; elementIndex < elementList.size(); elementIndex++) {
             var element = elementList.get(elementIndex);
-            if (!attributeSet.add(CommonVertexAttribute.getCommonType(element))) {
+            var commonType = CommonVertexAttribute.getCommonType(element);
+            if (element != VertexFormats.PADDING_ELEMENT && (commonType == null || !attributeSet.add(commonType))) {
                 return false;
             }
         }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/vertex/buffer/ExtendedBufferBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/vertex/buffer/ExtendedBufferBuilder.java
@@ -1,0 +1,14 @@
+package me.jellysquid.mods.sodium.client.render.vertex.buffer;
+
+import net.caffeinemc.mods.sodium.api.vertex.buffer.VertexBufferWriter;
+import net.caffeinemc.mods.sodium.api.vertex.format.VertexFormatDescription;
+
+import java.nio.ByteBuffer;
+
+public interface ExtendedBufferBuilder extends VertexBufferWriter {
+    ByteBuffer sodium$getBuffer();
+    int sodium$getElementOffset();
+    void sodium$moveToNextVertex();
+    VertexFormatDescription sodium$getFormatDescription();
+    boolean sodium$usingFixedColor();
+}

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/vertex/buffer/ExtendedBufferBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/vertex/buffer/ExtendedBufferBuilder.java
@@ -11,4 +11,5 @@ public interface ExtendedBufferBuilder extends VertexBufferWriter {
     void sodium$moveToNextVertex();
     VertexFormatDescription sodium$getFormatDescription();
     boolean sodium$usingFixedColor();
+    SodiumBufferBuilder sodium$getDelegate();
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/vertex/buffer/SodiumBufferBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/vertex/buffer/SodiumBufferBuilder.java
@@ -1,0 +1,321 @@
+package me.jellysquid.mods.sodium.client.render.vertex.buffer;
+
+import net.caffeinemc.mods.sodium.api.util.ColorABGR;
+import net.caffeinemc.mods.sodium.api.util.ColorARGB;
+import net.caffeinemc.mods.sodium.api.util.NormI8;
+import net.caffeinemc.mods.sodium.api.vertex.attributes.CommonVertexAttribute;
+import net.caffeinemc.mods.sodium.api.vertex.attributes.common.*;
+import net.caffeinemc.mods.sodium.api.vertex.buffer.VertexBufferWriter;
+import net.caffeinemc.mods.sodium.api.vertex.format.VertexFormatDescription;
+import net.minecraft.client.render.BufferBuilder;
+import net.minecraft.client.render.VertexConsumer;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.MemoryUtil;
+import org.spongepowered.asm.mixin.Unique;
+
+public class SodiumBufferBuilder implements VertexConsumer, VertexBufferWriter {
+    private static final int ATTRIBUTE_NOT_PRESENT = -1;
+
+    private static final int
+            ATTRIBUTE_POSITION_BIT  = 1 << CommonVertexAttribute.POSITION.ordinal(),
+            ATTRIBUTE_COLOR_BIT     = 1 << CommonVertexAttribute.COLOR.ordinal(),
+            ATTRIBUTE_TEXTURE_BIT   = 1 << CommonVertexAttribute.TEXTURE.ordinal(),
+            ATTRIBUTE_OVERLAY_BIT   = 1 << CommonVertexAttribute.OVERLAY.ordinal(),
+            ATTRIBUTE_LIGHT_BIT     = 1 << CommonVertexAttribute.LIGHT.ordinal(),
+            ATTRIBUTE_NORMAL_BIT    = 1 << CommonVertexAttribute.NORMAL.ordinal();
+
+    private final ExtendedBufferBuilder builder;
+
+    private int
+            attributeOffsetPosition,
+            attributeOffsetColor,
+            attributeOffsetTexture,
+            attributeOffsetOverlay,
+            attributeOffsetLight,
+            attributeOffsetNormal;
+
+    private int requiredAttributes, writtenAttributes;
+
+    private int packedFixedColor;
+
+    public SodiumBufferBuilder(ExtendedBufferBuilder builder) {
+        this.builder = builder;
+        this.resetAttributeBindings();
+        this.updateAttributeBindings(this.builder.sodium$getFormatDescription());
+    }
+
+    private void resetAttributeBindings() {
+        this.requiredAttributes = 0;
+
+        this.attributeOffsetPosition = ATTRIBUTE_NOT_PRESENT;
+        this.attributeOffsetColor = ATTRIBUTE_NOT_PRESENT;
+        this.attributeOffsetTexture = ATTRIBUTE_NOT_PRESENT;
+        this.attributeOffsetOverlay = ATTRIBUTE_NOT_PRESENT;
+        this.attributeOffsetLight = ATTRIBUTE_NOT_PRESENT;
+        this.attributeOffsetNormal = ATTRIBUTE_NOT_PRESENT;
+    }
+
+    private void updateAttributeBindings(VertexFormatDescription desc) {
+        this.resetAttributeBindings();
+
+        if (desc.containsElement(CommonVertexAttribute.POSITION)) {
+            this.requiredAttributes |= ATTRIBUTE_POSITION_BIT;
+            this.attributeOffsetPosition = desc.getElementOffset(CommonVertexAttribute.POSITION);
+        }
+
+        if (desc.containsElement(CommonVertexAttribute.COLOR)) {
+            this.requiredAttributes |= ATTRIBUTE_COLOR_BIT;
+            this.attributeOffsetColor = desc.getElementOffset(CommonVertexAttribute.COLOR);
+        }
+
+        if (desc.containsElement(CommonVertexAttribute.TEXTURE)) {
+            this.requiredAttributes |= ATTRIBUTE_TEXTURE_BIT;
+            this.attributeOffsetTexture = desc.getElementOffset(CommonVertexAttribute.TEXTURE);
+        }
+
+        if (desc.containsElement(CommonVertexAttribute.OVERLAY)) {
+            this.requiredAttributes |= ATTRIBUTE_OVERLAY_BIT;
+            this.attributeOffsetOverlay = desc.getElementOffset(CommonVertexAttribute.OVERLAY);
+        }
+
+        if (desc.containsElement(CommonVertexAttribute.LIGHT)) {
+            this.requiredAttributes |= ATTRIBUTE_LIGHT_BIT;
+            this.attributeOffsetLight = desc.getElementOffset(CommonVertexAttribute.LIGHT);
+        }
+
+        if (desc.containsElement(CommonVertexAttribute.NORMAL)) {
+            this.requiredAttributes |= ATTRIBUTE_NORMAL_BIT;
+            this.attributeOffsetNormal = desc.getElementOffset(CommonVertexAttribute.NORMAL);
+        }
+    }
+
+    @Override
+    public void push(MemoryStack stack, long ptr, int count, VertexFormatDescription format) {
+        this.builder.push(stack, ptr, count, format);
+    }
+
+    @Unique
+    private void putPositionAttribute(float x, float y, float z) {
+        if (this.attributeOffsetPosition == ATTRIBUTE_NOT_PRESENT) {
+            return;
+        }
+
+        final long offset = MemoryUtil.memAddress(this.builder.sodium$getBuffer(), this.builder.sodium$getElementOffset() + this.attributeOffsetPosition);
+        PositionAttribute.put(offset, x, y, z);
+
+        this.writtenAttributes |= ATTRIBUTE_POSITION_BIT;
+    }
+
+
+    @Unique
+    private void putColorAttribute(int rgba) {
+        if (this.attributeOffsetColor == ATTRIBUTE_NOT_PRESENT) {
+            return;
+        }
+
+        final long offset = MemoryUtil.memAddress(this.builder.sodium$getBuffer(), this.builder.sodium$getElementOffset() + this.attributeOffsetColor);
+        ColorAttribute.set(offset, rgba);
+
+        this.writtenAttributes |= ATTRIBUTE_COLOR_BIT;
+    }
+
+    @Unique
+    private void putTextureAttribute(float u, float v) {
+        if (this.attributeOffsetTexture == ATTRIBUTE_NOT_PRESENT) {
+            return;
+        }
+
+        final long offset = MemoryUtil.memAddress(this.builder.sodium$getBuffer(), this.builder.sodium$getElementOffset() + this.attributeOffsetTexture);
+        TextureAttribute.put(offset, u, v);
+
+        this.writtenAttributes |= ATTRIBUTE_TEXTURE_BIT;
+    }
+
+    @Unique
+    private void putOverlayAttribute(int uv) {
+        if (this.attributeOffsetOverlay == ATTRIBUTE_NOT_PRESENT) {
+            return;
+        }
+
+        final long offset = MemoryUtil.memAddress(this.builder.sodium$getBuffer(), this.builder.sodium$getElementOffset() + this.attributeOffsetOverlay);
+        OverlayAttribute.set(offset, uv);
+
+        this.writtenAttributes |= ATTRIBUTE_OVERLAY_BIT;
+    }
+
+    @Unique
+    private void putLightAttribute(int uv) {
+        if (this.attributeOffsetLight == ATTRIBUTE_NOT_PRESENT) {
+            return;
+        }
+
+        final long offset = MemoryUtil.memAddress(this.builder.sodium$getBuffer(), this.builder.sodium$getElementOffset() + this.attributeOffsetLight);
+        LightAttribute.set(offset, uv);
+
+        this.writtenAttributes |= ATTRIBUTE_LIGHT_BIT;
+    }
+
+    @Unique
+    private void putNormalAttribute(int normal) {
+        if (this.attributeOffsetNormal == ATTRIBUTE_NOT_PRESENT) {
+            return;
+        }
+
+        final long offset = MemoryUtil.memAddress(this.builder.sodium$getBuffer(), this.builder.sodium$getElementOffset() + this.attributeOffsetNormal);
+        NormalAttribute.set(offset, normal);
+
+        this.writtenAttributes |= ATTRIBUTE_NORMAL_BIT;
+    }
+
+    @Override
+    public void vertex(float x, float y, float z,
+                       float red, float green, float blue, float alpha,
+                       float u, float v,
+                       int overlay, int light,
+                       float normalX, float normalY, float normalZ
+    ) {
+        if (this.builder.sodium$usingFixedColor()) {
+            throw new IllegalStateException();
+        }
+
+        final long offset = MemoryUtil.memAddress(this.builder.sodium$getBuffer(), this.builder.sodium$getElementOffset());
+
+        if (this.attributeOffsetPosition != ATTRIBUTE_NOT_PRESENT) {
+            PositionAttribute.put(offset + this.attributeOffsetPosition, x, y, z);
+        }
+
+        if (this.attributeOffsetColor != ATTRIBUTE_NOT_PRESENT) {
+            ColorAttribute.set(offset + this.attributeOffsetColor, ColorABGR.pack(red, green, blue, alpha));
+        }
+
+        if (this.attributeOffsetTexture != ATTRIBUTE_NOT_PRESENT) {
+            TextureAttribute.put(offset + this.attributeOffsetTexture, u, v);
+        }
+
+        if (this.attributeOffsetOverlay != ATTRIBUTE_NOT_PRESENT) {
+            OverlayAttribute.set(offset + this.attributeOffsetOverlay, overlay);
+        }
+
+        if (this.attributeOffsetLight != ATTRIBUTE_NOT_PRESENT) {
+            LightAttribute.set(offset + this.attributeOffsetLight, light);
+        }
+
+        if (this.attributeOffsetNormal != ATTRIBUTE_NOT_PRESENT) {
+            NormalAttribute.set(offset + this.attributeOffsetNormal, NormI8.pack(normalX, normalY, normalZ));
+        }
+
+        // It's okay to mark elements as "written to" even if the vertex format does not specify those elements.
+        this.writtenAttributes = ATTRIBUTE_POSITION_BIT | ATTRIBUTE_COLOR_BIT | ATTRIBUTE_TEXTURE_BIT |
+                ATTRIBUTE_OVERLAY_BIT | ATTRIBUTE_LIGHT_BIT | ATTRIBUTE_NORMAL_BIT;
+
+        this.next();
+    }
+
+    @Override
+    public void fixedColor(int red, int green, int blue, int alpha) {
+        ((BufferBuilder)this.builder).fixedColor(red, green, blue, alpha);
+        this.packedFixedColor = ColorABGR.pack(red, green, blue, alpha);
+    }
+
+    @Override
+    public void unfixColor() {
+        ((BufferBuilder)this.builder).unfixColor();
+    }
+
+    @Override
+    public VertexConsumer vertex(double x, double y, double z) {
+        this.putPositionAttribute((float) x, (float) y, (float) z);
+
+        return this;
+    }
+
+    @Override
+    public VertexConsumer color(int red, int green, int blue, int alpha) {
+        if (this.builder.sodium$usingFixedColor()) {
+            throw new IllegalStateException();
+        }
+
+        this.putColorAttribute(ColorABGR.pack(red, green, blue, alpha));
+
+        return this;
+    }
+
+    @Override
+    public VertexConsumer color(int argb) { // No, this isn't a typo. One method takes RGBA, but this one takes ARGB.
+        if (this.builder.sodium$usingFixedColor()) {
+            throw new IllegalStateException();
+        }
+
+        // This should be RGBA.
+        // There is no reason it should be anything other than RGBA.
+        // It should certainly never be ABGR.
+        // But it is.
+        // Why?
+        this.putColorAttribute(ColorARGB.toABGR(argb));
+
+        return this;
+    }
+
+    @Override
+    public VertexConsumer texture(float u, float v) {
+        this.putTextureAttribute(u, v);
+
+        return this;
+    }
+
+    @Override
+    public VertexConsumer overlay(int uv) {
+        this.putOverlayAttribute(uv);
+
+        return this;
+    }
+
+
+    @Override
+    public VertexConsumer light(int uv) {
+        this.putLightAttribute(uv);
+
+        return this;
+    }
+    @Override
+    public VertexConsumer normal(float x, float y, float z) {
+        this.putNormalAttribute(NormI8.pack(x, y, z));
+
+        return this;
+    }
+
+    @Override
+    public void next() {
+        if (this.builder.sodium$usingFixedColor()) {
+            this.putColorAttribute(this.packedFixedColor);
+        }
+
+        if (!this.isVertexFinished()) {
+            throw new IllegalStateException("Not filled all elements of the vertex");
+        }
+
+        this.builder.sodium$moveToNextVertex();
+
+        this.writtenAttributes = 0;
+    }
+
+    private boolean isVertexFinished() {
+        return (this.writtenAttributes & this.requiredAttributes) == this.requiredAttributes;
+    }
+
+    @Override
+    public VertexConsumer light(int u, int v) {
+        return this.light(packU16x2(u, v));
+    }
+
+    @Override
+    public VertexConsumer overlay(int u, int v) {
+        return this.overlay(packU16x2(u, v));
+    }
+
+    @Unique
+    private static int packU16x2(int u, int v) {
+        return (u & 0xFFFF) << 0 |
+                (v & 0xFFFF) << 16;
+    }
+}

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/vertex/buffer/SodiumBufferBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/vertex/buffer/SodiumBufferBuilder.java
@@ -299,6 +299,10 @@ public class SodiumBufferBuilder implements VertexConsumer, VertexBufferWriter {
         this.writtenAttributes = 0;
     }
 
+    public void reset() {
+        this.writtenAttributes = 0;
+    }
+
     private boolean isVertexFinished() {
         return (this.writtenAttributes & this.requiredAttributes) == this.requiredAttributes;
     }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/vertex/buffer/SodiumBufferBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/vertex/buffer/SodiumBufferBuilder.java
@@ -94,6 +94,11 @@ public class SodiumBufferBuilder implements VertexConsumer, VertexBufferWriter {
         this.builder.push(stack, ptr, count, format);
     }
 
+    @Override
+    public boolean canUseIntrinsics() {
+        return this.builder.canUseIntrinsics();
+    }
+
     @Unique
     private void putPositionAttribute(float x, float y, float z) {
         if (this.attributeOffsetPosition == ATTRIBUTE_NOT_PRESENT) {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/vertex/buffer/SodiumBufferBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/vertex/buffer/SodiumBufferBuilder.java
@@ -303,6 +303,10 @@ public class SodiumBufferBuilder implements VertexConsumer, VertexBufferWriter {
         this.writtenAttributes = 0;
     }
 
+    public BufferBuilder getOriginalBufferBuilder() {
+        return (BufferBuilder)this.builder;
+    }
+
     private boolean isVertexFinished() {
         return (this.writtenAttributes & this.requiredAttributes) == this.requiredAttributes;
     }

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/BufferBuilderMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/BufferBuilderMixin.java
@@ -1,5 +1,6 @@
 package me.jellysquid.mods.sodium.mixin.core.render.immediate.consumer;
 
+import me.jellysquid.mods.sodium.client.render.vertex.buffer.ExtendedBufferBuilder;
 import net.caffeinemc.mods.sodium.api.memory.MemoryIntrinsics;
 import net.caffeinemc.mods.sodium.api.util.ColorABGR;
 import net.caffeinemc.mods.sodium.api.util.ColorARGB;
@@ -25,21 +26,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import java.nio.ByteBuffer;
 
 @Mixin(BufferBuilder.class)
-public abstract class BufferBuilderMixin extends FixedColorVertexConsumer implements VertexBufferWriter {
+public abstract class BufferBuilderMixin extends FixedColorVertexConsumer implements VertexBufferWriter, ExtendedBufferBuilder {
     @Shadow
     protected abstract void grow(int size);
-
-    @Unique
-    private static final int ATTRIBUTE_NOT_PRESENT = -1;
-
-    @Unique
-    private static final int
-            ATTRIBUTE_POSITION_BIT  = 1 << CommonVertexAttribute.POSITION.ordinal(),
-            ATTRIBUTE_COLOR_BIT     = 1 << CommonVertexAttribute.COLOR.ordinal(),
-            ATTRIBUTE_TEXTURE_BIT   = 1 << CommonVertexAttribute.TEXTURE.ordinal(),
-            ATTRIBUTE_OVERLAY_BIT   = 1 << CommonVertexAttribute.OVERLAY.ordinal(),
-            ATTRIBUTE_LIGHT_BIT     = 1 << CommonVertexAttribute.LIGHT.ordinal(),
-            ATTRIBUTE_NORMAL_BIT    = 1 << CommonVertexAttribute.NORMAL.ordinal();
 
     @Shadow
     private ByteBuffer buffer;
@@ -59,35 +48,6 @@ public abstract class BufferBuilderMixin extends FixedColorVertexConsumer implem
     @Unique
     private int vertexStride;
 
-    @Unique
-    private int
-            attributeOffsetPosition,
-            attributeOffsetColor,
-            attributeOffsetTexture,
-            attributeOffsetOverlay,
-            attributeOffsetLight,
-            attributeOffsetNormal;
-
-    @Unique
-    private int requiredAttributes, writtenAttributes;
-
-    @Inject(method = "<init>", at = @At("RETURN"))
-    private void onInit(int initialCapacity, CallbackInfo ci) {
-        this.resetAttributeBindings();
-    }
-
-    @Unique
-    private void resetAttributeBindings() {
-        this.requiredAttributes = 0;
-
-        this.attributeOffsetPosition = ATTRIBUTE_NOT_PRESENT;
-        this.attributeOffsetColor = ATTRIBUTE_NOT_PRESENT;
-        this.attributeOffsetTexture = ATTRIBUTE_NOT_PRESENT;
-        this.attributeOffsetOverlay = ATTRIBUTE_NOT_PRESENT;
-        this.attributeOffsetLight = ATTRIBUTE_NOT_PRESENT;
-        this.attributeOffsetNormal = ATTRIBUTE_NOT_PRESENT;
-    }
-
     @Inject(
             method = "setFormat",
             at = @At(
@@ -100,325 +60,27 @@ public abstract class BufferBuilderMixin extends FixedColorVertexConsumer implem
         this.formatDescription = VertexFormatRegistry.instance()
                 .get(format);
         this.vertexStride = this.formatDescription.stride();
-
-        this.updateAttributeBindings(this.formatDescription);
-    }
-
-    @Unique
-    private void updateAttributeBindings(VertexFormatDescription desc) {
-        this.resetAttributeBindings();
-
-        if (desc.containsElement(CommonVertexAttribute.POSITION)) {
-            this.requiredAttributes |= ATTRIBUTE_POSITION_BIT;
-            this.attributeOffsetPosition = desc.getElementOffset(CommonVertexAttribute.POSITION);
-        }
-
-        if (desc.containsElement(CommonVertexAttribute.COLOR)) {
-            this.requiredAttributes |= ATTRIBUTE_COLOR_BIT;
-            this.attributeOffsetColor = desc.getElementOffset(CommonVertexAttribute.COLOR);
-        }
-
-        if (desc.containsElement(CommonVertexAttribute.TEXTURE)) {
-            this.requiredAttributes |= ATTRIBUTE_TEXTURE_BIT;
-            this.attributeOffsetTexture = desc.getElementOffset(CommonVertexAttribute.TEXTURE);
-        }
-
-        if (desc.containsElement(CommonVertexAttribute.OVERLAY)) {
-            this.requiredAttributes |= ATTRIBUTE_OVERLAY_BIT;
-            this.attributeOffsetOverlay = desc.getElementOffset(CommonVertexAttribute.OVERLAY);
-        }
-
-        if (desc.containsElement(CommonVertexAttribute.LIGHT)) {
-            this.requiredAttributes |= ATTRIBUTE_LIGHT_BIT;
-            this.attributeOffsetLight = desc.getElementOffset(CommonVertexAttribute.LIGHT);
-        }
-
-        if (desc.containsElement(CommonVertexAttribute.NORMAL)) {
-            this.requiredAttributes |= ATTRIBUTE_NORMAL_BIT;
-            this.attributeOffsetNormal = desc.getElementOffset(CommonVertexAttribute.NORMAL);
-        }
-    }
-
-    @Inject(
-            method = "begin",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/minecraft/client/render/BufferBuilder;setFormat(Lnet/minecraft/client/render/VertexFormat;)V"
-            )
-    )
-    private void onBegin(VertexFormat.DrawMode drawMode, VertexFormat format, CallbackInfo ci) {
-        this.writtenAttributes = 0;
-    }
-
-    @Inject(method = "resetBuilding", at = @At("RETURN"))
-    private void onResetBuilding(CallbackInfo ci) {
-        this.writtenAttributes = 0;
-    }
-
-    @Inject(method = "reset", at = @At("RETURN"))
-    private void onReset(CallbackInfo ci) {
-        this.writtenAttributes = 0;
-    }
-
-    @Unique
-    private void putPositionAttribute(float x, float y, float z) {
-        if (this.attributeOffsetPosition == ATTRIBUTE_NOT_PRESENT) {
-            return;
-        }
-
-        final long offset = MemoryUtil.memAddress(this.buffer, this.elementOffset + this.attributeOffsetPosition);
-        PositionAttribute.put(offset, x, y, z);
-
-        this.writtenAttributes |= ATTRIBUTE_POSITION_BIT;
-    }
-
-
-    @Unique
-    private void putColorAttribute(int rgba) {
-        if (this.attributeOffsetColor == ATTRIBUTE_NOT_PRESENT) {
-            return;
-        }
-
-        final long offset = MemoryUtil.memAddress(this.buffer, this.elementOffset + this.attributeOffsetColor);
-        ColorAttribute.set(offset, rgba);
-
-        this.writtenAttributes |= ATTRIBUTE_COLOR_BIT;
-    }
-
-    @Unique
-    private void putTextureAttribute(float u, float v) {
-        if (this.attributeOffsetTexture == ATTRIBUTE_NOT_PRESENT) {
-            return;
-        }
-
-        final long offset = MemoryUtil.memAddress(this.buffer, this.elementOffset + this.attributeOffsetTexture);
-        TextureAttribute.put(offset, u, v);
-
-        this.writtenAttributes |= ATTRIBUTE_TEXTURE_BIT;
-    }
-
-    @Unique
-    private void putOverlayAttribute(int uv) {
-        if (this.attributeOffsetOverlay == ATTRIBUTE_NOT_PRESENT) {
-            return;
-        }
-
-        final long offset = MemoryUtil.memAddress(this.buffer, this.elementOffset + this.attributeOffsetOverlay);
-        OverlayAttribute.set(offset, uv);
-
-        this.writtenAttributes |= ATTRIBUTE_OVERLAY_BIT;
-    }
-
-    @Unique
-    private void putLightAttribute(int uv) {
-        if (this.attributeOffsetLight == ATTRIBUTE_NOT_PRESENT) {
-            return;
-        }
-
-        final long offset = MemoryUtil.memAddress(this.buffer, this.elementOffset + this.attributeOffsetLight);
-        LightAttribute.set(offset, uv);
-
-        this.writtenAttributes |= ATTRIBUTE_LIGHT_BIT;
-    }
-
-    @Unique
-    private void putNormalAttribute(int normal) {
-        if (this.attributeOffsetNormal == ATTRIBUTE_NOT_PRESENT) {
-            return;
-        }
-
-        final long offset = MemoryUtil.memAddress(this.buffer, this.elementOffset + this.attributeOffsetNormal);
-        NormalAttribute.set(offset, normal);
-
-        this.writtenAttributes |= ATTRIBUTE_NORMAL_BIT;
     }
 
     @Override
-    public void vertex(float x, float y, float z,
-                       float red, float green, float blue, float alpha,
-                       float u, float v,
-                       int overlay, int light,
-                       float normalX, float normalY, float normalZ
-    ) {
-        if (this.colorFixed) {
-            throw new IllegalStateException();
-        }
-
-        final long offset = MemoryUtil.memAddress(this.buffer, this.elementOffset);
-
-        if (this.attributeOffsetPosition != ATTRIBUTE_NOT_PRESENT) {
-            PositionAttribute.put(offset + this.attributeOffsetPosition, x, y, z);
-        }
-
-        if (this.attributeOffsetColor != ATTRIBUTE_NOT_PRESENT) {
-            ColorAttribute.set(offset + this.attributeOffsetColor, ColorABGR.pack(red, green, blue, alpha));
-        }
-
-        if (this.attributeOffsetTexture != ATTRIBUTE_NOT_PRESENT) {
-            TextureAttribute.put(offset + this.attributeOffsetTexture, u, v);
-        }
-
-        if (this.attributeOffsetOverlay != ATTRIBUTE_NOT_PRESENT) {
-            OverlayAttribute.set(offset + this.attributeOffsetOverlay, overlay);
-        }
-
-        if (this.attributeOffsetLight != ATTRIBUTE_NOT_PRESENT) {
-            LightAttribute.set(offset + this.attributeOffsetLight, light);
-        }
-
-        if (this.attributeOffsetNormal != ATTRIBUTE_NOT_PRESENT) {
-            NormalAttribute.set(offset + this.attributeOffsetNormal, NormI8.pack(normalX, normalY, normalZ));
-        }
-
-        // It's okay to mark elements as "written to" even if the vertex format does not specify those elements.
-        this.writtenAttributes = ATTRIBUTE_POSITION_BIT | ATTRIBUTE_COLOR_BIT | ATTRIBUTE_TEXTURE_BIT |
-                ATTRIBUTE_OVERLAY_BIT | ATTRIBUTE_LIGHT_BIT | ATTRIBUTE_NORMAL_BIT;
-
-        this.next();
+    public ByteBuffer sodium$getBuffer() {
+        return this.buffer;
     }
 
     @Override
-    public VertexConsumer vertex(double x, double y, double z) {
-        this.putPositionAttribute((float) x, (float) y, (float) z);
-
-        return this;
+    public int sodium$getElementOffset() {
+        return this.elementOffset;
     }
 
     @Override
-    public VertexConsumer color(int red, int green, int blue, int alpha) {
-        if (this.colorFixed) {
-            throw new IllegalStateException();
-        }
-
-        this.putColorAttribute(ColorABGR.pack(red, green, blue, alpha));
-
-        return this;
+    public VertexFormatDescription sodium$getFormatDescription() {
+        return this.formatDescription;
     }
 
     @Override
-    public VertexConsumer color(int argb) { // No, this isn't a typo. One method takes RGBA, but this one takes ARGB.
-        if (this.colorFixed) {
-            throw new IllegalStateException();
-        }
-
-        // This should be RGBA.
-        // There is no reason it should be anything other than RGBA.
-        // It should certainly never be ABGR.
-        // But it is.
-        // Why?
-        this.putColorAttribute(ColorARGB.toABGR(argb));
-
-        return this;
-    }
-
-    @Override
-    public VertexConsumer texture(float u, float v) {
-        this.putTextureAttribute(u, v);
-
-        return this;
-    }
-
-    @Override
-    public VertexConsumer overlay(int uv) {
-        this.putOverlayAttribute(uv);
-
-        return this;
-    }
-
-
-    @Override
-    public VertexConsumer light(int uv) {
-        this.putLightAttribute(uv);
-
-        return this;
-    }
-    @Override
-    public VertexConsumer normal(float x, float y, float z) {
-        this.putNormalAttribute(NormI8.pack(x, y, z));
-
-        return this;
-    }
-
-    @Override
-    public VertexConsumer light(int u, int v) {
-        return this.light(packU16x2(u, v));
-    }
-
-    @Override
-    public VertexConsumer overlay(int u, int v) {
-        return this.overlay(packU16x2(u, v));
-    }
-
-    @Unique
-    private static int packU16x2(int u, int v) {
-        return (u & 0xFFFF) << 0 |
-                (v & 0xFFFF) << 16;
-    }
-
-    /**
-     * @author JellySquid
-     * @reason Only used by BufferVertexConsumer's default implementations, which our patches remove
-     */
-    @Overwrite
-    public VertexFormatElement getCurrentElement() {
-        throw createBlockedUpcallException();
-    }
-
-    /**
-     * @author JellySquid
-     * @reason Only used by BufferVertexConsumer's default implementations, which our patches remove
-     */
-    @Overwrite
-    public void nextElement() {
-        throw createBlockedUpcallException();
-    }
-
-    /**
-     * @author JellySquid
-     * @reason Only used by BufferVertexConsumer's default implementations, which our patches remove
-     */
-    @Overwrite
-    public void putByte(int index, byte value) {
-        throw createBlockedUpcallException();
-    }
-
-    /**
-     * @author JellySquid
-     * @reason Only used by BufferVertexConsumer's default implementations, which our patches remove
-     */
-    @Overwrite
-    public void putShort(int index, short value) {
-        throw createBlockedUpcallException();
-    }
-
-    /**
-     * @author JellySquid
-     * @reason Only used by BufferVertexConsumer's default implementations, which our patches remove
-     */
-    @Overwrite
-    public void putFloat(int index, float value) {
-        throw createBlockedUpcallException();
-    }
-
-    /**
-     * @author JellySquid
-     * @reason The implementation no longer cares about the current element
-     */
-    @Overwrite
-    @Override
-    public void next() {
-        if (this.colorFixed) {
-            this.writeFixedColor();
-        }
-
-        if (!this.isVertexFinished()) {
-            throw new IllegalStateException("Not filled all elements of the vertex");
-        }
-
+    public void sodium$moveToNextVertex() {
         this.vertexCount++;
         this.elementOffset += this.vertexStride;
-
-        this.writtenAttributes = 0;
 
         this.grow(this.vertexStride);
 
@@ -427,14 +89,9 @@ public abstract class BufferBuilderMixin extends FixedColorVertexConsumer implem
         }
     }
 
-    @Unique
-    private boolean isVertexFinished() {
-        return (this.writtenAttributes & this.requiredAttributes) == this.requiredAttributes;
-    }
-
-    @Unique
-    private void writeFixedColor() {
-        this.putColorAttribute(ColorABGR.pack(this.fixedRed, this.fixedGreen, this.fixedBlue, this.fixedAlpha));
+    @Override
+    public boolean sodium$usingFixedColor() {
+        return this.colorFixed;
     }
 
     @Unique
@@ -489,10 +146,5 @@ public abstract class BufferBuilderMixin extends FixedColorVertexConsumer implem
         VertexSerializerRegistry.instance()
                 .get(format, this.formatDescription)
                 .serialize(src, dst, count);
-    }
-
-    @Unique
-    private static RuntimeException createBlockedUpcallException() {
-        return new UnsupportedOperationException("The internal methods provided by BufferVertexConsumer (as used to upcall into BufferBuilder) are unsupported");
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/BufferBuilderMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/BufferBuilderMixin.java
@@ -130,7 +130,7 @@ public abstract class BufferBuilderMixin extends FixedColorVertexConsumer implem
 
     @Override
     public boolean canUseIntrinsics() {
-        return true;
+        return this.formatDescription != null && this.formatDescription.isSimpleFormat();
     }
 
     @Override

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/VertexConsumerProviderImmediateMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/VertexConsumerProviderImmediateMixin.java
@@ -11,7 +11,9 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import java.util.Map;
 import java.util.Set;
@@ -29,10 +31,9 @@ public class VertexConsumerProviderImmediateMixin {
         }
     }
 
-    @Redirect(method = "draw(Lnet/minecraft/client/render/RenderLayer;)V", at = @At(value = "INVOKE", target = "Ljava/util/Set;remove(Ljava/lang/Object;)Z"))
-    private boolean stopReplacement(Set<BufferBuilder> instance, Object bufferbuilder) {
-        bufferBuilderReplacements.remove(bufferbuilder);
-        return instance.remove(bufferbuilder);
+    @Inject(method = "draw(Lnet/minecraft/client/render/RenderLayer;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/RenderLayer;draw(Lnet/minecraft/client/render/BufferBuilder;Lcom/mojang/blaze3d/systems/VertexSorter;)V"), locals = LocalCapture.CAPTURE_FAILHARD)
+    private void stopReplacement(RenderLayer layer, CallbackInfo ci, BufferBuilder buffer) {
+        bufferBuilderReplacements.remove(buffer);
     }
 
     @Inject(method = "getBuffer", at = @At("RETURN"), cancellable = true)

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/VertexConsumerProviderImmediateMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/VertexConsumerProviderImmediateMixin.java
@@ -1,0 +1,45 @@
+package me.jellysquid.mods.sodium.mixin.core.render.immediate.consumer;
+
+import com.mojang.blaze3d.systems.VertexSorter;
+import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
+import me.jellysquid.mods.sodium.client.render.vertex.buffer.ExtendedBufferBuilder;
+import me.jellysquid.mods.sodium.client.render.vertex.buffer.SodiumBufferBuilder;
+import net.caffeinemc.mods.sodium.api.vertex.format.VertexFormatRegistry;
+import net.minecraft.client.render.*;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Map;
+import java.util.Set;
+
+@Mixin(VertexConsumerProvider.Immediate.class)
+public class VertexConsumerProviderImmediateMixin {
+    @Unique
+    private final Map<VertexConsumer, SodiumBufferBuilder> bufferBuilderReplacements = new Reference2ReferenceOpenHashMap<>();
+
+    @Redirect(method = "getBuffer", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/BufferBuilder;begin(Lnet/minecraft/client/render/VertexFormat$DrawMode;Lnet/minecraft/client/render/VertexFormat;)V"))
+    private void startReplacement(BufferBuilder instance, VertexFormat.DrawMode drawMode, VertexFormat format) {
+        instance.begin(drawMode, format);
+        if (VertexFormatRegistry.instance().get(format).isSimpleFormat()) {
+            bufferBuilderReplacements.put(instance, new SodiumBufferBuilder((ExtendedBufferBuilder)instance));
+        }
+    }
+
+    @Redirect(method = "draw(Lnet/minecraft/client/render/RenderLayer;)V", at = @At(value = "INVOKE", target = "Ljava/util/Set;remove(Ljava/lang/Object;)Z"))
+    private boolean stopReplacement(Set<BufferBuilder> instance, Object bufferbuilder) {
+        bufferBuilderReplacements.remove(bufferbuilder);
+        return instance.remove(bufferbuilder);
+    }
+
+    @Inject(method = "getBuffer", at = @At("RETURN"), cancellable = true)
+    private void useFasterVertexConsumer(RenderLayer layer, CallbackInfoReturnable<VertexConsumer> cir) {
+        SodiumBufferBuilder replacement = bufferBuilderReplacements.get(cir.getReturnValue());
+        if (replacement != null) {
+            cir.setReturnValue(replacement);
+        }
+    }
+}

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/VertexConsumerProviderImmediateMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/VertexConsumerProviderImmediateMixin.java
@@ -1,46 +1,24 @@
 package me.jellysquid.mods.sodium.mixin.core.render.immediate.consumer;
 
-import com.mojang.blaze3d.systems.VertexSorter;
-import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
 import me.jellysquid.mods.sodium.client.render.vertex.buffer.ExtendedBufferBuilder;
 import me.jellysquid.mods.sodium.client.render.vertex.buffer.SodiumBufferBuilder;
-import net.caffeinemc.mods.sodium.api.vertex.format.VertexFormatRegistry;
-import net.minecraft.client.render.*;
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.VertexConsumerProvider;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
-
-import java.util.Map;
-import java.util.Set;
 
 @Mixin(VertexConsumerProvider.Immediate.class)
 public class VertexConsumerProviderImmediateMixin {
-    @Unique
-    private final Map<VertexConsumer, SodiumBufferBuilder> bufferBuilderReplacements = new Reference2ReferenceOpenHashMap<>();
-
-    @Redirect(method = "getBuffer", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/BufferBuilder;begin(Lnet/minecraft/client/render/VertexFormat$DrawMode;Lnet/minecraft/client/render/VertexFormat;)V"))
-    private void startReplacement(BufferBuilder instance, VertexFormat.DrawMode drawMode, VertexFormat format) {
-        instance.begin(drawMode, format);
-        if (VertexFormatRegistry.instance().get(format).isSimpleFormat()) {
-            bufferBuilderReplacements.put(instance, new SodiumBufferBuilder((ExtendedBufferBuilder)instance));
-        }
-    }
-
-    @Inject(method = "draw(Lnet/minecraft/client/render/RenderLayer;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/RenderLayer;draw(Lnet/minecraft/client/render/BufferBuilder;Lcom/mojang/blaze3d/systems/VertexSorter;)V"), locals = LocalCapture.CAPTURE_FAILHARD)
-    private void stopReplacement(RenderLayer layer, CallbackInfo ci, BufferBuilder buffer) {
-        bufferBuilderReplacements.remove(buffer);
-    }
-
     @Inject(method = "getBuffer", at = @At("RETURN"), cancellable = true)
     private void useFasterVertexConsumer(RenderLayer layer, CallbackInfoReturnable<VertexConsumer> cir) {
-        SodiumBufferBuilder replacement = bufferBuilderReplacements.get(cir.getReturnValue());
-        if (replacement != null) {
-            cir.setReturnValue(replacement);
+        if(cir.getReturnValue() instanceof ExtendedBufferBuilder bufferBuilder) {
+            SodiumBufferBuilder replacement = bufferBuilder.sodium$getDelegate();
+            if (replacement != null) {
+                cir.setReturnValue(replacement);
+            }
         }
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/VertexConsumerProviderImmediateMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/immediate/consumer/VertexConsumerProviderImmediateMixin.java
@@ -8,17 +8,27 @@ import net.minecraft.client.render.VertexConsumerProvider;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(VertexConsumerProvider.Immediate.class)
 public class VertexConsumerProviderImmediateMixin {
     @Inject(method = "getBuffer", at = @At("RETURN"), cancellable = true)
     private void useFasterVertexConsumer(RenderLayer layer, CallbackInfoReturnable<VertexConsumer> cir) {
-        if(cir.getReturnValue() instanceof ExtendedBufferBuilder bufferBuilder) {
+        if (cir.getReturnValue() instanceof ExtendedBufferBuilder bufferBuilder) {
             SodiumBufferBuilder replacement = bufferBuilder.sodium$getDelegate();
             if (replacement != null) {
                 cir.setReturnValue(replacement);
             }
+        }
+    }
+
+    @ModifyVariable(method = "method_24213", at = @At(value = "LOAD", ordinal = 0))
+    private VertexConsumer changeComparedVertexConsumer(VertexConsumer input) {
+        if (input instanceof SodiumBufferBuilder replacement) {
+            return replacement.getOriginalBufferBuilder();
+        } else {
+            return input;
         }
     }
 }

--- a/src/main/resources/sodium.mixins.json
+++ b/src/main/resources/sodium.mixins.json
@@ -22,6 +22,7 @@
     "core.render.immediate.consumer.OutlineVertexConsumerMixin",
     "core.render.immediate.consumer.OverlayVertexConsumerMixin",
     "core.render.immediate.consumer.SpriteTexturedVertexConsumerMixin",
+    "core.render.immediate.consumer.VertexConsumerProviderImmediateMixin",
     "core.render.immediate.consumer.VertexConsumersMixin$DualMixin",
     "core.render.immediate.consumer.VertexConsumersMixin$UnionMixin",
     "core.render.world.BufferBuilderStorageMixin",


### PR DESCRIPTION
This PR implements #2240. The original `BufferBuilder` method implementations have been restored, and a new wrapper class is created that is returned by `VertexConsumerProvider.Immediate`.

Please feel free to critique the implementation; it was put together relatively quickly (and then many hours were spent debugging batching being broken).