### PR TITLE
Do not refer to sodium as 'free and open-source'

### DIFF
--- a/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumOptionsGUI.java
+++ b/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumOptionsGUI.java
@@ -442,7 +442,7 @@ public class SodiumOptionsGUI extends Screen implements ScreenPromptable {
     static {
         DONATION_PROMPT_MESSAGE = List.of(
                 FormattedText.composite(Component.literal("Hello!")),
-                FormattedText.composite(Component.literal("It seems that you've been enjoying "), Component.literal("Sodium").withColor(0x27eb92), Component.literal(", the free and open-source optimization mod for Minecraft.")),
+                FormattedText.composite(Component.literal("It seems that you've been enjoying "), Component.literal("Sodium").withColor(0x27eb92), Component.literal(".")),
                 FormattedText.composite(Component.literal("Mods like these are complex. They require "), Component.literal("thousands of hours").withColor(0xff6e00), Component.literal(" of development, debugging, and tuning to create the experience that players have come to expect.")),
                 FormattedText.composite(Component.literal("If you'd like to show your token of appreciation, and support the development of our mod in the process, then consider "), Component.literal("buying us a coffee").withColor(0xed49ce), Component.literal(".")),
                 FormattedText.composite(Component.literal("And thanks again for using our mod! We hope it helps you (and your computer.)"))


### PR DESCRIPTION
Sodium is not free or open-source according to the FSF or OSI definitions, referring to sodium as FOSS may cause confusion for people who expect that to mean they are given certain rights not guaranteed by sodium's current license.  It also could be seen as deceptive to have this in a message requesting donations, as some people might not have donated if they had known sodium used a more restrictive license then is implied.