### PR TITLE
Allow using the space key to activate elements in the Sodium video options screen

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/CyclingControl.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/CyclingControl.java
@@ -5,6 +5,7 @@ import me.jellysquid.mods.sodium.client.gui.options.TextProvider;
 import me.jellysquid.mods.sodium.client.util.Dim2i;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.input.KeyCodes;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.text.Text;
 import org.apache.commons.lang3.Validate;
@@ -112,7 +113,7 @@ public class CyclingControl<T extends Enum<T>> implements Control<T> {
         public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
             if (!isFocused()) return false;
 
-            if (keyCode == InputUtil.GLFW_KEY_ENTER) {
+            if (KeyCodes.isToggle(keyCode)) {
                 cycleControl(Screen.hasShiftDown());
                 return true;
             }

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/TickBoxControl.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/TickBoxControl.java
@@ -3,6 +3,7 @@ package me.jellysquid.mods.sodium.client.gui.options.control;
 import me.jellysquid.mods.sodium.client.gui.options.Option;
 import me.jellysquid.mods.sodium.client.util.Dim2i;
 import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.input.KeyCodes;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.client.util.math.Rect2i;
 
@@ -80,7 +81,7 @@ public class TickBoxControl implements Control<Boolean> {
         public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
             if (!isFocused()) return false;
 
-            if (keyCode == InputUtil.GLFW_KEY_ENTER) {
+            if (KeyCodes.isToggle(keyCode)) {
                 toggleControl();
                 this.playClickSound();
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/widgets/FlatButtonWidget.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/widgets/FlatButtonWidget.java
@@ -6,6 +6,7 @@ import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.ScreenRect;
 import net.minecraft.client.gui.navigation.GuiNavigation;
 import net.minecraft.client.gui.navigation.GuiNavigationPath;
+import net.minecraft.client.input.KeyCodes;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.text.Text;
 import org.jetbrains.annotations.NotNull;
@@ -85,7 +86,7 @@ public class FlatButtonWidget extends AbstractWidget implements Drawable {
         if (!this.isFocused())
             return false;
 
-        if (keyCode == InputUtil.GLFW_KEY_ENTER) {
+        if (KeyCodes.isToggle(keyCode)) {
             doAction();
             return true;
         }


### PR DESCRIPTION
The space key detected using the `KeyCodes.isToggle` method seems to work equivalently to the enter key, which is already supported for activating elements in the Sodium video options screen.

Fixes #2275