### PR TITLE
Bugfix/0.6 water occlusion behind transparent blocks

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/DefaultFluidRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/DefaultFluidRenderer.java
@@ -76,7 +76,7 @@ public class DefaultFluidRenderer {
         if (blockState.getFluidState().getType().isSame(fluid)) {
             return true;
         }
-        return blockState.isFaceSturdy(world, adjPos, dir.getOpposite(), SupportType.FULL);
+        return blockState.canOcclude() && blockState.isFaceSturdy(world, adjPos, dir.getOpposite(), SupportType.FULL);
     }
 
     private boolean isSideExposed(BlockAndTintGetter world, int x, int y, int z, Direction dir, float height) {


### PR DESCRIPTION
When a transparent/translucent block surrounds a fluid, the fluid is considered to be occluded, however this is incorrect as the fluid can be seen through the transparent block. 

Issue present:
![2024-05-05_13 29 52](https://github.com/CaffeineMC/sodium-fabric/assets/68366846/7c5a51df-b0fd-4079-8cfb-60b9a4b7144c)

Issue resolved with this PR:
![2024-05-05_13 30 21](https://github.com/CaffeineMC/sodium-fabric/assets/68366846/4b51c51f-e505-4122-9156-3d68ca0692d9)


bug introduced in 0.6 branch during bc38d5638d391d3dfd1a928f6c7981116a7510f7 (not in dev)