### PR TITLE
Fix issue #2591 by ignoring null driver names

### DIFF
--- a/src/main/java/net/caffeinemc/mods/sodium/client/compatibility/checks/PreLaunchChecks.java
+++ b/src/main/java/net/caffeinemc/mods/sodium/client/compatibility/checks/PreLaunchChecks.java
@@ -116,7 +116,7 @@ public class PreLaunchChecks {
 
         for (var adapter : GraphicsAdapterProbe.getAdapters()) {
             if (adapter instanceof D3DKMT.WDDMAdapterInfo wddmAdapterInfo) {
-                var driverName = wddmAdapterInfo.getOpenGlIcdName();
+                @Nullable var driverName = wddmAdapterInfo.getOpenGlIcdName();
                 var driverVersion = wddmAdapterInfo.openglIcdVersion();
 
                 if (driverName == null) {

--- a/src/main/java/net/caffeinemc/mods/sodium/client/compatibility/checks/PreLaunchChecks.java
+++ b/src/main/java/net/caffeinemc/mods/sodium/client/compatibility/checks/PreLaunchChecks.java
@@ -119,6 +119,10 @@ public class PreLaunchChecks {
                 var driverName = wddmAdapterInfo.getOpenGlIcdName();
                 var driverVersion = wddmAdapterInfo.openglIcdVersion();
 
+                if (driverName == null) {
+                    continue;
+                }
+
                 // Intel OpenGL ICD for Generation 7 GPUs
                 if (driverName.matches("ig7icd(32|64)")) {
                     // https://www.intel.com/content/www/us/en/support/articles/000005654/graphics.html


### PR DESCRIPTION
This is a fairly trivial fix for #2591.

The function this is in seems to only be for detecting Intel drivers (not applicable for Adreno cards), so this shouldn't break any existing behavior.