### PR TITLE
bugifx: 0.6: The top face of fluids must not be occluded even if the block above h…

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/DefaultFluidRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/DefaultFluidRenderer.java
@@ -76,7 +76,7 @@ public class DefaultFluidRenderer {
         if (blockState.getFluidState().getType().isSame(fluid)) {
             return true;
         }
-        return blockState.canOcclude() && blockState.isFaceSturdy(world, adjPos, dir.getOpposite(), SupportType.FULL);
+        return blockState.canOcclude() && dir != Direction.UP && blockState.isFaceSturdy(world, adjPos, dir.getOpposite(), SupportType.FULL);
     }
 
     private boolean isSideExposed(BlockAndTintGetter world, int x, int y, int z, Direction dir, float height) {


### PR DESCRIPTION
The top face of fluids must not be occluded even if the block above has a full-face bottom. The top fluid face is not coplanar with the bottom full-face, and thus can be seen from sideways, and the top side should be rendered so that underground aquifers and lava pockets render properly in spectator mode. 

Note how under the **solid block** (here, packed ice, #2468 fixed only the case for translucent blocks) the top face is occluded, but remains visible from the side air-blocks, or from translucent blocks on the side.
![2024-05-06_00 55 11](https://github.com/CaffeineMC/sodium-fabric/assets/68366846/75c31fe0-ba9e-412a-b8ee-9cb4df6f82d2)

Bug: Underground water aquifers are invisible, same for lava pockets
![2024-05-06_00 56 22](https://github.com/CaffeineMC/sodium-fabric/assets/68366846/101ea427-052f-495b-933d-37fe893e2452)

This PR: returns to ground truth: 
![2024-05-06_00 56 52](https://github.com/CaffeineMC/sodium-fabric/assets/68366846/b556ffc1-f966-4ffe-93d1-33ec33b00e3e)


Bug present only in 0.6 (not in dev) from https://github.com/CaffeineMC/sodium-fabric/commit/bc38d5638d391d3dfd1a928f6c7981116a7510f7