### PR TITLE
Avoid shader compiler warnings

### DIFF
--- a/src/main/resources/assets/sodium/shaders/blocks/block_layer_opaque.vsh
+++ b/src/main/resources/assets/sodium/shaders/blocks/block_layer_opaque.vsh
@@ -9,7 +9,9 @@ out vec4 v_Color;
 out vec2 v_TexCoord;
 
 out float v_MaterialMipBias;
+#ifdef USE_FRAGMENT_DISCARD
 out float v_MaterialAlphaCutoff;
+#endif
 
 #ifdef USE_FOG
 out float v_FragDistance;
@@ -52,5 +54,7 @@ void main() {
     v_TexCoord = _vert_tex_diffuse_coord;
 
     v_MaterialMipBias = _material_mip_bias(_material_params);
+#ifdef USE_FRAGMENT_DISCARD
     v_MaterialAlphaCutoff = _material_alpha_cutoff(_material_params);
+#endif
 }


### PR DESCRIPTION
Usually it prints the following warnings to the console:
```
[18:32:03] [Render thread/WARN] (GlProgram) Program link log for sodium:chunk_shader: WARNING: Output of vertex shader 'v_MaterialAlphaCutoff' not read by fragment shader

[18:32:03] [Render thread/WARN] (GlProgram) Program link log for sodium:chunk_shader: WARNING: Output of vertex shader 'v_MaterialAlphaCutoff' not read by fragment shader
```
This might not happen on all systems due to differences in drivers, but on macOS it always does this when loading or reloading a world. Not declaring this out variable avoids the shader compiler warning by only adding it if the fragment shader is actually going to read it.