### PR TITLE
Fix screen prompts not being keyboard-navigable

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumOptionsGUI.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumOptionsGUI.java
@@ -16,6 +16,7 @@ import me.jellysquid.mods.sodium.client.util.Dim2i;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.Element;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.option.VideoOptionsScreen;
 import net.minecraft.text.OrderedText;
@@ -139,6 +140,10 @@ public class SodiumOptionsGUI extends Screen implements ScreenPromptable {
         super.init();
 
         this.rebuildGUI();
+
+        if (this.prompt != null) {
+            this.prompt.init();
+        }
     }
 
     private void rebuildGUI() {
@@ -372,11 +377,11 @@ public class SodiumOptionsGUI extends Screen implements ScreenPromptable {
 
     @Override
     public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-        if (this.prompt != null) {
-            return this.prompt.keyPressed(keyCode, scanCode, modifiers);
+        if (this.prompt != null && this.prompt.keyPressed(keyCode, scanCode, modifiers)) {
+            return true;
         }
 
-        if (keyCode == GLFW.GLFW_KEY_P && (modifiers & GLFW.GLFW_MOD_SHIFT) != 0) {
+        if (this.prompt == null && keyCode == GLFW.GLFW_KEY_P && (modifiers & GLFW.GLFW_MOD_SHIFT) != 0) {
             MinecraftClient.getInstance().setScreen(new VideoOptionsScreen(this.prevScreen, MinecraftClient.getInstance().options));
 
             return true;
@@ -409,6 +414,11 @@ public class SodiumOptionsGUI extends Screen implements ScreenPromptable {
     @Override
     public void close() {
         this.client.setScreen(this.prevScreen);
+    }
+
+    @Override
+    public List<? extends Element> children() {
+        return this.prompt == null ? super.children() : this.prompt.getWidgets();
     }
 
     @Override

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/prompt/ScreenPrompt.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/prompt/ScreenPrompt.java
@@ -34,6 +34,19 @@ public class ScreenPrompt implements Element, Drawable {
         this.action = action;
     }
 
+    public void init() {
+        var parentDimensions = this.parent.getDimensions();
+
+        int boxX = (parentDimensions.width() / 2) - (width / 2);
+        int boxY = (parentDimensions.height() / 2) - (height / 2);
+
+        this.closeButton = new FlatButtonWidget(new Dim2i((boxX + width) - 84, (boxY + height) - 24, 80, 20), Text.literal("Close"), this::close);
+        this.closeButton.setStyle(createButtonStyle());
+
+        this.actionButton = new FlatButtonWidget(new Dim2i((boxX + width) - 198, (boxY + height) - 24, 110, 20), this.action.label, this::runAction);
+        this.actionButton.setStyle(createButtonStyle());
+    }
+
     public void render(DrawContext drawContext, int mouseX, int mouseY, float delta) {
         var matrices = drawContext.getMatrices();
         matrices.push();
@@ -74,12 +87,6 @@ public class ScreenPrompt implements Element, Drawable {
             textY += 8;
         }
 
-        this.closeButton = new FlatButtonWidget(new Dim2i((boxX + width) - 84, (boxY + height) - 24, 80, 20), Text.literal("Close"), this::close);
-        this.closeButton.setStyle(createButtonStyle());
-
-        this.actionButton = new FlatButtonWidget(new Dim2i((boxX + width) - 198, (boxY + height) - 24, 110, 20), this.action.label, this::runAction);
-        this.actionButton.setStyle(createButtonStyle());
-
         for (var button : getWidgets()) {
             button.render(drawContext, mouseX, mouseY, delta);
         }
@@ -100,8 +107,8 @@ public class ScreenPrompt implements Element, Drawable {
     }
 
     @NotNull
-    private List<AbstractWidget> getWidgets() {
-        return List.of(this.closeButton, this.actionButton);
+    public List<AbstractWidget> getWidgets() {
+        return List.of(this.actionButton, this.closeButton);
     }
 
     @Override
@@ -128,6 +135,7 @@ public class ScreenPrompt implements Element, Drawable {
     public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
         if (keyCode == GLFW.GLFW_KEY_ESCAPE) {
             this.close();
+            return true;
         }
 
         return Element.super.keyPressed(keyCode, scanCode, modifiers);


### PR DESCRIPTION
Previously, the buttons of screen prompts could not be navigated through the keyboard because they were being recreated upon each render. This pull request changes the behavior of screen prompts to only recreate these buttons when necessary, matching vanilla behavior.