### PR TITLE
GH actions 1.20.6 requires java 21

### DIFF
--- a/.github/workflows/build-commit.yml
+++ b/.github/workflows/build-commit.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
       - name: Initialize caches
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -25,6 +25,6 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
       - name: Build artifacts
         run: ./gradlew build

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
       - name: Build artifacts
         run: ./gradlew build -Pbuild.release=true
       - name: Upload assets to GitHub

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
       - name: Initialize caches
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
This can be cherry-picked to 1.20.5/stable etc. as needed.