### PR TITLE
[TS] Fix sorting crash when geometry with dot product of -1 is processed

### DIFF
--- a/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/bsp_tree/InnerMultiPartitionBSPNode.java
+++ b/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/bsp_tree/InnerMultiPartitionBSPNode.java
@@ -9,7 +9,7 @@ import it.unimi.dsi.fastutil.objects.ReferenceArrayList;
  * Partitions quads into multiple child BSP nodes with multiple parallel
  * partition planes. This is uses less memory and time than constructing a
  * binary BSP tree through more partitioning passes.
- * 
+ *
  * Implementation note: Detecting and avoiding the double array when possible
  * brings no performance benefit in sorting speed, only a building speed
  * detriment.
@@ -116,13 +116,13 @@ class InnerMultiPartitionBSPNode extends InnerPartitionBSPNode {
             var partition = partitions.get(i);
 
             // if the partition actually has a plane
-            float partitionDistance = -1;
+            float partitionDistance = Float.NaN;
             if (endsWithPlane || i < count - 1) {
                 partitionDistance = partition.distance();
                 workspace.addAlignedPartitionPlane(axis, partitionDistance);
 
                 // NOTE: sanity check
-                if (partitionDistance == -1) {
+                if (Float.isNaN(partitionDistance)) {
                     throw new IllegalStateException("partition distance not set");
                 }
 
@@ -139,9 +139,10 @@ class InnerMultiPartitionBSPNode extends InnerPartitionBSPNode {
                         oldChildIndex++;
                         oldPartitionDistance = oldChildIndex < oldPlaneDistances.length
                                 ? oldPlaneDistances[oldChildIndex]
-                                : -1;
+                                : Float.NaN;
                     }
-                    if (oldChildIndex < oldPartitionNodes.length && oldPartitionDistance == partitionDistance) {
+                    if (oldChildIndex < oldPartitionNodes.length
+                            && (oldPartitionDistance == partitionDistance || Float.isNaN(partitionDistance) && Float.isNaN(oldPartitionDistance))) {
                         oldChild = oldPartitionNodes[oldChildIndex];
                     }
                 }

--- a/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/bsp_tree/InnerPartitionBSPNode.java
+++ b/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/bsp_tree/InnerPartitionBSPNode.java
@@ -279,7 +279,7 @@ abstract class InnerPartitionBSPNode extends BSPNode {
 
             // find gaps
             partitions.clear();
-            float distance = -1;
+            float distance = Float.NaN;
             IntArrayList quadsBefore = null;
             IntArrayList quadsOn = null;
             int thickness = 0;
@@ -289,7 +289,7 @@ abstract class InnerPartitionBSPNode extends BSPNode {
                         // unless at the start, flush if there's a gap
                         if (thickness == 0 && (quadsBefore != null || quadsOn != null)) {
                             partitions.add(new Partition(distance, quadsBefore, quadsOn));
-                            distance = -1;
+                            distance = Float.NaN;
                             quadsBefore = null;
                             quadsOn = null;
                         }
@@ -298,11 +298,11 @@ abstract class InnerPartitionBSPNode extends BSPNode {
 
                         // flush to partition if still writing last partition
                         if (quadsOn != null) {
-                            if (distance == -1) {
+                            if (Float.isNaN(distance)) {
                                 throw new IllegalStateException("distance not set");
                             }
                             partitions.add(new Partition(distance, quadsBefore, quadsOn));
-                            distance = -1;
+                            distance = Float.NaN;
                             quadsOn = null;
                         }
                         if (quadsBefore == null) {
@@ -359,7 +359,7 @@ abstract class InnerPartitionBSPNode extends BSPNode {
             // flush the last partition, use the -1 distance to indicate the end if it
             // doesn't use quadsOn (which requires a certain distance to be given)
             if (quadsBefore != null || quadsOn != null) {
-                partitions.add(new Partition(endsWithPlane ? distance : -1, quadsBefore, quadsOn));
+                partitions.add(new Partition(endsWithPlane ? distance : Float.NaN, quadsBefore, quadsOn));
             }
 
             // check if this can be turned into a binary partition node


### PR DESCRIPTION
Fixes an issue where resource packs that generate geometry with a dot product of -1 would confuse the partitioning code leading to a crash. This has been fixed by instead using the semantically correct Float.NaN instead. Care was taken to ensure conditionals use Float.isNaN and don't rely on == behavior for NaNs.
Thanks to @Lolothepro for reporting this on discord.