### PR TITLE
Fix world not rendering above or below min/max height

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/occlusion/OcclusionCuller.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/occlusion/OcclusionCuller.java
@@ -293,7 +293,7 @@ public class OcclusionCuller {
     private void tryVisitNode(WriteQueue<RenderSection> queue, int x, int y, int z, int direction, int frame, Viewport viewport) {
         RenderSection section = this.getRenderSection(x, y, z);
 
-        if (section == null || isWithinFrustum(viewport, section)) {
+        if (section == null || !isWithinFrustum(viewport, section)) {
             return;
         }
 


### PR DESCRIPTION
Issue reported by a user on Discord [here](https://discord.com/channels/602796788608401408/752637878462578778/1200975571518246953). This is a regression from https://github.com/CaffeineMC/sodium-fabric/commit/27e531f36479c4de63c36afdc5b8707d96487c16.