### PR TITLE
Reorient water quads as needed based on corner height to fix #609

### DIFF
--- a/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/DefaultFluidRenderer.java
+++ b/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/DefaultFluidRenderer.java
@@ -215,16 +215,29 @@ public class DefaultFluidRenderer {
 
             quad.setSprite(sprite);
 
-            setVertex(quad, 0, 0.0f, northWestHeight, 0.0f, u1, v1);
-            setVertex(quad, 1, 0.0f, southWestHeight, 1.0F, u2, v2);
-            setVertex(quad, 2, 1.0F, southEastHeight, 1.0F, u3, v3);
-            setVertex(quad, 3, 1.0F, northEastHeight, 0.0f, u4, v4);
-
             // top surface alignedness is calculated with a more relaxed epsilon
             boolean aligned = isAlignedEquals(northEastHeight, northWestHeight)
                     && isAlignedEquals(northWestHeight, southEastHeight)
                     && isAlignedEquals(southEastHeight, southWestHeight)
                     && isAlignedEquals(southWestHeight, northEastHeight);
+
+            boolean creaseNorthEastSouthWest = aligned
+                    || northEastHeight > northWestHeight && northEastHeight > southEastHeight
+                    || northEastHeight < northWestHeight && northEastHeight < southEastHeight
+                    || southWestHeight > northWestHeight && southWestHeight > southEastHeight
+                    || southWestHeight < northWestHeight && southWestHeight < southEastHeight;
+
+            if (creaseNorthEastSouthWest) {
+                setVertex(quad, 1, 0.0f, northWestHeight, 0.0f, u1, v1);
+                setVertex(quad, 2, 0.0f, southWestHeight, 1.0F, u2, v2);
+                setVertex(quad, 3, 1.0F, southEastHeight, 1.0F, u3, v3);
+                setVertex(quad, 0, 1.0F, northEastHeight, 0.0f, u4, v4);
+            } else {
+                setVertex(quad, 0, 0.0f, northWestHeight, 0.0f, u1, v1);
+                setVertex(quad, 1, 0.0f, southWestHeight, 1.0F, u2, v2);
+                setVertex(quad, 2, 1.0F, southEastHeight, 1.0F, u3, v3);
+                setVertex(quad, 3, 1.0F, northEastHeight, 0.0f, u4, v4);
+            }
 
             this.updateQuad(quad, level, blockPos, lighter, Direction.UP, 1.0F, colorProvider, fluidState);
             this.writeQuad(meshBuilder, collector, material, offset, quad, aligned ? ModelQuadFacing.POS_Y : ModelQuadFacing.UNASSIGNED, false);
@@ -233,7 +246,6 @@ public class DefaultFluidRenderer {
                 this.writeQuad(meshBuilder, collector, material, offset, quad,
                         aligned ? ModelQuadFacing.NEG_Y : ModelQuadFacing.UNASSIGNED, true);
             }
-
         }
 
         if (!sfDown) {
@@ -405,7 +417,7 @@ public class DefaultFluidRenderer {
         var vertices = this.vertices;
 
         for (int i = 0; i < 4; i++) {
-            var out = vertices[flip ? 3 - i : i];
+            var out = vertices[flip ? (3 - i + 1) & 0b11 : i];
             out.x = offset.getX() + quad.getX(i);
             out.y = offset.getY() + quad.getY(i);
             out.z = offset.getZ() + quad.getZ(i);


### PR DESCRIPTION
the seam is placed such that it touches the highest or lowest corner
![2024-05-05_19 01 33](https://github.com/CaffeineMC/sodium-fabric/assets/17120022/536cdf6e-37a4-4b92-87c1-bd9a334478ee)

It was necessary to offset the inner water quads by 1 to align their seam with their upwards facing counterparts.

Fixes #609 