### PR TITLE
Fix fast cloud rendering

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/CloudRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/CloudRenderer.java
@@ -245,6 +245,10 @@ public class CloudRenderer {
 
         int cellColor = textureData.getCellColor(cellIndex);
 
+        if (ColorABGR.unpackAlpha(cellColor) == 0) {
+            return;
+        }
+
         float x = offsetX * 12;
         float z = offsetZ * 12;
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/CloudRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/CloudRenderer.java
@@ -75,8 +75,9 @@ public class CloudRenderer {
         int centerCellZ = (int) (Math.floor(cloudCenterZ / 12.0));
 
         // -1 if below clouds, +1 if above clouds
-        int orientation = (int) Math.signum(pos.y() - cloudHeight);
-        var parameters = new CloudGeometryParameters(centerCellX, centerCellZ, cloudDistance, orientation, Minecraft.getInstance().options.getCloudsType());
+        var cloudType = Minecraft.getInstance().options.getCloudsType();
+        int orientation = cloudType == CloudStatus.FANCY ? (int) Math.signum(pos.y() - cloudHeight) : 0;
+        var parameters = new CloudGeometryParameters(centerCellX, centerCellZ, cloudDistance, orientation, cloudType);
 
         CloudGeometry geometry = this.cachedGeometry;
 


### PR DESCRIPTION
Fix fast cloud rendering as described in #2646. Closes #2646.

Makes it possible to have no vertex buffer, and to simply not render clouds if there is none. Disables view-dependent culling on fast clouds. Resolves the crash and makes them visible from the top and bottom.