### PR TITLE
Replace frame limiter

### DIFF
--- a/src/main/java/net/caffeinemc/mods/sodium/client/data/config/MixinConfig.java
+++ b/src/main/java/net/caffeinemc/mods/sodium/client/data/config/MixinConfig.java
@@ -69,6 +69,8 @@ public class MixinConfig {
 
         this.addMixinRule("features.render.particle", true);
 
+        this.addMixinRule("features.render.sync", true);
+
         this.addMixinRule("features.render.world", true);
         this.addMixinRule("features.render.world.clouds", true);
         this.addMixinRule("features.render.world.sky", true);

--- a/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/sync/RenderSystemMixin.java
+++ b/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/sync/RenderSystemMixin.java
@@ -24,7 +24,7 @@ public class RenderSystemMixin {
 
         for (; now < target; now = GLFW.glfwGetTime()) {
             double waitTime = (target - now) - 0.002; // -2ms to account for inaccuracy of timeouts on some operating systems
-            if (waitTime >= 0.001) { // pretty sure you can't sleep for less than 1ms on Windows or Linux
+            if (waitTime >= 0.001) { // pretty sure you can't sleep for less than 1ms without platform-specific code
                 GLFW.glfwWaitEventsTimeout(waitTime); // could be replaced with Thread.sleep(), but i'm not sure if it'd be as precise
             }
         }

--- a/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/sync/RenderSystemMixin.java
+++ b/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/sync/RenderSystemMixin.java
@@ -1,0 +1,35 @@
+package net.caffeinemc.mods.sodium.mixin.features.render.sync;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import org.lwjgl.glfw.GLFW;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(value = RenderSystem.class, remap = false)
+public class RenderSystemMixin {
+
+    @Shadow
+    private static double lastDrawTime = Double.MIN_VALUE;
+
+    /**
+     * @author theyareonit
+     * @reason Improve frame synchronization
+     */
+    @Overwrite
+    public static void limitDisplayFPS(int fps) {
+        double frametime = 1.0 / fps;
+        double target =  lastDrawTime + frametime;
+        double now = GLFW.glfwGetTime();
+
+        for (; now < target; now = GLFW.glfwGetTime()) {
+            double waitTime = (target - now) - 0.002; // -2ms to account for inaccuracy of timeouts on some operating systems
+            if (waitTime >= 0.001) { // pretty sure you can't sleep for less than 1ms on Windows or Linux
+                GLFW.glfwWaitEventsTimeout(waitTime); // could be replaced with Thread.sleep(), but i'm not sure if it'd be as precise
+            }
+        }
+
+        lastDrawTime = now - (now % frametime); // subtracting (now % frametime) keeps frames in sync
+        GLFW.glfwPollEvents(); // glfwWaitEventsTimeout won't catch every input if subtracting 2ms from the timeout
+    }
+}

--- a/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/sync/RenderSystemMixin.java
+++ b/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/sync/RenderSystemMixin.java
@@ -18,12 +18,9 @@ public class RenderSystemMixin {
         double end = (now - (now % frameTime)) + frameTime; // subtracting (now % frameTime) corrects for desync
 
         for (; now < end; now = GLFW.glfwGetTime()) {
-            int waitTime = (int)((end - now) * 1000.0) - 2; // -2ms to account for sleep imprecision on some operating systems
-            if (waitTime >= 1) { // cant sleep less than 1ms without platform-specific code
-                try {
-                    Thread.sleep(waitTime); // precision seems fine on both linux and windows
-                }
-                catch (Exception e) {}
+            double waitTime = (end - now) - 0.002; // -2ms to account for sleep imprecision on some operating systems
+            if (waitTime >= 0.001) { // cant sleep less than 1ms without platform-specific code
+                GLFW.glfwWaitEventsTimeout(waitTime);
             }
         }
 

--- a/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/sync/RenderSystemMixin.java
+++ b/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/sync/RenderSystemMixin.java
@@ -4,14 +4,9 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import org.lwjgl.glfw.GLFW;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
-import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(value = RenderSystem.class, remap = false)
 public class RenderSystemMixin {
-
-    @Shadow
-    private static double lastDrawTime = Double.MIN_VALUE;
-
     /**
      * @author theyareonit
      * @reason Improve frame synchronization
@@ -19,17 +14,19 @@ public class RenderSystemMixin {
     @Overwrite
     public static void limitDisplayFPS(int fps) {
         double frametime = 1.0 / fps;
-        double target =  lastDrawTime + frametime;
         double now = GLFW.glfwGetTime();
+        double target = (now - (now % frametime)) + frametime; // subtracting (now % frametime) corrects for desync
 
         for (; now < target; now = GLFW.glfwGetTime()) {
-            double waitTime = (target - now) - 0.002; // -2ms to account for inaccuracy of timeouts on some operating systems
-            if (waitTime >= 0.001) { // pretty sure you can't sleep for less than 1ms without platform-specific code
-                GLFW.glfwWaitEventsTimeout(waitTime); // could be replaced with Thread.sleep(), but i'm not sure if it'd be as precise
+            int waitTime = (int)((target - now) * 1000.0) - 2; // -2ms to account for sleep imprecision in some OSes
+            if (waitTime >= 1) { // cant sleep less than 1ms without platform-specific code
+                try {
+                    Thread.sleep(waitTime); // precision seems fine on both linux and windows
+                }
+                catch (Exception e) {}
             }
         }
 
-        lastDrawTime = now - (now % frametime); // subtracting (now % frametime) keeps frames in sync
         GLFW.glfwPollEvents(); // glfwWaitEventsTimeout won't catch every input if subtracting 2ms from the timeout
     }
 }

--- a/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/sync/RenderSystemMixin.java
+++ b/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/sync/RenderSystemMixin.java
@@ -13,12 +13,12 @@ public class RenderSystemMixin {
      */
     @Overwrite
     public static void limitDisplayFPS(int fps) {
-        double frametime = 1.0 / fps;
+        double frameTime = 1.0 / fps;
         double now = GLFW.glfwGetTime();
-        double target = (now - (now % frametime)) + frametime; // subtracting (now % frametime) corrects for desync
+        double end = (now - (now % frameTime)) + frameTime; // subtracting (now % frameTime) corrects for desync
 
-        for (; now < target; now = GLFW.glfwGetTime()) {
-            int waitTime = (int)((target - now) * 1000.0) - 2; // -2ms to account for sleep imprecision in some OSes
+        for (; now < end; now = GLFW.glfwGetTime()) {
+            int waitTime = (int)((end - now) * 1000.0) - 2; // -2ms to account for sleep imprecision on some operating systems
             if (waitTime >= 1) { // cant sleep less than 1ms without platform-specific code
                 try {
                     Thread.sleep(waitTime); // precision seems fine on both linux and windows
@@ -27,6 +27,6 @@ public class RenderSystemMixin {
             }
         }
 
-        GLFW.glfwPollEvents(); // glfwWaitEventsTimeout won't catch every input if subtracting 2ms from the timeout
+        GLFW.glfwPollEvents();
     }
 }

--- a/src/main/resources/sodium.mixins.json
+++ b/src/main/resources/sodium.mixins.json
@@ -60,6 +60,7 @@
     "features.render.model.block.ModelBlockRendererMixin",
     "features.render.model.item.ItemRendererMixin",
     "features.render.particle.SingleQuadParticleMixin",
+    "features.render.sync.RenderSystemMixin",
     "features.render.world.clouds.LevelRendererMixin",
     "features.render.world.sky.FogRendererMixin",
     "features.render.world.sky.ClientLevelMixin",


### PR DESCRIPTION
Fixes https://github.com/CaffeineMC/sodium-fabric/issues/2610 by removing the possibility for long-term desync between the player's FPS cap and their actual framerate.

I'm not 100% sure about the things I mentioned in the comments about GLFW.glfwWaitEventsTimeout and Thread.sleep. I would appreciate some input from anyone who might know more on those subjects.