### PR TITLE
Patch for sprites not being marked as active when used in a SpriteCoordinateExpander 

### DIFF
--- a/src/main/java/net/caffeinemc/mods/sodium/mixin/core/render/immediate/consumer/SpriteCoordinateExpanderMixin.java
+++ b/src/main/java/net/caffeinemc/mods/sodium/mixin/core/render/immediate/consumer/SpriteCoordinateExpanderMixin.java
@@ -4,6 +4,7 @@ import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.caffeinemc.mods.sodium.api.vertex.attributes.CommonVertexAttribute;
 import net.caffeinemc.mods.sodium.api.vertex.attributes.common.TextureAttribute;
 import net.caffeinemc.mods.sodium.api.vertex.format.VertexFormatDescription;
+import net.caffeinemc.mods.sodium.client.render.texture.SpriteUtil;
 import net.minecraft.client.renderer.SpriteCoordinateExpander;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.caffeinemc.mods.sodium.api.vertex.buffer.VertexBufferWriter;
@@ -33,6 +34,7 @@ public class SpriteCoordinateExpanderMixin implements VertexBufferWriter {
 
     @Inject(method = "<init>", at = @At("RETURN"))
     private void onInit(VertexConsumer delegate, TextureAtlasSprite sprite, CallbackInfo ci) {
+        SpriteUtil.markSpriteActive(sprite);
         this.minU = sprite.getU0();
         this.minV = sprite.getV0();
 


### PR DESCRIPTION
Fix for https://github.com/CaffeineMC/sodium-fabric/issues/2601 class of issues, however it assumes that a new SpriteCoordinateExpander is created every frame. Marking it as active in the hot path every write might have performance implications, thus only a partial fix.