### PR TITLE
Updated text of brightness slider tooltip

### DIFF
--- a/src/main/resources/assets/sodium/lang/en_us.json
+++ b/src/main/resources/assets/sodium/lang/en_us.json
@@ -9,7 +9,7 @@
   "sodium.options.pages.advanced": "Advanced",
   "sodium.options.view_distance.tooltip": "The render distance controls how far away terrain will be rendered. Shorter distances mean that less terrain will be rendered, improving frame rates.",
   "sodium.options.simulation_distance.tooltip": "The simulation distance controls how far away terrain and entities will be loaded and ticked. Shorter distances can reduce the internal server's load and may improve frame rates.",
-  "sodium.options.brightness.tooltip": "Controls the brightness (gamma) of the game.",
+  "sodium.options.brightness.tooltip": "Controls the lighting intensity in darker areas of the game. Well lit areas are not affected.",
   "sodium.options.gui_scale.tooltip": "Sets the maximum scale factor to be used for the user interface. If \"auto\" is used, then the largest scale factor will always be used.",
   "sodium.options.fullscreen.tooltip": "If enabled, the game will display in full-screen (if supported).",
   "sodium.options.v_sync.tooltip": "If enabled, the game's frame rate will be synchronized to the monitor's refresh rate, making for a generally smoother experience at the expense of overall input latency. This setting might reduce performance if your system is too slow.",


### PR DESCRIPTION
Resolves #2347 by changing the tooltip of the brightness slider to use less misleading language. Changed the text to use the phrase "lighting intensity" to replace "brightness (gamma)", to make it more clear and less ambiguous about what is actually being changed.