### PR TITLE
Fix delay with FREX Flawless Frames

### DIFF
--- a/src/main/java/net/caffeinemc/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/src/main/java/net/caffeinemc/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -206,9 +206,9 @@ public class SodiumWorldRenderer {
             this.lastCameraPos = new Vector3d(pos);
         }
 
-        boolean runChunkUpdates = true;
+        int maxChunkUpdates = updateChunksImmediately ? this.renderDistance : 1;
 
-        while (runChunkUpdates) {
+        for (int i = 0; i < maxChunkUpdates; i++) {
             if (this.renderSectionManager.needsUpdate()) {
                 profiler.popPush("chunk_render_lists");
 
@@ -224,7 +224,9 @@ public class SodiumWorldRenderer {
 
             this.renderSectionManager.uploadChunks();
 
-            runChunkUpdates = updateChunksImmediately && this.renderSectionManager.needsUpdate();
+            if (!this.renderSectionManager.needsUpdate()) {
+                break;
+            }
         }
 
         profiler.popPush("chunk_render_tick");

--- a/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -128,11 +128,12 @@ public class RenderSectionManager {
         this.cameraPosition = cameraPosition;
     }
 
-    public void update(Camera camera, Viewport viewport, int frame, boolean spectator) {
-        this.createTerrainRenderList(camera, viewport, frame, spectator);
+    public void update(Camera camera, Viewport viewport, boolean spectator) {
+        this.lastUpdatedFrame += 1;
+
+        this.createTerrainRenderList(camera, viewport, this.lastUpdatedFrame, spectator);
 
         this.needsGraphUpdate = false;
-        this.lastUpdatedFrame = frame;
     }
 
     private void createTerrainRenderList(Camera camera, Viewport viewport, int frame, boolean spectator) {

--- a/src/main/java/net/caffeinemc/mods/sodium/mixin/core/render/world/LevelRendererMixin.java
+++ b/src/main/java/net/caffeinemc/mods/sodium/mixin/core/render/world/LevelRendererMixin.java
@@ -49,9 +49,6 @@ public abstract class LevelRendererMixin implements LevelRendererExtension {
     @Unique
     private SodiumWorldRenderer renderer;
 
-    @Unique
-    private int frame;
-
     @Override
     public SodiumWorldRenderer sodium$getWorldRenderer() {
         return this.renderer;
@@ -130,7 +127,7 @@ public abstract class LevelRendererMixin implements LevelRendererExtension {
         RenderDevice.enterManagedCode();
 
         try {
-            this.renderer.setupTerrain(camera, viewport, this.frame++, spectator, updateChunksImmediately);
+            this.renderer.setupTerrain(camera, viewport, spectator, updateChunksImmediately);
         } finally {
             RenderDevice.exitManagedCode();
         }


### PR DESCRIPTION
Fix delay with FREX Flawless Frames due to dependency between building & visibility.

In order for a chunk to be built, it must be visible.
In order for a chunk to become visible via the graph search, it must have a neighbor that is built.

This dependency results in the graph search propagating visibility one section at a time. Normally this would be unnoticeable, but when using FREX Flawless Frames we want the entire world to be visible ASAP.

The solution in this PR is to simply to do building & visibility in a loop until there are no chunks left to build (but only when flawless frames is on)

This has also been ported to 1.20.6 here, might be useful as a reference if doing another 1.20.6 release: https://github.com/Moulberry/sodium-fabric/tree/fix_flawless_frames_delay/1.20.6