### PR TITLE
Fix cycling controls not playing a sound when activated using the keyboard

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/CyclingControl.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/CyclingControl.java
@@ -6,7 +6,6 @@ import me.jellysquid.mods.sodium.client.util.Dim2i;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.input.KeyCodes;
-import net.minecraft.client.util.InputUtil;
 import net.minecraft.text.Text;
 import org.apache.commons.lang3.Validate;
 
@@ -101,8 +100,6 @@ public class CyclingControl<T extends Enum<T>> implements Control<T> {
         public boolean mouseClicked(double mouseX, double mouseY, int button) {
             if (this.option.isAvailable() && button == 0 && this.dim.containsCursor(mouseX, mouseY)) {
                 cycleControl(Screen.hasShiftDown());
-                this.playClickSound();
-
                 return true;
             }
 
@@ -121,7 +118,9 @@ public class CyclingControl<T extends Enum<T>> implements Control<T> {
             return false;
         }
 
-        public void cycleControl(boolean reverse) {
+        private void cycleControl(boolean reverse) {
+            this.playClickSound();
+
             if (reverse) {
                 this.currentIndex = (this.currentIndex + this.allowedValues.length - 1) % this.allowedValues.length;
             } else {

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/TickBoxControl.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/options/control/TickBoxControl.java
@@ -4,7 +4,6 @@ import me.jellysquid.mods.sodium.client.gui.options.Option;
 import me.jellysquid.mods.sodium.client.util.Dim2i;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.input.KeyCodes;
-import net.minecraft.client.util.InputUtil;
 import net.minecraft.client.util.math.Rect2i;
 
 public class TickBoxControl implements Control<Boolean> {
@@ -69,8 +68,6 @@ public class TickBoxControl implements Control<Boolean> {
         public boolean mouseClicked(double mouseX, double mouseY, int button) {
             if (this.option.isAvailable() && button == 0 && this.dim.containsCursor(mouseX, mouseY)) {
                 toggleControl();
-                this.playClickSound();
-
                 return true;
             }
 
@@ -83,15 +80,14 @@ public class TickBoxControl implements Control<Boolean> {
 
             if (KeyCodes.isToggle(keyCode)) {
                 toggleControl();
-                this.playClickSound();
-
                 return true;
             }
 
             return false;
         }
 
-        public void toggleControl() {
+        private void toggleControl() {
+            this.playClickSound();
             this.option.setValue(!this.option.getValue());
         }
     }

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/widgets/FlatButtonWidget.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/widgets/FlatButtonWidget.java
@@ -7,7 +7,6 @@ import net.minecraft.client.gui.ScreenRect;
 import net.minecraft.client.gui.navigation.GuiNavigation;
 import net.minecraft.client.gui.navigation.GuiNavigationPath;
 import net.minecraft.client.input.KeyCodes;
-import net.minecraft.client.util.InputUtil;
 import net.minecraft.text.Text;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;


### PR DESCRIPTION
Helper methods of controls now contain functionality for playing a sound when changing the control's value to prevent inconsistency between code paths, which was apparent with cycling controls.

Fixes #2309