### PR TITLE
Fix active option slider labels showing unformatted values

### DIFF
--- a/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumOptionsGUI.java
+++ b/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumOptionsGUI.java
@@ -222,7 +222,7 @@ public class SodiumOptionsGUI extends Screen implements ScreenPromptable {
             // Add each option's control element
             for (Option<?> option : group.getOptions()) {
                 Control<?> control = option.getControl();
-                ControlElement<?> element = control.createElement(new Dim2i(x, y, 200, 18));
+                ControlElement<?> element = control.createElement(new Dim2i(x, y, 240, 18));
 
                 this.addRenderableWidget(element);
 

--- a/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/SliderControl.java
+++ b/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/SliderControl.java
@@ -41,7 +41,7 @@ public class SliderControl implements Control<Integer> {
 
     @Override
     public int getMaxWidth() {
-        return 130;
+        return 170;
     }
 
     private static class Button extends ControlElement<Integer> {

--- a/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/SliderControl.java
+++ b/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/SliderControl.java
@@ -112,7 +112,7 @@ public class SliderControl implements Control<Integer> {
             this.drawRect(graphics, thumbX, sliderY, thumbX + (THUMB_WIDTH * 2), sliderY + sliderHeight, 0xFFFFFFFF);
             this.drawRect(graphics, sliderX, trackY, sliderX + sliderWidth, trackY + TRACK_HEIGHT, 0xFFFFFFFF);
 
-            String label = String.valueOf(this.getIntValue());
+            Component label = this.formatter.format(this.getIntValue());
 
             int labelWidth = this.font.width(label);
 


### PR DESCRIPTION
Resolves #2482.

To do this I've increased the width of the controls to ensure the in some cases way wider label can fit without further changes:

![2024-07-23_10 21 59](https://github.com/user-attachments/assets/59534d7a-ff00-49cc-8ba8-17a07cbec92f)
