### PR TITLE
Account for XDG_CURRENT_DESKTOP being unset

### DIFF
--- a/src/desktop/java/net/caffeinemc/mods/sodium/desktop/utils/browse/GNOMEImpl.java
+++ b/src/desktop/java/net/caffeinemc/mods/sodium/desktop/utils/browse/GNOMEImpl.java
@@ -1,10 +1,11 @@
 package net.caffeinemc.mods.sodium.desktop.utils.browse;
 
 import java.io.IOException;
+import java.util.Objects;
 
 class GNOMEImpl implements BrowseUrlHandler {
     public static boolean isSupported() {
-        return XDGImpl.isSupported() && System.getenv("XDG_CURRENT_DESKTOP").equals("GNOME");
+        return XDGImpl.isSupported() && Objects.equals(System.getenv("XDG_CURRENT_DESKTOP"), "GNOME");
     }
 
     @Override

--- a/src/desktop/java/net/caffeinemc/mods/sodium/desktop/utils/browse/KDEImpl.java
+++ b/src/desktop/java/net/caffeinemc/mods/sodium/desktop/utils/browse/KDEImpl.java
@@ -1,10 +1,11 @@
 package net.caffeinemc.mods.sodium.desktop.utils.browse;
 
 import java.io.IOException;
+import java.util.Objects;
 
 class KDEImpl implements BrowseUrlHandler {
     public static boolean isSupported() {
-        return XDGImpl.isSupported() && System.getenv("XDG_CURRENT_DESKTOP").equals("KDE");
+        return XDGImpl.isSupported() && Objects.equals(System.getenv("XDG_CURRENT_DESKTOP"), "KDE");
     }
 
     @Override


### PR DESCRIPTION
Simply put some distributions (puppy linux) don't have `XDG_CURRENT_DESKTOP` set.