### PR TITLE
Add jitpack config making recent builds not fail

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ plugins {
     // is not reachable for some reason, and it makes builds much more reproducible. Observation also shows that it
     // really helps to improve startup times on slow connections.
     id("fabric-loom") version "1.5.7"
+    id("maven-publish")
 }
 
 base {

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,4 @@
 jdk:
   - openjdk17
+before_install:
+  - rm -rf ~/.gradle/caches


### PR DESCRIPTION
- Adds a jitpack.yml to use open jdk 17 to build sodium
- Adds the maven-publish plugin so jitpack will run the right commands
- Purge's gradle cache before building a artifact that will be on jitpack

Requested by @MCRcortex so they can depend on the latest commit of sodium for their mods