### PR TITLE
Disable rendering clouds if texture is completely blank

### DIFF
--- a/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/CloudRenderer.java
+++ b/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/CloudRenderer.java
@@ -63,6 +63,11 @@ public class CloudRenderer {
             return;
         }
 
+        // Skip rendering clouds if texture is completely blank
+        if (this.textureData.isBlank) {
+            return;
+        }
+
         Vec3 pos = camera.getPosition();
 
         double cloudTime = (ticks + tickDelta) * 0.03F;
@@ -500,6 +505,7 @@ public class CloudRenderer {
     private static class CloudTextureData {
         private final byte[] faces;
         private final int[] colors;
+        private boolean isBlank;
 
         private final int width, height;
 
@@ -509,6 +515,7 @@ public class CloudRenderer {
 
             this.faces = new byte[width * height];
             this.colors = new int[width * height];
+            this.isBlank = true;
 
             this.width = width;
             this.height = height;
@@ -526,6 +533,7 @@ public class CloudRenderer {
 
                     if (!isTransparentCell(color)) {
                         this.faces[index] = (byte) getOpenFaces(texture, color, x, z);
+                        this.isBlank = false;
                     }
                 }
             }


### PR DESCRIPTION
Some resourcepacks/maps may disable clouds by blanking out the texture. This PR introduces a simple check to skip cloud rendering when this is the case