### PR TITLE
Attribute locations are not influenced by out locations, fix an offset of 1

### DIFF
--- a/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/shader/ChunkShaderBindingPoints.java
+++ b/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/shader/ChunkShaderBindingPoints.java
@@ -1,10 +1,10 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.shader;
 
 public class ChunkShaderBindingPoints {
-    public static final int ATTRIBUTE_POSITION_ID = 1;
-    public static final int ATTRIBUTE_COLOR = 2;
-    public static final int ATTRIBUTE_BLOCK_TEXTURE = 3;
-    public static final int ATTRIBUTE_LIGHT_TEXTURE = 4;
+    public static final int ATTRIBUTE_POSITION_ID = 0;
+    public static final int ATTRIBUTE_COLOR = 1;
+    public static final int ATTRIBUTE_BLOCK_TEXTURE = 2;
+    public static final int ATTRIBUTE_LIGHT_TEXTURE = 3;
 
     public static final int FRAG_COLOR = 0;
 }


### PR DESCRIPTION
To my knowledge, when it comes to shader attribute binding points, 1, 2, 3, and 4, should probably be 0, 1, 2, 3. fragColor falls under a separate func for binding. So a 0 and 0 collision is not possible here. Very much a nitpick, but I wanted to make sure I am correct in this. 

Very much a nitpick, but could avoid a hassle with the recent development of new drivers, if there are any other areas that should be changed as well let me know.

