### PR TITLE
bugfix 0.6: missing accesswidener for fabric

### DIFF
--- a/fabric/src/main/resources/sodium.accesswidener
+++ b/fabric/src/main/resources/sodium.accesswidener
@@ -13,6 +13,7 @@ accessible class net/minecraft/client/renderer/FogRenderer$MobEffectFogFunction
 accessible class net/minecraft/client/renderer/texture/Stitcher$Holder
 accessible class net/minecraft/world/level/biome/Biome$ClimateSettings
 accessible method net/minecraft/client/renderer/SectionBufferBuilderPool <init> (Ljava/util/List;)V
+accessible field com/mojang/blaze3d/vertex/PoseStack$Pose trustedNormals Z
 
 accessible method com/mojang/blaze3d/vertex/PoseStack$Pose <init> (Lorg/joml/Matrix4f;Lorg/joml/Matrix3f;)V
 


### PR DESCRIPTION
Adds missing accessible field com/mojang/blaze3d/vertex/PoseStack$Pose trustedNormals Z

Fixes the following exception in production deployments.
```
java.lang.IllegalAccessError: class net.caffeinemc.mods.sodium.client.render.immediate.model.BakedModelEncoder tried to access field net.minecraft.class_4587$class_4665.field_48930 (net.caffeinemc.mods.sodium.client.render.immediate.model.BakedModelEncoder and net.minecraft.class_4587$class_4665 are in unnamed module of loader net.fabricmc.loader.impl.launch.knot.KnotClassLoader @604ed9f0)
	at net.caffeinemc.mods.sodium.client.render.immediate.model.BakedModelEncoder.writeQuadVertices(BakedModelEncoder.java:44) ~[sodium-fabric-1.20.6-0.6.0-snapshot+mc1.20.6-local.jar:?]
	at net.minecraft.class_918.renderBakedItemQuads(class_918.java:2595) ~[client-intermediary.jar:?]
	at net.minecraft.class_918.handler$ejo000$sodium$renderModelFast(class_918.java:2573) ~[client-intermediary.jar:?]
```