### PR TITLE
Add support for custom fluid rendering

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ object Constants {
     const val MINECRAFT_VERSION: String = "1.20.4"
     const val YARN_VERSION: String = "1.20.4+build.3"
     const val FABRIC_LOADER_VERSION: String = "0.15.6"
-    const val FABRIC_API_VERSION: String = "0.95.3+1.20.4"
+    const val FABRIC_API_VERSION: String = "0.96.0+1.20.4"
 
     // https://semver.org/
     const val MOD_VERSION: String = "0.5.8"
@@ -76,8 +76,9 @@ dependencies {
     // Fabric API modules
     addEmbeddedFabricModule("fabric-api-base")
     addEmbeddedFabricModule("fabric-block-view-api-v2")
-    addEmbeddedFabricModule("fabric-rendering-fluids-v1")
+    addEmbeddedFabricModule("fabric-renderer-api-v1")
     addEmbeddedFabricModule("fabric-rendering-data-attachment-v1")
+    addEmbeddedFabricModule("fabric-rendering-fluids-v1")
     addEmbeddedFabricModule("fabric-resource-loader-v0")
 }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
@@ -1,14 +1,17 @@
 package me.jellysquid.mods.sodium.client;
 
-import me.jellysquid.mods.sodium.client.gui.SodiumGameOptions;
 import me.jellysquid.mods.sodium.client.data.fingerprint.FingerprintMeasure;
 import me.jellysquid.mods.sodium.client.data.fingerprint.HashedFingerprint;
+import me.jellysquid.mods.sodium.client.gui.SodiumGameOptions;
 import me.jellysquid.mods.sodium.client.gui.console.Console;
 import me.jellysquid.mods.sodium.client.gui.console.message.MessageLevel;
+import me.jellysquid.mods.sodium.client.render.frapi.SpriteFinderCache;
 import me.jellysquid.mods.sodium.client.util.FlawlessFrames;
 import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
+import net.minecraft.resource.ResourceType;
 import net.minecraft.text.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,6 +38,8 @@ public class SodiumClientMod implements ClientModInitializer {
         CONFIG = loadConfig();
 
         FlawlessFrames.onClientInitialization();
+
+        ResourceManagerHelper.get(ResourceType.CLIENT_RESOURCES).registerReloadListener(SpriteFinderCache.ReloadListener.INSTANCE);
 
         try {
             updateFingerprint();

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/buffers/BakedChunkModelBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/buffers/BakedChunkModelBuilder.java
@@ -1,12 +1,15 @@
 package me.jellysquid.mods.sodium.client.render.chunk.compile.buffers;
 
 import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadFacing;
+import me.jellysquid.mods.sodium.client.render.chunk.terrain.material.Material;
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.builder.ChunkMeshBufferBuilder;
 import me.jellysquid.mods.sodium.client.render.chunk.data.BuiltSectionInfo;
+import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.texture.Sprite;
 
 public class BakedChunkModelBuilder implements ChunkModelBuilder {
     private final ChunkMeshBufferBuilder[] vertexBuffers;
+    private final ChunkVertexConsumer vertexConsumerAdapter = new ChunkVertexConsumer(this);
 
     private BuiltSectionInfo.Builder renderData;
 
@@ -22,6 +25,12 @@ public class BakedChunkModelBuilder implements ChunkModelBuilder {
     @Override
     public void addSprite(Sprite sprite) {
         this.renderData.addSprite(sprite);
+    }
+
+    @Override
+    public VertexConsumer asVertexConsumer(Material material) {
+        vertexConsumerAdapter.setMaterial(material);
+        return vertexConsumerAdapter;
     }
 
     public void destroy() {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/buffers/BakedChunkModelBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/buffers/BakedChunkModelBuilder.java
@@ -1,15 +1,15 @@
 package me.jellysquid.mods.sodium.client.render.chunk.compile.buffers;
 
 import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadFacing;
+import me.jellysquid.mods.sodium.client.render.chunk.data.BuiltSectionInfo;
 import me.jellysquid.mods.sodium.client.render.chunk.terrain.material.Material;
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.builder.ChunkMeshBufferBuilder;
-import me.jellysquid.mods.sodium.client.render.chunk.data.BuiltSectionInfo;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.texture.Sprite;
 
 public class BakedChunkModelBuilder implements ChunkModelBuilder {
     private final ChunkMeshBufferBuilder[] vertexBuffers;
-    private final ChunkVertexConsumer vertexConsumerAdapter = new ChunkVertexConsumer(this);
+    private final ChunkVertexConsumer fallbackVertexConsumer = new ChunkVertexConsumer(this);
 
     private BuiltSectionInfo.Builder renderData;
 
@@ -28,9 +28,9 @@ public class BakedChunkModelBuilder implements ChunkModelBuilder {
     }
 
     @Override
-    public VertexConsumer asVertexConsumer(Material material) {
-        vertexConsumerAdapter.setMaterial(material);
-        return vertexConsumerAdapter;
+    public VertexConsumer asFallbackVertexConsumer(Material material) {
+        fallbackVertexConsumer.setMaterial(material);
+        return fallbackVertexConsumer;
     }
 
     public void destroy() {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/buffers/ChunkModelBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/buffers/ChunkModelBuilder.java
@@ -1,11 +1,15 @@
 package me.jellysquid.mods.sodium.client.render.chunk.compile.buffers;
 
 import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadFacing;
+import me.jellysquid.mods.sodium.client.render.chunk.terrain.material.Material;
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.builder.ChunkMeshBufferBuilder;
+import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.texture.Sprite;
 
 public interface ChunkModelBuilder {
     ChunkMeshBufferBuilder getVertexBuffer(ModelQuadFacing facing);
 
     void addSprite(Sprite sprite);
+
+    VertexConsumer asVertexConsumer(Material material);
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/buffers/ChunkModelBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/buffers/ChunkModelBuilder.java
@@ -11,5 +11,17 @@ public interface ChunkModelBuilder {
 
     void addSprite(Sprite sprite);
 
-    VertexConsumer asVertexConsumer(Material material);
+    /**
+     * <b>This method should not be used unless absolutely necessary!</b> It exists only for compatibility purposes.
+     * Prefer using the other methods in this class instead as they are more efficient.
+     *
+     * <p>Returns a {@link VertexConsumer} which adds geometry to this model builder using the given {@link Material}.
+     * The returned vertex consumer expects quads and requires the position, color, texture, light, and normal
+     * attributes to be provided for each vertex. The returned vertex consumer may be a reused object, so it must not be
+     * stored or cached in any way by the caller.
+     *
+     * @param material the material that should be used for geometry pushed to the vertex consumer
+     * @return the fallback vertex consumer which adds geometry to this model builder
+     */
+    VertexConsumer asFallbackVertexConsumer(Material material);
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/buffers/ChunkVertexConsumer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/buffers/ChunkVertexConsumer.java
@@ -1,0 +1,174 @@
+package me.jellysquid.mods.sodium.client.render.chunk.compile.buffers;
+
+import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadFacing;
+import me.jellysquid.mods.sodium.client.render.chunk.terrain.material.Material;
+import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexEncoder;
+import me.jellysquid.mods.sodium.client.render.frapi.SpriteFinderCache;
+import net.caffeinemc.mods.sodium.api.util.ColorABGR;
+import net.caffeinemc.mods.sodium.api.util.ColorARGB;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.texture.Sprite;
+import net.minecraft.util.math.Direction;
+
+public class ChunkVertexConsumer implements VertexConsumer {
+    private static final int ATTRIBUTE_POSITION_BIT = 1 << 0;
+    private static final int ATTRIBUTE_COLOR_BIT = 1 << 1;
+    private static final int ATTRIBUTE_TEXTURE_BIT = 1 << 2;
+    private static final int ATTRIBUTE_LIGHT_BIT = 1 << 3;
+    private static final int ATTRIBUTE_NORMAL_BIT = 1 << 4;
+    private static final int REQUIRED_ATTRIBUTES = (1 << 5) - 1;
+
+    private final ChunkModelBuilder modelBuilder;
+    private final ChunkVertexEncoder.Vertex[] vertices = ChunkVertexEncoder.Vertex.uninitializedQuad();
+
+    private Material material;
+    private boolean isColorFixed;
+    private int fixedColor = 0xFFFFFFFF;
+    private int vertexIndex;
+    private int writtenAttributes;
+    private ModelQuadFacing facing;
+
+    public ChunkVertexConsumer(ChunkModelBuilder modelBuilder) {
+        this.modelBuilder = modelBuilder;
+    }
+
+    public void setMaterial(Material material) {
+        this.material = material;
+    }
+
+    @Override
+    public VertexConsumer vertex(double x, double y, double z) {
+        ChunkVertexEncoder.Vertex vertex = this.vertices[this.vertexIndex];
+        vertex.x = (float) x;
+        vertex.y = (float) y;
+        vertex.z = (float) z;
+        this.writtenAttributes |= ATTRIBUTE_POSITION_BIT;
+        return this;
+    }
+
+    // Writing color ignores alpha since alpha is used as a color multiplier by Sodium.
+    @Override
+    public VertexConsumer color(int red, int green, int blue, int alpha) {
+        if (this.isColorFixed) {
+            throw new IllegalStateException();
+        }
+
+        ChunkVertexEncoder.Vertex vertex = this.vertices[this.vertexIndex];
+        vertex.color = ColorABGR.pack(red, green, blue, 0xFF);
+        this.writtenAttributes |= ATTRIBUTE_COLOR_BIT;
+        return this;
+    }
+
+    @Override
+    public VertexConsumer color(float red, float green, float blue, float alpha) {
+        if (this.isColorFixed) {
+            throw new IllegalStateException();
+        }
+
+        ChunkVertexEncoder.Vertex vertex = this.vertices[this.vertexIndex];
+        vertex.color = ColorABGR.pack(red, green, blue, 1);
+        this.writtenAttributes |= ATTRIBUTE_COLOR_BIT;
+        return this;
+    }
+
+    @Override
+    public VertexConsumer color(int argb) {
+        if (this.isColorFixed) {
+            throw new IllegalStateException();
+        }
+
+        ChunkVertexEncoder.Vertex vertex = this.vertices[this.vertexIndex];
+        vertex.color = ColorARGB.toABGR(argb, 0xFF);
+        this.writtenAttributes |= ATTRIBUTE_COLOR_BIT;
+        return this;
+    }
+
+    @Override
+    public VertexConsumer texture(float u, float v) {
+        ChunkVertexEncoder.Vertex vertex = this.vertices[this.vertexIndex];
+        vertex.u = u;
+        vertex.v = v;
+        this.writtenAttributes |= ATTRIBUTE_TEXTURE_BIT;
+        return this;
+    }
+
+    // Overlay is ignored for chunk geometry.
+    @Override
+    public VertexConsumer overlay(int u, int v) {
+        return this;
+    }
+
+    @Override
+    public VertexConsumer overlay(int uv) {
+        return this;
+    }
+
+    @Override
+    public VertexConsumer light(int u, int v) {
+        ChunkVertexEncoder.Vertex vertex = this.vertices[this.vertexIndex];
+        vertex.light = ((v & 0xFFFF) << 16) | (u & 0xFFFF);
+        this.writtenAttributes |= ATTRIBUTE_LIGHT_BIT;
+        return this;
+    }
+
+    @Override
+    public VertexConsumer light(int uv) {
+        ChunkVertexEncoder.Vertex vertex = this.vertices[this.vertexIndex];
+        vertex.light = uv;
+        this.writtenAttributes |= ATTRIBUTE_LIGHT_BIT;
+        return this;
+    }
+
+    @Override
+    public VertexConsumer normal(float x, float y, float z) {
+        if (this.vertexIndex == 0) {
+            this.facing = ModelQuadFacing.fromDirection(Direction.getFacing(x, y, z));
+        }
+
+        this.writtenAttributes |= ATTRIBUTE_NORMAL_BIT;
+        return this;
+    }
+
+    @Override
+    public void next() {
+        if (this.isColorFixed) {
+            ChunkVertexEncoder.Vertex vertex = this.vertices[this.vertexIndex];
+            vertex.color = this.fixedColor;
+            this.writtenAttributes |= ATTRIBUTE_COLOR_BIT;
+        }
+
+        if (this.writtenAttributes != REQUIRED_ATTRIBUTES) {
+            throw new IllegalStateException("Not filled all elements of the vertex");
+        }
+
+        this.vertexIndex++;
+
+        if (this.vertexIndex == 4) {
+            this.modelBuilder.getVertexBuffer(this.facing).push(this.vertices, this.material);
+
+            float u = 0;
+            float v = 0;
+
+            for (ChunkVertexEncoder.Vertex vertex : this.vertices) {
+                u += vertex.u;
+                v += vertex.v;
+            }
+
+            Sprite sprite = SpriteFinderCache.forBlockAtlas().find(u * 0.25f, v * 0.25f);
+            this.modelBuilder.addSprite(sprite);
+
+            this.vertexIndex = 0;
+        }
+    }
+
+    @Override
+    public void fixedColor(int red, int green, int blue, int alpha) {
+        this.fixedColor = ColorABGR.pack(red, green, blue, 0xFF);
+        this.isColorFixed = true;
+    }
+
+    @Override
+    public void unfixColor() {
+        this.isColorFixed = false;
+    }
+}

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/pipeline/BlockRenderCache.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/pipeline/BlockRenderCache.java
@@ -8,7 +8,6 @@ import me.jellysquid.mods.sodium.client.world.cloned.ChunkRenderContext;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.block.BlockModels;
 import net.minecraft.client.world.ClientWorld;
-import net.minecraft.world.World;
 
 public class BlockRenderCache {
     private final ArrayLightDataCache lightDataCache;

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/pipeline/DefaultFluidRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/pipeline/DefaultFluidRenderer.java
@@ -1,0 +1,459 @@
+package me.jellysquid.mods.sodium.client.render.chunk.compile.pipeline;
+
+import me.jellysquid.mods.sodium.client.model.color.ColorProvider;
+import me.jellysquid.mods.sodium.client.model.color.ColorProviderRegistry;
+import me.jellysquid.mods.sodium.client.model.color.DefaultColorProviders;
+import me.jellysquid.mods.sodium.client.model.light.LightMode;
+import me.jellysquid.mods.sodium.client.model.light.LightPipeline;
+import me.jellysquid.mods.sodium.client.model.light.LightPipelineProvider;
+import me.jellysquid.mods.sodium.client.model.light.data.QuadLightData;
+import me.jellysquid.mods.sodium.client.model.quad.ModelQuad;
+import me.jellysquid.mods.sodium.client.model.quad.ModelQuadView;
+import me.jellysquid.mods.sodium.client.model.quad.ModelQuadViewMutable;
+import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadFacing;
+import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadFlags;
+import me.jellysquid.mods.sodium.client.render.chunk.compile.buffers.ChunkModelBuilder;
+import me.jellysquid.mods.sodium.client.render.chunk.terrain.material.Material;
+import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexEncoder;
+import me.jellysquid.mods.sodium.client.util.DirectionUtil;
+import me.jellysquid.mods.sodium.client.world.WorldSlice;
+import net.caffeinemc.mods.sodium.api.util.ColorABGR;
+import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandler;
+import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandlerRegistry;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.SideShapeType;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.texture.Sprite;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.fluid.FluidState;
+import net.minecraft.registry.tag.FluidTags;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.util.shape.VoxelShapes;
+import net.minecraft.world.BlockRenderView;
+import org.apache.commons.lang3.mutable.MutableFloat;
+import org.apache.commons.lang3.mutable.MutableInt;
+
+public class DefaultFluidRenderer {
+    // TODO: allow this to be changed by vertex format
+    // TODO: move fluid rendering to a separate render pass and control glPolygonOffset and glDepthFunc to fix this properly
+    private static final float EPSILON = 0.001f;
+
+    private final ColorProviderRegistry colorProviderRegistry;
+    private final LightPipelineProvider lighters;
+
+    private final ModelQuadViewMutable quad = new ModelQuad();
+    private final QuadLightData quadLightData = new QuadLightData();
+    private final int[] quadColors = new int[4];
+    private final ChunkVertexEncoder.Vertex[] vertices = ChunkVertexEncoder.Vertex.uninitializedQuad();
+
+    private final BlockPos.Mutable scratchPos = new BlockPos.Mutable();
+    private final MutableFloat scratchHeight = new MutableFloat(0);
+    private final MutableInt scratchSamples = new MutableInt();
+
+    public DefaultFluidRenderer(ColorProviderRegistry colorProviderRegistry, LightPipelineProvider lighters) {
+        this.colorProviderRegistry = colorProviderRegistry;
+        this.lighters = lighters;
+        this.quad.setLightFace(Direction.UP);
+    }
+
+    private boolean isFluidOccluded(BlockRenderView world, int x, int y, int z, Direction dir, Fluid fluid) {
+        BlockPos pos = this.scratchPos.set(x, y, z);
+        BlockState blockState = world.getBlockState(pos);
+        BlockPos adjPos = this.scratchPos.set(x + dir.getOffsetX(), y + dir.getOffsetY(), z + dir.getOffsetZ());
+
+        if (blockState.isOpaque()) {
+            return world.getFluidState(adjPos).getFluid().matchesType(fluid) || blockState.isSideSolid(world, pos, dir, SideShapeType.FULL);
+        }
+        return world.getFluidState(adjPos).getFluid().matchesType(fluid);
+    }
+
+    private boolean isSideExposed(BlockRenderView world, int x, int y, int z, Direction dir, float height) {
+        BlockPos pos = this.scratchPos.set(x + dir.getOffsetX(), y + dir.getOffsetY(), z + dir.getOffsetZ());
+        BlockState blockState = world.getBlockState(pos);
+
+        if (blockState.isOpaque()) {
+            VoxelShape shape = blockState.getCullingShape(world, pos);
+
+            // Hoist these checks to avoid allocating the shape below
+            if (shape == VoxelShapes.fullCube()) {
+                // The top face always be inset, so if the shape above is a full cube it can't possibly occlude
+                return dir == Direction.UP;
+            } else if (shape.isEmpty()) {
+                return true;
+            }
+
+            VoxelShape threshold = VoxelShapes.cuboid(0.0D, 0.0D, 0.0D, 1.0D, height, 1.0D);
+
+            return !VoxelShapes.isSideCovered(threshold, shape, dir);
+        }
+
+        return true;
+    }
+
+    public void render(WorldSlice world, FluidState fluidState, BlockPos blockPos, BlockPos offset, ChunkModelBuilder meshBuilder, Material material, FluidRenderHandler handler) {
+        int posX = blockPos.getX();
+        int posY = blockPos.getY();
+        int posZ = blockPos.getZ();
+
+        Fluid fluid = fluidState.getFluid();
+
+        boolean sfUp = this.isFluidOccluded(world, posX, posY, posZ, Direction.UP, fluid);
+        boolean sfDown = this.isFluidOccluded(world, posX, posY, posZ, Direction.DOWN, fluid) ||
+                !this.isSideExposed(world, posX, posY, posZ, Direction.DOWN, 0.8888889F);
+        boolean sfNorth = this.isFluidOccluded(world, posX, posY, posZ, Direction.NORTH, fluid);
+        boolean sfSouth = this.isFluidOccluded(world, posX, posY, posZ, Direction.SOUTH, fluid);
+        boolean sfWest = this.isFluidOccluded(world, posX, posY, posZ, Direction.WEST, fluid);
+        boolean sfEast = this.isFluidOccluded(world, posX, posY, posZ, Direction.EAST, fluid);
+
+        if (sfUp && sfDown && sfEast && sfWest && sfNorth && sfSouth) {
+            return;
+        }
+
+        Sprite[] sprites = handler.getFluidSprites(world, blockPos, fluidState);
+        final ColorProvider<FluidState> colorProvider = this.getColorProvider(fluid, handler);
+
+        float fluidHeight = this.fluidHeight(world, fluid, blockPos, Direction.UP);
+        float northWestHeight, southWestHeight, southEastHeight, northEastHeight;
+        if (fluidHeight >= 1.0f) {
+            northWestHeight = 1.0f;
+            southWestHeight = 1.0f;
+            southEastHeight = 1.0f;
+            northEastHeight = 1.0f;
+        } else {
+            var scratchPos = new BlockPos.Mutable();
+            float heightNorth = this.fluidHeight(world, fluid, scratchPos.set(blockPos, Direction.NORTH), Direction.NORTH);
+            float heightSouth = this.fluidHeight(world, fluid, scratchPos.set(blockPos, Direction.SOUTH), Direction.SOUTH);
+            float heightEast = this.fluidHeight(world, fluid, scratchPos.set(blockPos, Direction.EAST), Direction.EAST);
+            float heightWest = this.fluidHeight(world, fluid, scratchPos.set(blockPos, Direction.WEST), Direction.WEST);
+            northWestHeight = this.fluidCornerHeight(world, fluid, fluidHeight, heightNorth, heightWest, scratchPos.set(blockPos)
+                    .move(Direction.NORTH)
+                    .move(Direction.WEST));
+            southWestHeight = this.fluidCornerHeight(world, fluid, fluidHeight, heightSouth, heightWest, scratchPos.set(blockPos)
+                    .move(Direction.SOUTH)
+                    .move(Direction.WEST));
+            southEastHeight = this.fluidCornerHeight(world, fluid, fluidHeight, heightSouth, heightEast, scratchPos.set(blockPos)
+                    .move(Direction.SOUTH)
+                    .move(Direction.EAST));
+            northEastHeight = this.fluidCornerHeight(world, fluid, fluidHeight, heightNorth, heightEast, scratchPos.set(blockPos)
+                    .move(Direction.NORTH)
+                    .move(Direction.EAST));
+        }
+        float yOffset = sfDown ? 0.0F : EPSILON;
+
+        final ModelQuadViewMutable quad = this.quad;
+
+        LightMode lightMode = fluidState.isIn(FluidTags.WATER) && MinecraftClient.isAmbientOcclusionEnabled() ? LightMode.SMOOTH : LightMode.FLAT;
+        LightPipeline lighter = this.lighters.getLighter(lightMode);
+
+        quad.setFlags(0);
+
+        if (!sfUp && this.isSideExposed(world, posX, posY, posZ, Direction.UP, Math.min(Math.min(northWestHeight, southWestHeight), Math.min(southEastHeight, northEastHeight)))) {
+            northWestHeight -= EPSILON;
+            southWestHeight -= EPSILON;
+            southEastHeight -= EPSILON;
+            northEastHeight -= EPSILON;
+
+            Vec3d velocity = fluidState.getVelocity(world, blockPos);
+
+            Sprite sprite;
+            ModelQuadFacing facing;
+            float u1, u2, u3, u4;
+            float v1, v2, v3, v4;
+
+            if (velocity.x == 0.0D && velocity.z == 0.0D) {
+                sprite = sprites[0];
+                facing = ModelQuadFacing.POS_Y;
+                u1 = sprite.getFrameU(0.0f);
+                v1 = sprite.getFrameV(0.0f);
+                u2 = u1;
+                v2 = sprite.getFrameV(1.0f);
+                u3 = sprite.getFrameU(1.0f);
+                v3 = v2;
+                u4 = u3;
+                v4 = v1;
+            } else {
+                sprite = sprites[1];
+                facing = ModelQuadFacing.UNASSIGNED;
+                float dir = (float) MathHelper.atan2(velocity.z, velocity.x) - (1.5707964f);
+                float sin = MathHelper.sin(dir) * 0.25F;
+                float cos = MathHelper.cos(dir) * 0.25F;
+                u1 = sprite.getFrameU(0.5F + (-cos - sin));
+                v1 = sprite.getFrameV(0.5F + -cos + sin);
+                u2 = sprite.getFrameU(0.5F + -cos + sin);
+                v2 = sprite.getFrameV(0.5F + cos + sin);
+                u3 = sprite.getFrameU(0.5F + cos + sin);
+                v3 = sprite.getFrameV(0.5F + (cos - sin));
+                u4 = sprite.getFrameU(0.5F + (cos - sin));
+                v4 = sprite.getFrameV(0.5F + (-cos - sin));
+            }
+
+            float uAvg = (u1 + u2 + u3 + u4) / 4.0F;
+            float vAvg = (v1 + v2 + v3 + v4) / 4.0F;
+            float s3 = sprites[0].getAnimationFrameDelta();
+
+            u1 = MathHelper.lerp(s3, u1, uAvg);
+            u2 = MathHelper.lerp(s3, u2, uAvg);
+            u3 = MathHelper.lerp(s3, u3, uAvg);
+            u4 = MathHelper.lerp(s3, u4, uAvg);
+            v1 = MathHelper.lerp(s3, v1, vAvg);
+            v2 = MathHelper.lerp(s3, v2, vAvg);
+            v3 = MathHelper.lerp(s3, v3, vAvg);
+            v4 = MathHelper.lerp(s3, v4, vAvg);
+
+            quad.setSprite(sprite);
+
+            setVertex(quad, 0, 0.0f, northWestHeight, 0.0f, u1, v1);
+            setVertex(quad, 1, 0.0f, southWestHeight, 1.0F, u2, v2);
+            setVertex(quad, 2, 1.0F, southEastHeight, 1.0F, u3, v3);
+            setVertex(quad, 3, 1.0F, northEastHeight, 0.0f, u4, v4);
+
+            this.updateQuad(quad, world, blockPos, lighter, Direction.UP, 1.0F, colorProvider, fluidState);
+            this.writeQuad(meshBuilder, material, offset, quad, facing, false);
+
+            if (fluidState.canFlowTo(world, this.scratchPos.set(posX, posY + 1, posZ))) {
+                this.writeQuad(meshBuilder, material, offset, quad,
+                        ModelQuadFacing.NEG_Y, true);
+            }
+        }
+
+        if (!sfDown) {
+            Sprite sprite = sprites[0];
+
+            float minU = sprite.getMinU();
+            float maxU = sprite.getMaxU();
+            float minV = sprite.getMinV();
+            float maxV = sprite.getMaxV();
+            quad.setSprite(sprite);
+
+            setVertex(quad, 0, 0.0f, yOffset, 1.0F, minU, maxV);
+            setVertex(quad, 1, 0.0f, yOffset, 0.0f, minU, minV);
+            setVertex(quad, 2, 1.0F, yOffset, 0.0f, maxU, minV);
+            setVertex(quad, 3, 1.0F, yOffset, 1.0F, maxU, maxV);
+
+            this.updateQuad(quad, world, blockPos, lighter, Direction.DOWN, 1.0F, colorProvider, fluidState);
+            this.writeQuad(meshBuilder, material, offset, quad, ModelQuadFacing.NEG_Y, false);
+        }
+
+        quad.setFlags(ModelQuadFlags.IS_PARALLEL | ModelQuadFlags.IS_ALIGNED);
+
+        for (Direction dir : DirectionUtil.HORIZONTAL_DIRECTIONS) {
+            float c1;
+            float c2;
+            float x1;
+            float z1;
+            float x2;
+            float z2;
+
+            switch (dir) {
+                case NORTH -> {
+                    if (sfNorth) {
+                        continue;
+                    }
+                    c1 = northWestHeight;
+                    c2 = northEastHeight;
+                    x1 = 0.0f;
+                    x2 = 1.0F;
+                    z1 = EPSILON;
+                    z2 = z1;
+                }
+                case SOUTH -> {
+                    if (sfSouth) {
+                        continue;
+                    }
+                    c1 = southEastHeight;
+                    c2 = southWestHeight;
+                    x1 = 1.0F;
+                    x2 = 0.0f;
+                    z1 = 1.0f - EPSILON;
+                    z2 = z1;
+                }
+                case WEST -> {
+                    if (sfWest) {
+                        continue;
+                    }
+                    c1 = southWestHeight;
+                    c2 = northWestHeight;
+                    x1 = EPSILON;
+                    x2 = x1;
+                    z1 = 1.0F;
+                    z2 = 0.0f;
+                }
+                case EAST -> {
+                    if (sfEast) {
+                        continue;
+                    }
+                    c1 = northEastHeight;
+                    c2 = southEastHeight;
+                    x1 = 1.0f - EPSILON;
+                    x2 = x1;
+                    z1 = 0.0f;
+                    z2 = 1.0F;
+                }
+                default -> {
+                    continue;
+                }
+            }
+
+            if (this.isSideExposed(world, posX, posY, posZ, dir, Math.max(c1, c2))) {
+                int adjX = posX + dir.getOffsetX();
+                int adjY = posY + dir.getOffsetY();
+                int adjZ = posZ + dir.getOffsetZ();
+
+                Sprite sprite = sprites[1];
+
+                boolean isOverlay = false;
+
+                if (sprites.length > 2) {
+                    BlockPos adjPos = this.scratchPos.set(adjX, adjY, adjZ);
+                    BlockState adjBlock = world.getBlockState(adjPos);
+
+                    if (FluidRenderHandlerRegistry.INSTANCE.isBlockTransparent(adjBlock.getBlock())) {
+                        sprite = sprites[2];
+                        isOverlay = true;
+                    }
+                }
+
+                float u1 = sprite.getFrameU(0.0F);
+                float u2 = sprite.getFrameU(0.5F);
+                float v1 = sprite.getFrameV((1.0F - c1) * 0.5F);
+                float v2 = sprite.getFrameV((1.0F - c2) * 0.5F);
+                float v3 = sprite.getFrameV(0.5F);
+
+                quad.setSprite(sprite);
+
+                setVertex(quad, 0, x2, c2, z2, u2, v2);
+                setVertex(quad, 1, x2, yOffset, z2, u2, v3);
+                setVertex(quad, 2, x1, yOffset, z1, u1, v3);
+                setVertex(quad, 3, x1, c1, z1, u1, v1);
+
+                float br = dir.getAxis() == Direction.Axis.Z ? 0.8F : 0.6F;
+
+                ModelQuadFacing facing = ModelQuadFacing.fromDirection(dir);
+
+                this.updateQuad(quad, world, blockPos, lighter, dir, br, colorProvider, fluidState);
+                this.writeQuad(meshBuilder, material, offset, quad, facing, false);
+
+                if (!isOverlay) {
+                    this.writeQuad(meshBuilder, material, offset, quad, facing.getOpposite(), true);
+                }
+            }
+        }
+    }
+
+    private ColorProvider<FluidState> getColorProvider(Fluid fluid, FluidRenderHandler handler) {
+        var override = this.colorProviderRegistry.getColorProvider(fluid);
+
+        if (override != null) {
+            return override;
+        }
+        
+        return DefaultColorProviders.adapt(handler);
+    }
+
+    private void updateQuad(ModelQuadView quad, WorldSlice world, BlockPos pos, LightPipeline lighter, Direction dir, float brightness,
+                            ColorProvider<FluidState> colorProvider, FluidState fluidState) {
+        QuadLightData light = this.quadLightData;
+        lighter.calculate(quad, pos, light, null, dir, false);
+
+        colorProvider.getColors(world, pos, fluidState, quad, this.quadColors);
+
+        // multiply the per-vertex color against the combined brightness
+        // the combined brightness is the per-vertex brightness multiplied by the block's brightness
+        for (int i = 0; i < 4; i++) {
+            this.quadColors[i] = ColorABGR.withAlpha(this.quadColors[i], light.br[i] * brightness);
+        }
+    }
+
+    private void writeQuad(ChunkModelBuilder builder, Material material, BlockPos offset, ModelQuadView quad,
+                           ModelQuadFacing facing, boolean flip) {
+        var vertices = this.vertices;
+
+        for (int i = 0; i < 4; i++) {
+            var out = vertices[flip ? 3 - i : i];
+            out.x = offset.getX() + quad.getX(i);
+            out.y = offset.getY() + quad.getY(i);
+            out.z = offset.getZ() + quad.getZ(i);
+
+            out.color = this.quadColors[i];
+            out.u = quad.getTexU(i);
+            out.v = quad.getTexV(i);
+            out.light = this.quadLightData.lm[i];
+        }
+
+        Sprite sprite = quad.getSprite();
+
+        if (sprite != null) {
+            builder.addSprite(sprite);
+        }
+
+        var vertexBuffer = builder.getVertexBuffer(facing);
+        vertexBuffer.push(vertices, material);
+    }
+
+    private static void setVertex(ModelQuadViewMutable quad, int i, float x, float y, float z, float u, float v) {
+        quad.setX(i, x);
+        quad.setY(i, y);
+        quad.setZ(i, z);
+        quad.setTexU(i, u);
+        quad.setTexV(i, v);
+    }
+
+    private float fluidCornerHeight(BlockRenderView world, Fluid fluid, float fluidHeight, float fluidHeightX, float fluidHeightY, BlockPos blockPos) {
+        if (fluidHeightY >= 1.0f || fluidHeightX >= 1.0f) {
+            return 1.0f;
+        }
+
+        if (fluidHeightY > 0.0f || fluidHeightX > 0.0f) {
+            float height = this.fluidHeight(world, fluid, blockPos, Direction.UP);
+
+            if (height >= 1.0f) {
+                return 1.0f;
+            }
+
+            this.modifyHeight(this.scratchHeight, this.scratchSamples, height);
+        }
+
+        this.modifyHeight(this.scratchHeight, this.scratchSamples, fluidHeight);
+        this.modifyHeight(this.scratchHeight, this.scratchSamples, fluidHeightY);
+        this.modifyHeight(this.scratchHeight, this.scratchSamples, fluidHeightX);
+
+        float result = this.scratchHeight.floatValue() / this.scratchSamples.intValue();
+        this.scratchHeight.setValue(0);
+        this.scratchSamples.setValue(0);
+
+        return result;
+    }
+
+    private void modifyHeight(MutableFloat totalHeight, MutableInt samples, float target) {
+        if (target >= 0.8f) {
+            totalHeight.add(target * 10.0f);
+            samples.add(10);
+        } else if (target >= 0.0f) {
+            totalHeight.add(target);
+            samples.increment();
+        }
+    }
+
+    private float fluidHeight(BlockRenderView world, Fluid fluid, BlockPos blockPos, Direction direction) {
+        BlockState blockState = world.getBlockState(blockPos);
+        FluidState fluidState = blockState.getFluidState();
+
+        if (fluid.matchesType(fluidState.getFluid())) {
+            FluidState fluidStateUp = world.getFluidState(blockPos.up());
+
+            if (fluid.matchesType(fluidStateUp.getFluid())) {
+                return 1.0f;
+            } else {
+                return fluidState.getHeight();
+            }
+        }
+        if (!blockState.isSolid()) {
+            return 0.0f;
+        }
+        return -1.0f;
+    }
+}

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/pipeline/FluidRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/pipeline/FluidRenderer.java
@@ -1,115 +1,28 @@
 package me.jellysquid.mods.sodium.client.render.chunk.compile.pipeline;
 
-import me.jellysquid.mods.sodium.client.model.color.ColorProvider;
 import me.jellysquid.mods.sodium.client.model.color.ColorProviderRegistry;
-import me.jellysquid.mods.sodium.client.model.color.DefaultColorProviders;
-import me.jellysquid.mods.sodium.client.model.light.LightMode;
-import me.jellysquid.mods.sodium.client.model.light.LightPipeline;
 import me.jellysquid.mods.sodium.client.model.light.LightPipelineProvider;
-import me.jellysquid.mods.sodium.client.model.light.data.QuadLightData;
-import me.jellysquid.mods.sodium.client.model.quad.ModelQuad;
-import me.jellysquid.mods.sodium.client.model.quad.ModelQuadView;
-import me.jellysquid.mods.sodium.client.model.quad.ModelQuadViewMutable;
-import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadFacing;
-import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadFlags;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.ChunkBuildBuffers;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.buffers.ChunkModelBuilder;
 import me.jellysquid.mods.sodium.client.render.chunk.terrain.material.DefaultMaterials;
 import me.jellysquid.mods.sodium.client.render.chunk.terrain.material.Material;
-import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexEncoder;
-import me.jellysquid.mods.sodium.client.util.DirectionUtil;
 import me.jellysquid.mods.sodium.client.world.WorldSlice;
-import net.caffeinemc.mods.sodium.api.util.ColorABGR;
 import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandler;
 import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandlerRegistry;
 import net.minecraft.block.BlockState;
-import net.minecraft.block.SideShapeType;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.texture.Sprite;
-import net.minecraft.fluid.Fluid;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.registry.tag.FluidTags;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Direction;
-import net.minecraft.util.math.MathHelper;
-import net.minecraft.util.math.Vec3d;
-import net.minecraft.util.shape.VoxelShape;
-import net.minecraft.util.shape.VoxelShapes;
-import net.minecraft.world.BlockRenderView;
-import org.apache.commons.lang3.mutable.MutableFloat;
-import org.apache.commons.lang3.mutable.MutableInt;
 
 public class FluidRenderer {
-    // The current renderer is set before invoking FluidRenderHandler#renderFluid and cleared afterwards.
-    private static final ThreadLocal<FluidRenderer> CURRENT_RENDERER = new ThreadLocal<>();
+    // The current default context is set up before invoking FluidRenderHandler#renderFluid and cleared afterwards.
+    private static final ThreadLocal<DefaultRenderContext> CURRENT_DEFAULT_CONTEXT = ThreadLocal.withInitial(DefaultRenderContext::new);
 
-    // TODO: allow this to be changed by vertex format
-    // TODO: move fluid rendering to a separate render pass and control glPolygonOffset and glDepthFunc to fix this properly
-    private static final float EPSILON = 0.001f;
-
-    private final BlockPos.Mutable scratchPos = new BlockPos.Mutable();
-    private final MutableFloat scratchHeight = new MutableFloat(0);
-    private final MutableInt scratchSamples = new MutableInt();
-
-    private final ModelQuadViewMutable quad = new ModelQuad();
-
-    private final LightPipelineProvider lighters;
-
-    private final QuadLightData quadLightData = new QuadLightData();
-    private final int[] quadColors = new int[4];
-
-    private final ChunkVertexEncoder.Vertex[] vertices = ChunkVertexEncoder.Vertex.uninitializedQuad();
-    private final ColorProviderRegistry colorProviderRegistry;
-
-    // These fields are set before invoking FluidRenderHandler#renderFluid and cleared afterwards.
-    private WorldSlice currentWorld;
-    private FluidState currentFluidState;
-    private BlockPos currentBlockPos;
-    private BlockPos currentOffset;
-    private ChunkModelBuilder currentMeshBuilder;
-    private Material currentMaterial;
-    private FluidRenderHandler currentHandler;
+    private final DefaultFluidRenderer defaultRenderer;
 
     public FluidRenderer(ColorProviderRegistry colorProviderRegistry, LightPipelineProvider lighters) {
-        this.quad.setLightFace(Direction.UP);
-
-        this.lighters = lighters;
-        this.colorProviderRegistry = colorProviderRegistry;
-    }
-
-    private boolean isFluidOccluded(BlockRenderView world, int x, int y, int z, Direction dir, Fluid fluid) {
-        BlockPos pos = this.scratchPos.set(x, y, z);
-        BlockState blockState = world.getBlockState(pos);
-        BlockPos adjPos = this.scratchPos.set(x + dir.getOffsetX(), y + dir.getOffsetY(), z + dir.getOffsetZ());
-
-        if (blockState.isOpaque()) {
-            return world.getFluidState(adjPos).getFluid().matchesType(fluid) || blockState.isSideSolid(world, pos, dir, SideShapeType.FULL);
-        }
-        return world.getFluidState(adjPos).getFluid().matchesType(fluid);
-    }
-
-    private boolean isSideExposed(BlockRenderView world, int x, int y, int z, Direction dir, float height) {
-        BlockPos pos = this.scratchPos.set(x + dir.getOffsetX(), y + dir.getOffsetY(), z + dir.getOffsetZ());
-        BlockState blockState = world.getBlockState(pos);
-
-        if (blockState.isOpaque()) {
-            VoxelShape shape = blockState.getCullingShape(world, pos);
-
-            // Hoist these checks to avoid allocating the shape below
-            if (shape == VoxelShapes.fullCube()) {
-                // The top face always be inset, so if the shape above is a full cube it can't possibly occlude
-                return dir == Direction.UP;
-            } else if (shape.isEmpty()) {
-                return true;
-            }
-
-            VoxelShape threshold = VoxelShapes.cuboid(0.0D, 0.0D, 0.0D, 1.0D, height, 1.0D);
-
-            return !VoxelShapes.isSideCovered(threshold, shape, dir);
-        }
-
-        return true;
+        defaultRenderer = new DefaultFluidRenderer(colorProviderRegistry, lighters);
     }
 
     public void render(WorldSlice world, BlockState blockState, FluidState fluidState, BlockPos blockPos, BlockPos offset, ChunkBuildBuffers buffers) {
@@ -141,402 +54,63 @@ public class FluidRenderer {
         //
         // Due to all the above, Sodium injects into head of vanilla FluidRenderer#render before Fabric API and cancels
         // the call if it was invoked from inside FluidRenderHandler#renderFluid. The injector ends up calling
-        // renderDefault, which emulates what vanilla FluidRenderer#render does, but is more efficient. To allow
-        // invoking this method from the injector, where there is no local Sodium context, the parameters to
-        // renderDefault are stored in fields and the FluidRenderer itself is stored in a ThreadLocal.
+        // DefaultFluidRenderer#render, which emulates what vanilla FluidRenderer#render does, but is more efficient.
+        // To allow invoking this method from the injector, where there is no local Sodium context, the renderer and
+        // parameters are bundled into a DefaultRenderContext which is stored in a ThreadLocal.
 
-        currentWorld = world;
-        currentFluidState = fluidState;
-        currentBlockPos = blockPos;
-        currentOffset = offset;
-        currentMeshBuilder = meshBuilder;
-        currentMaterial = material;
-        currentHandler = handler;
-        CURRENT_RENDERER.set(this);
+        DefaultRenderContext defaultContext = CURRENT_DEFAULT_CONTEXT.get();
+        defaultContext.setUp(this.defaultRenderer, world, fluidState, blockPos, offset, meshBuilder, material, handler);
 
-        handler.renderFluid(blockPos, world, meshBuilder.asVertexConsumer(material), blockState, fluidState);
-
-        CURRENT_RENDERER.set(null);
-        currentWorld = null;
-        currentFluidState = null;
-        currentBlockPos = null;
-        currentOffset = null;
-        currentMeshBuilder = null;
-        currentMaterial = null;
-        currentHandler = null;
+        try {
+            handler.renderFluid(blockPos, world, meshBuilder.asFallbackVertexConsumer(material), blockState, fluidState);
+        } finally {
+            defaultContext.clear();
+        }
     }
 
     public static boolean renderFromVanilla() {
-        FluidRenderer renderer = CURRENT_RENDERER.get();
-
-        if (renderer != null) {
-            renderer.renderDefault(renderer.currentWorld, renderer.currentFluidState, renderer.currentBlockPos, renderer.currentOffset, renderer.currentMeshBuilder, renderer.currentMaterial, renderer.currentHandler);
-            return true;
-        }
-
-        return false;
+        return CURRENT_DEFAULT_CONTEXT.get().renderIfSetUp();
     }
 
-    private void renderDefault(WorldSlice world, FluidState fluidState, BlockPos blockPos, BlockPos offset, ChunkModelBuilder meshBuilder, Material material, FluidRenderHandler handler) {
-        int posX = blockPos.getX();
-        int posY = blockPos.getY();
-        int posZ = blockPos.getZ();
+    private static class DefaultRenderContext {
+        private DefaultFluidRenderer renderer;
+        private WorldSlice world;
+        private FluidState fluidState;
+        private BlockPos blockPos;
+        private BlockPos offset;
+        private ChunkModelBuilder meshBuilder;
+        private Material material;
+        private FluidRenderHandler handler;
 
-        Fluid fluid = fluidState.getFluid();
-
-        boolean sfUp = this.isFluidOccluded(world, posX, posY, posZ, Direction.UP, fluid);
-        boolean sfDown = this.isFluidOccluded(world, posX, posY, posZ, Direction.DOWN, fluid) ||
-                !this.isSideExposed(world, posX, posY, posZ, Direction.DOWN, 0.8888889F);
-        boolean sfNorth = this.isFluidOccluded(world, posX, posY, posZ, Direction.NORTH, fluid);
-        boolean sfSouth = this.isFluidOccluded(world, posX, posY, posZ, Direction.SOUTH, fluid);
-        boolean sfWest = this.isFluidOccluded(world, posX, posY, posZ, Direction.WEST, fluid);
-        boolean sfEast = this.isFluidOccluded(world, posX, posY, posZ, Direction.EAST, fluid);
-
-        if (sfUp && sfDown && sfEast && sfWest && sfNorth && sfSouth) {
-            return;
+        public void setUp(DefaultFluidRenderer renderer, WorldSlice world, FluidState fluidState, BlockPos blockPos, BlockPos offset, ChunkModelBuilder meshBuilder, Material material, FluidRenderHandler handler) {
+            this.renderer = renderer;
+            this.world = world;
+            this.fluidState = fluidState;
+            this.blockPos = blockPos;
+            this.offset = offset;
+            this.meshBuilder = meshBuilder;
+            this.material = material;
+            this.handler = handler;
         }
 
-        Sprite[] sprites = handler.getFluidSprites(world, blockPos, fluidState);
-        final ColorProvider<FluidState> colorProvider = this.getColorProvider(fluid, handler);
-
-        float fluidHeight = this.fluidHeight(world, fluid, blockPos, Direction.UP);
-        float northWestHeight, southWestHeight, southEastHeight, northEastHeight;
-        if (fluidHeight >= 1.0f) {
-            northWestHeight = 1.0f;
-            southWestHeight = 1.0f;
-            southEastHeight = 1.0f;
-            northEastHeight = 1.0f;
-        } else {
-            var scratchPos = new BlockPos.Mutable();
-            float heightNorth = this.fluidHeight(world, fluid, scratchPos.set(blockPos, Direction.NORTH), Direction.NORTH);
-            float heightSouth = this.fluidHeight(world, fluid, scratchPos.set(blockPos, Direction.SOUTH), Direction.SOUTH);
-            float heightEast = this.fluidHeight(world, fluid, scratchPos.set(blockPos, Direction.EAST), Direction.EAST);
-            float heightWest = this.fluidHeight(world, fluid, scratchPos.set(blockPos, Direction.WEST), Direction.WEST);
-            northWestHeight = this.fluidCornerHeight(world, fluid, fluidHeight, heightNorth, heightWest, scratchPos.set(blockPos)
-                    .move(Direction.NORTH)
-                    .move(Direction.WEST));
-            southWestHeight = this.fluidCornerHeight(world, fluid, fluidHeight, heightSouth, heightWest, scratchPos.set(blockPos)
-                    .move(Direction.SOUTH)
-                    .move(Direction.WEST));
-            southEastHeight = this.fluidCornerHeight(world, fluid, fluidHeight, heightSouth, heightEast, scratchPos.set(blockPos)
-                    .move(Direction.SOUTH)
-                    .move(Direction.EAST));
-            northEastHeight = this.fluidCornerHeight(world, fluid, fluidHeight, heightNorth, heightEast, scratchPos.set(blockPos)
-                    .move(Direction.NORTH)
-                    .move(Direction.EAST));
+        public void clear() {
+            this.renderer = null;
+            this.world = null;
+            this.fluidState = null;
+            this.blockPos = null;
+            this.offset = null;
+            this.meshBuilder = null;
+            this.material = null;
+            this.handler = null;
         }
-        float yOffset = sfDown ? 0.0F : EPSILON;
 
-        final ModelQuadViewMutable quad = this.quad;
-
-        LightMode lightMode = fluidState.isIn(FluidTags.WATER) && MinecraftClient.isAmbientOcclusionEnabled() ? LightMode.SMOOTH : LightMode.FLAT;
-        LightPipeline lighter = this.lighters.getLighter(lightMode);
-
-        quad.setFlags(0);
-
-        if (!sfUp && this.isSideExposed(world, posX, posY, posZ, Direction.UP, Math.min(Math.min(northWestHeight, southWestHeight), Math.min(southEastHeight, northEastHeight)))) {
-            northWestHeight -= EPSILON;
-            southWestHeight -= EPSILON;
-            southEastHeight -= EPSILON;
-            northEastHeight -= EPSILON;
-
-            Vec3d velocity = fluidState.getVelocity(world, blockPos);
-
-            Sprite sprite;
-            ModelQuadFacing facing;
-            float u1, u2, u3, u4;
-            float v1, v2, v3, v4;
-
-            if (velocity.x == 0.0D && velocity.z == 0.0D) {
-                sprite = sprites[0];
-                facing = ModelQuadFacing.POS_Y;
-                u1 = sprite.getFrameU(0.0f);
-                v1 = sprite.getFrameV(0.0f);
-                u2 = u1;
-                v2 = sprite.getFrameV(1.0f);
-                u3 = sprite.getFrameU(1.0f);
-                v3 = v2;
-                u4 = u3;
-                v4 = v1;
-            } else {
-                sprite = sprites[1];
-                facing = ModelQuadFacing.UNASSIGNED;
-                float dir = (float) MathHelper.atan2(velocity.z, velocity.x) - (1.5707964f);
-                float sin = MathHelper.sin(dir) * 0.25F;
-                float cos = MathHelper.cos(dir) * 0.25F;
-                u1 = sprite.getFrameU(0.5F + (-cos - sin));
-                v1 = sprite.getFrameV(0.5F + -cos + sin);
-                u2 = sprite.getFrameU(0.5F + -cos + sin);
-                v2 = sprite.getFrameV(0.5F + cos + sin);
-                u3 = sprite.getFrameU(0.5F + cos + sin);
-                v3 = sprite.getFrameV(0.5F + (cos - sin));
-                u4 = sprite.getFrameU(0.5F + (cos - sin));
-                v4 = sprite.getFrameV(0.5F + (-cos - sin));
+        public boolean renderIfSetUp() {
+            if (this.renderer != null) {
+                this.renderer.render(this.world, this.fluidState, this.blockPos, this.offset, this.meshBuilder, this.material, this.handler);
+                return true;
             }
 
-            float uAvg = (u1 + u2 + u3 + u4) / 4.0F;
-            float vAvg = (v1 + v2 + v3 + v4) / 4.0F;
-            float s3 = sprites[0].getAnimationFrameDelta();
-
-            u1 = MathHelper.lerp(s3, u1, uAvg);
-            u2 = MathHelper.lerp(s3, u2, uAvg);
-            u3 = MathHelper.lerp(s3, u3, uAvg);
-            u4 = MathHelper.lerp(s3, u4, uAvg);
-            v1 = MathHelper.lerp(s3, v1, vAvg);
-            v2 = MathHelper.lerp(s3, v2, vAvg);
-            v3 = MathHelper.lerp(s3, v3, vAvg);
-            v4 = MathHelper.lerp(s3, v4, vAvg);
-
-            quad.setSprite(sprite);
-
-            setVertex(quad, 0, 0.0f, northWestHeight, 0.0f, u1, v1);
-            setVertex(quad, 1, 0.0f, southWestHeight, 1.0F, u2, v2);
-            setVertex(quad, 2, 1.0F, southEastHeight, 1.0F, u3, v3);
-            setVertex(quad, 3, 1.0F, northEastHeight, 0.0f, u4, v4);
-
-            this.updateQuad(quad, world, blockPos, lighter, Direction.UP, 1.0F, colorProvider, fluidState);
-            this.writeQuad(meshBuilder, material, offset, quad, facing, false);
-
-            if (fluidState.canFlowTo(world, this.scratchPos.set(posX, posY + 1, posZ))) {
-                this.writeQuad(meshBuilder, material, offset, quad,
-                        ModelQuadFacing.NEG_Y, true);
-            }
+            return false;
         }
-
-        if (!sfDown) {
-            Sprite sprite = sprites[0];
-
-            float minU = sprite.getMinU();
-            float maxU = sprite.getMaxU();
-            float minV = sprite.getMinV();
-            float maxV = sprite.getMaxV();
-            quad.setSprite(sprite);
-
-            setVertex(quad, 0, 0.0f, yOffset, 1.0F, minU, maxV);
-            setVertex(quad, 1, 0.0f, yOffset, 0.0f, minU, minV);
-            setVertex(quad, 2, 1.0F, yOffset, 0.0f, maxU, minV);
-            setVertex(quad, 3, 1.0F, yOffset, 1.0F, maxU, maxV);
-
-            this.updateQuad(quad, world, blockPos, lighter, Direction.DOWN, 1.0F, colorProvider, fluidState);
-            this.writeQuad(meshBuilder, material, offset, quad, ModelQuadFacing.NEG_Y, false);
-        }
-
-        quad.setFlags(ModelQuadFlags.IS_PARALLEL | ModelQuadFlags.IS_ALIGNED);
-
-        for (Direction dir : DirectionUtil.HORIZONTAL_DIRECTIONS) {
-            float c1;
-            float c2;
-            float x1;
-            float z1;
-            float x2;
-            float z2;
-
-            switch (dir) {
-                case NORTH -> {
-                    if (sfNorth) {
-                        continue;
-                    }
-                    c1 = northWestHeight;
-                    c2 = northEastHeight;
-                    x1 = 0.0f;
-                    x2 = 1.0F;
-                    z1 = EPSILON;
-                    z2 = z1;
-                }
-                case SOUTH -> {
-                    if (sfSouth) {
-                        continue;
-                    }
-                    c1 = southEastHeight;
-                    c2 = southWestHeight;
-                    x1 = 1.0F;
-                    x2 = 0.0f;
-                    z1 = 1.0f - EPSILON;
-                    z2 = z1;
-                }
-                case WEST -> {
-                    if (sfWest) {
-                        continue;
-                    }
-                    c1 = southWestHeight;
-                    c2 = northWestHeight;
-                    x1 = EPSILON;
-                    x2 = x1;
-                    z1 = 1.0F;
-                    z2 = 0.0f;
-                }
-                case EAST -> {
-                    if (sfEast) {
-                        continue;
-                    }
-                    c1 = northEastHeight;
-                    c2 = southEastHeight;
-                    x1 = 1.0f - EPSILON;
-                    x2 = x1;
-                    z1 = 0.0f;
-                    z2 = 1.0F;
-                }
-                default -> {
-                    continue;
-                }
-            }
-
-            if (this.isSideExposed(world, posX, posY, posZ, dir, Math.max(c1, c2))) {
-                int adjX = posX + dir.getOffsetX();
-                int adjY = posY + dir.getOffsetY();
-                int adjZ = posZ + dir.getOffsetZ();
-
-                Sprite sprite = sprites[1];
-
-                boolean isOverlay = false;
-
-                if (sprites.length > 2) {
-                    BlockPos adjPos = this.scratchPos.set(adjX, adjY, adjZ);
-                    BlockState adjBlock = world.getBlockState(adjPos);
-
-                    if (FluidRenderHandlerRegistry.INSTANCE.isBlockTransparent(adjBlock.getBlock())) {
-                        sprite = sprites[2];
-                        isOverlay = true;
-                    }
-                }
-
-                float u1 = sprite.getFrameU(0.0F);
-                float u2 = sprite.getFrameU(0.5F);
-                float v1 = sprite.getFrameV((1.0F - c1) * 0.5F);
-                float v2 = sprite.getFrameV((1.0F - c2) * 0.5F);
-                float v3 = sprite.getFrameV(0.5F);
-
-                quad.setSprite(sprite);
-
-                setVertex(quad, 0, x2, c2, z2, u2, v2);
-                setVertex(quad, 1, x2, yOffset, z2, u2, v3);
-                setVertex(quad, 2, x1, yOffset, z1, u1, v3);
-                setVertex(quad, 3, x1, c1, z1, u1, v1);
-
-                float br = dir.getAxis() == Direction.Axis.Z ? 0.8F : 0.6F;
-
-                ModelQuadFacing facing = ModelQuadFacing.fromDirection(dir);
-
-                this.updateQuad(quad, world, blockPos, lighter, dir, br, colorProvider, fluidState);
-                this.writeQuad(meshBuilder, material, offset, quad, facing, false);
-
-                if (!isOverlay) {
-                    this.writeQuad(meshBuilder, material, offset, quad, facing.getOpposite(), true);
-                }
-            }
-        }
-    }
-
-    private ColorProvider<FluidState> getColorProvider(Fluid fluid, FluidRenderHandler handler) {
-        var override = this.colorProviderRegistry.getColorProvider(fluid);
-
-        if (override != null) {
-            return override;
-        }
-        
-        return DefaultColorProviders.adapt(handler);
-    }
-
-    private void updateQuad(ModelQuadView quad, WorldSlice world, BlockPos pos, LightPipeline lighter, Direction dir, float brightness,
-                            ColorProvider<FluidState> colorProvider, FluidState fluidState) {
-        QuadLightData light = this.quadLightData;
-        lighter.calculate(quad, pos, light, null, dir, false);
-
-        colorProvider.getColors(world, pos, fluidState, quad, this.quadColors);
-
-        // multiply the per-vertex color against the combined brightness
-        // the combined brightness is the per-vertex brightness multiplied by the block's brightness
-        for (int i = 0; i < 4; i++) {
-            this.quadColors[i] = ColorABGR.withAlpha(this.quadColors[i], light.br[i] * brightness);
-        }
-    }
-
-    private void writeQuad(ChunkModelBuilder builder, Material material, BlockPos offset, ModelQuadView quad,
-                           ModelQuadFacing facing, boolean flip) {
-        var vertices = this.vertices;
-
-        for (int i = 0; i < 4; i++) {
-            var out = vertices[flip ? 3 - i : i];
-            out.x = offset.getX() + quad.getX(i);
-            out.y = offset.getY() + quad.getY(i);
-            out.z = offset.getZ() + quad.getZ(i);
-
-            out.color = this.quadColors[i];
-            out.u = quad.getTexU(i);
-            out.v = quad.getTexV(i);
-            out.light = this.quadLightData.lm[i];
-        }
-
-        Sprite sprite = quad.getSprite();
-
-        if (sprite != null) {
-            builder.addSprite(sprite);
-        }
-
-        var vertexBuffer = builder.getVertexBuffer(facing);
-        vertexBuffer.push(vertices, material);
-    }
-
-    private static void setVertex(ModelQuadViewMutable quad, int i, float x, float y, float z, float u, float v) {
-        quad.setX(i, x);
-        quad.setY(i, y);
-        quad.setZ(i, z);
-        quad.setTexU(i, u);
-        quad.setTexV(i, v);
-    }
-
-    private float fluidCornerHeight(BlockRenderView world, Fluid fluid, float fluidHeight, float fluidHeightX, float fluidHeightY, BlockPos blockPos) {
-        if (fluidHeightY >= 1.0f || fluidHeightX >= 1.0f) {
-            return 1.0f;
-        }
-
-        if (fluidHeightY > 0.0f || fluidHeightX > 0.0f) {
-            float height = this.fluidHeight(world, fluid, blockPos, Direction.UP);
-
-            if (height >= 1.0f) {
-                return 1.0f;
-            }
-
-            this.modifyHeight(this.scratchHeight, this.scratchSamples, height);
-        }
-
-        this.modifyHeight(this.scratchHeight, this.scratchSamples, fluidHeight);
-        this.modifyHeight(this.scratchHeight, this.scratchSamples, fluidHeightY);
-        this.modifyHeight(this.scratchHeight, this.scratchSamples, fluidHeightX);
-
-        float result = this.scratchHeight.floatValue() / this.scratchSamples.intValue();
-        this.scratchHeight.setValue(0);
-        this.scratchSamples.setValue(0);
-
-        return result;
-    }
-
-    private void modifyHeight(MutableFloat totalHeight, MutableInt samples, float target) {
-        if (target >= 0.8f) {
-            totalHeight.add(target * 10.0f);
-            samples.add(10);
-        } else if (target >= 0.0f) {
-            totalHeight.add(target);
-            samples.increment();
-        }
-    }
-
-    private float fluidHeight(BlockRenderView world, Fluid fluid, BlockPos blockPos, Direction direction) {
-        BlockState blockState = world.getBlockState(blockPos);
-        FluidState fluidState = blockState.getFluidState();
-
-        if (fluid.matchesType(fluidState.getFluid())) {
-            FluidState fluidStateUp = world.getFluidState(blockPos.up());
-
-            if (fluid.matchesType(fluidStateUp.getFluid())) {
-                return 1.0f;
-            } else {
-                return fluidState.getHeight();
-            }
-        }
-        if (!blockState.isSolid()) {
-            return 0.0f;
-        }
-        return -1.0f;
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderMeshingTask.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderMeshingTask.java
@@ -106,7 +106,7 @@ public class ChunkBuilderMeshingTask extends ChunkBuilderTask<ChunkBuildOutput> 
                         FluidState fluidState = blockState.getFluidState();
 
                         if (!fluidState.isEmpty()) {
-                            cache.getFluidRenderer().render(slice, fluidState, blockPos, modelOffset, buffers);
+                            cache.getFluidRenderer().render(slice, blockState, fluidState, blockPos, modelOffset, buffers);
                         }
 
                         if (blockState.hasBlockEntity()) {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/frapi/SpriteFinderCache.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/frapi/SpriteFinderCache.java
@@ -1,0 +1,52 @@
+package me.jellysquid.mods.sodium.client.render.frapi;
+
+import net.fabricmc.fabric.api.renderer.v1.model.SpriteFinder;
+import net.fabricmc.fabric.api.resource.ResourceReloadListenerKeys;
+import net.fabricmc.fabric.api.resource.SimpleSynchronousResourceReloadListener;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.model.BakedModelManager;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.screen.PlayerScreenHandler;
+import net.minecraft.util.Identifier;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Caches {@link SpriteFinder}s for maximum efficiency. They must be refreshed after each resource reload.
+ *
+ * <p><b>This class should not be used during a resource reload</b>, as returned SpriteFinders may be null or outdated.
+ */
+public class SpriteFinderCache {
+    private static SpriteFinder blockAtlasSpriteFinder;
+
+    public static SpriteFinder forBlockAtlas() {
+        return blockAtlasSpriteFinder;
+    }
+
+    public static class ReloadListener implements SimpleSynchronousResourceReloadListener {
+        public static final Identifier ID = new Identifier("sodium", "sprite_finder_cache");
+        public static final List<Identifier> DEPENDENCIES = List.of(ResourceReloadListenerKeys.MODELS);
+        public static final ReloadListener INSTANCE = new ReloadListener();
+
+        private ReloadListener() {
+        }
+
+        // BakedModelManager#getAtlas only returns correct results after the BakedModelManager is done reloading
+        @Override
+        public void reload(ResourceManager manager) {
+            BakedModelManager modelManager = MinecraftClient.getInstance().getBakedModelManager();
+            blockAtlasSpriteFinder = SpriteFinder.get(modelManager.getAtlas(PlayerScreenHandler.BLOCK_ATLAS_TEXTURE));
+        }
+
+        @Override
+        public Identifier getFabricId() {
+            return ID;
+        }
+
+        @Override
+        public Collection<Identifier> getFabricDependencies() {
+            return DEPENDENCIES;
+        }
+    }
+}

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/chunk/FluidRendererMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/render/chunk/FluidRendererMixin.java
@@ -1,0 +1,18 @@
+package me.jellysquid.mods.sodium.mixin.core.render.chunk;
+
+import me.jellysquid.mods.sodium.client.render.chunk.compile.pipeline.FluidRenderer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+// Apply after Fabric API
+@Mixin(value = net.minecraft.client.render.block.FluidRenderer.class, priority = 2000)
+public class FluidRendererMixin {
+    @Inject(method = "render", at = @At("HEAD"), cancellable = true)
+    private void onHeadRender(CallbackInfo ci) {
+        if (FluidRenderer.renderFromVanilla()) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -70,8 +70,11 @@
   ],
   "depends": {
     "fabricloader": ">=0.12.0",
-    "fabric-rendering-data-attachment-v1": ">=0.1",
-    "fabric-rendering-fluids-v1": ">=0.1"
+    "fabric-block-view-api-v2": "*",
+    "fabric-renderer-api-v1": "*",
+    "fabric-rendering-data-attachment-v1": "*",
+    "fabric-rendering-fluids-v1": "*",
+    "fabric-resource-loader-v0": "*"
   },
   "breaks": {
     "optifabric": "*",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -73,7 +73,7 @@
     "fabric-block-view-api-v2": "*",
     "fabric-renderer-api-v1": "*",
     "fabric-rendering-data-attachment-v1": "*",
-    "fabric-rendering-fluids-v1": "*",
+    "fabric-rendering-fluids-v1": ">=2.0.0",
     "fabric-resource-loader-v0": "*"
   },
   "breaks": {

--- a/src/main/resources/sodium.mixins.json
+++ b/src/main/resources/sodium.mixins.json
@@ -17,6 +17,7 @@
     "core.model.colors.ItemColorsMixin",
     "core.model.quad.BakedQuadMixin",
     "core.render.VertexFormatAccessor",
+    "core.render.chunk.FluidRendererMixin",
     "core.render.frustum.FrustumMixin",
     "core.render.immediate.consumer.BufferBuilderMixin",
     "core.render.immediate.consumer.OutlineVertexConsumerMixin",


### PR DESCRIPTION
This pull request adds support for custom fluid rendering, specifically through `FluidRenderHandler#renderFluid`, which is added by Fabric API. These changes have been tested with Bumblezone, after modifying the jar to disable the mixin to Sodium's `FluidRenderer`.