### PR TITLE
[TS] Delete VertexRange, use isTranslucent, fix partition tree sorting on geometry with negative dot products

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gl/util/VertexRange.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gl/util/VertexRange.java
@@ -1,4 +1,0 @@
-package net.caffeinemc.mods.sodium.client.gl.util;
-
-public record VertexRange(int vertexStart, int vertexCount) {
-}

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/DefaultChunkRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/DefaultChunkRenderer.java
@@ -13,12 +13,11 @@ import net.caffeinemc.mods.sodium.client.gl.tessellation.TessellationBinding;
 import net.caffeinemc.mods.sodium.client.model.quad.properties.ModelQuadFacing;
 import net.caffeinemc.mods.sodium.client.render.chunk.data.SectionRenderDataStorage;
 import net.caffeinemc.mods.sodium.client.render.chunk.data.SectionRenderDataUnsafe;
-import net.caffeinemc.mods.sodium.client.render.chunk.lists.ChunkRenderListIterable;
 import net.caffeinemc.mods.sodium.client.render.chunk.lists.ChunkRenderList;
+import net.caffeinemc.mods.sodium.client.render.chunk.lists.ChunkRenderListIterable;
 import net.caffeinemc.mods.sodium.client.render.chunk.region.RenderRegion;
 import net.caffeinemc.mods.sodium.client.render.chunk.shader.ChunkShaderBindingPoints;
 import net.caffeinemc.mods.sodium.client.render.chunk.shader.ChunkShaderInterface;
-import net.caffeinemc.mods.sodium.client.render.chunk.terrain.DefaultTerrainRenderPasses;
 import net.caffeinemc.mods.sodium.client.render.chunk.terrain.TerrainRenderPass;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.SortBehavior;
 import net.caffeinemc.mods.sodium.client.render.chunk.vertex.format.ChunkMeshAttribute;
@@ -26,6 +25,7 @@ import net.caffeinemc.mods.sodium.client.render.chunk.vertex.format.ChunkVertexT
 import net.caffeinemc.mods.sodium.client.render.viewport.CameraTransform;
 import net.caffeinemc.mods.sodium.client.util.BitwiseMath;
 import org.lwjgl.system.MemoryUtil;
+
 import java.util.Iterator;
 
 public class DefaultChunkRenderer extends ShaderChunkRenderer {
@@ -100,8 +100,7 @@ public class DefaultChunkRenderer extends ShaderChunkRenderer {
     }
 
     private static boolean isTranslucentRenderPass(TerrainRenderPass renderPass) {
-        return renderPass == DefaultTerrainRenderPasses.TRANSLUCENT
-                && SodiumClientMod.options().performance.getSortBehavior() != SortBehavior.OFF;
+        return renderPass.isTranslucent() && SodiumClientMod.options().performance.getSortBehavior() != SortBehavior.OFF;
     }
 
     private static void fillCommandBuffer(MultiDrawBatch batch,

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/ChunkBuildBuffers.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/ChunkBuildBuffers.java
@@ -69,18 +69,16 @@ public class ChunkBuildBuffers {
             var buffer = builder.getVertexBuffer(facing);
 
             if (buffer.isEmpty()) {
-                vertexCounts[ordinal] = -1;
                 continue;
             }
 
             vertexBuffers.add(buffer.slice());
+            var bufferCount = buffer.count();
             if (!forceUnassigned) {
-                vertexCounts[ordinal] = buffer.count();
-            } else {
-                vertexCounts[ordinal] = -1;
+                vertexCounts[ordinal] = bufferCount;
             }
 
-            vertexSum += buffer.count();
+            vertexSum += bufferCount;
         }
 
         if (vertexSum == 0) {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/buffers/ChunkVertexConsumer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/buffers/ChunkVertexConsumer.java
@@ -1,17 +1,15 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.compile.buffers;
 
 import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.caffeinemc.mods.sodium.api.util.ColorABGR;
+import net.caffeinemc.mods.sodium.api.util.ColorARGB;
 import net.caffeinemc.mods.sodium.api.util.NormI8;
 import net.caffeinemc.mods.sodium.client.model.quad.properties.ModelQuadFacing;
-import net.caffeinemc.mods.sodium.client.render.chunk.terrain.material.DefaultMaterials;
 import net.caffeinemc.mods.sodium.client.render.chunk.terrain.material.Material;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.TranslucentGeometryCollector;
 import net.caffeinemc.mods.sodium.client.render.chunk.vertex.format.ChunkVertexEncoder;
-import net.caffeinemc.mods.sodium.api.util.ColorABGR;
-import net.caffeinemc.mods.sodium.api.util.ColorARGB;
 import net.caffeinemc.mods.sodium.client.render.texture.SpriteFinderCache;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
-import net.minecraft.core.Direction;
 import org.jetbrains.annotations.NotNull;
 
 public class ChunkVertexConsumer implements VertexConsumer {
@@ -129,8 +127,8 @@ public class ChunkVertexConsumer implements VertexConsumer {
 
             ModelQuadFacing cullFace = ModelQuadFacing.fromPackedNormal(normal);
 
-            if (material == DefaultMaterials.TRANSLUCENT && collector != null) {
-                collector.appendQuad(normal, vertices, cullFace);
+            if (this.material.isTranslucent() && this.collector != null) {
+                this.collector.appendQuad(normal, this.vertices, cullFace);
             }
 
             this.modelBuilder.getVertexBuffer(cullFace).push(this.vertices, this.material);
@@ -156,21 +154,21 @@ public class ChunkVertexConsumer implements VertexConsumer {
     }
 
     private int calculateNormal() {
-        final float x0 = vertices[0].x;
-        final float y0 = vertices[0].y;
-        final float z0 = vertices[0].z;
+        final float x0 = this.vertices[0].x;
+        final float y0 = this.vertices[0].y;
+        final float z0 = this.vertices[0].z;
 
-        final float x1 = vertices[1].x;
-        final float y1 = vertices[1].y;
-        final float z1 = vertices[1].z;
+        final float x1 = this.vertices[1].x;
+        final float y1 = this.vertices[1].y;
+        final float z1 = this.vertices[1].z;
 
-        final float x2 = vertices[2].x;
-        final float y2 = vertices[2].y;
-        final float z2 = vertices[2].z;
+        final float x2 = this.vertices[2].x;
+        final float y2 = this.vertices[2].y;
+        final float z2 = this.vertices[2].z;
 
-        final float x3 = vertices[3].x;
-        final float y3 = vertices[3].y;
-        final float z3 = vertices[3].z;
+        final float x3 = this.vertices[3].x;
+        final float y3 = this.vertices[3].y;
+        final float z3 = this.vertices[3].z;
 
         final float dx0 = x2 - x0;
         final float dy0 = y2 - y0;

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/BlockRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/BlockRenderer.java
@@ -1,5 +1,6 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.compile.pipeline;
 
+import net.caffeinemc.mods.sodium.api.util.ColorARGB;
 import net.caffeinemc.mods.sodium.client.model.color.ColorProvider;
 import net.caffeinemc.mods.sodium.client.model.color.ColorProviderRegistry;
 import net.caffeinemc.mods.sodium.client.model.light.LightMode;
@@ -20,7 +21,6 @@ import net.caffeinemc.mods.sodium.client.render.texture.SpriteFinderCache;
 import net.caffeinemc.mods.sodium.client.services.PlatformModelAccess;
 import net.caffeinemc.mods.sodium.client.services.SodiumModelData;
 import net.caffeinemc.mods.sodium.client.world.LevelSlice;
-import net.caffeinemc.mods.sodium.api.util.ColorARGB;
 import net.fabricmc.fabric.api.renderer.v1.material.BlendMode;
 import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
 import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
@@ -175,8 +175,8 @@ public class BlockRenderer extends AbstractBlockRenderContext {
 
         ModelQuadFacing normalFace = quad.normalFace();
 
-        if (material == DefaultMaterials.TRANSLUCENT && collector != null) {
-            collector.appendQuad(quad.getFaceNormal(), vertices, normalFace);
+        if (material.isTranslucent() && this.collector != null) {
+            this.collector.appendQuad(quad.getFaceNormal(), vertices, normalFace);
         }
 
         ChunkMeshBufferBuilder vertexBuffer = modelBuilder.getVertexBuffer(normalFace);

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderMeshingTask.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderMeshingTask.java
@@ -8,7 +8,6 @@ import net.caffeinemc.mods.sodium.client.render.chunk.compile.ChunkBuildContext;
 import net.caffeinemc.mods.sodium.client.render.chunk.compile.ChunkBuildOutput;
 import net.caffeinemc.mods.sodium.client.render.chunk.compile.executor.ChunkBuilder;
 import net.caffeinemc.mods.sodium.client.render.chunk.compile.pipeline.BlockRenderCache;
-import net.caffeinemc.mods.sodium.client.render.chunk.compile.pipeline.BlockRenderContext;
 import net.caffeinemc.mods.sodium.client.render.chunk.compile.pipeline.BlockRenderer;
 import net.caffeinemc.mods.sodium.client.render.chunk.data.BuiltSectionInfo;
 import net.caffeinemc.mods.sodium.client.render.chunk.data.BuiltSectionMeshParts;
@@ -20,7 +19,6 @@ import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.SortTy
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.TranslucentGeometryCollector;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data.PresentTranslucentData;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data.TranslucentData;
-import net.caffeinemc.mods.sodium.client.services.PlatformLevelAccess;
 import net.caffeinemc.mods.sodium.client.services.PlatformLevelRenderHooks;
 import net.caffeinemc.mods.sodium.client.util.task.CancellationToken;
 import net.caffeinemc.mods.sodium.client.world.LevelSlice;
@@ -37,9 +35,9 @@ import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FluidState;
-import java.util.Map;
-
 import org.joml.Vector3dc;
+
+import java.util.Map;
 
 /**
  * Rebuilds all the meshes of a chunk for each given render pass with non-occluded blocks. The result is then uploaded
@@ -160,8 +158,7 @@ public class ChunkBuilderMeshingTask extends ChunkBuilderTask<ChunkBuildOutput> 
         for (TerrainRenderPass pass : DefaultTerrainRenderPasses.ALL) {
             // consolidate all translucent geometry into UNASSIGNED so that it's rendered
             // all together if it needs to share an index buffer between the directions
-            boolean isTranslucent = pass == DefaultTerrainRenderPasses.TRANSLUCENT;
-            BuiltSectionMeshParts mesh = buffers.createMesh(pass, isTranslucent && sortType.needsDirectionMixing);
+            BuiltSectionMeshParts mesh = buffers.createMesh(pass, pass.isTranslucent() && sortType.needsDirectionMixing);
 
             if (mesh != null) {
                 meshes.put(pass, mesh);

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/data/BuiltSectionMeshParts.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/data/BuiltSectionMeshParts.java
@@ -1,14 +1,13 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.data;
 
-import net.caffeinemc.mods.sodium.client.gl.util.VertexRange;
 import net.caffeinemc.mods.sodium.client.util.NativeBuffer;
 
 public class BuiltSectionMeshParts {
-    private final VertexRange[] ranges;
+    private final int[] vertexCounts;
     private final NativeBuffer buffer;
 
-    public BuiltSectionMeshParts(NativeBuffer buffer, VertexRange[] ranges) {
-        this.ranges = ranges;
+    public BuiltSectionMeshParts(NativeBuffer buffer, int[] vertexCounts) {
+        this.vertexCounts = vertexCounts;
         this.buffer = buffer;
     }
 
@@ -16,7 +15,7 @@ public class BuiltSectionMeshParts {
         return this.buffer;
     }
 
-    public VertexRange[] getVertexRanges() {
-        return this.ranges;
+    public int[] getVertexCounts() {
+        return this.vertexCounts;
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/data/SectionRenderDataStorage.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/data/SectionRenderDataStorage.java
@@ -63,10 +63,6 @@ public class SectionRenderDataStorage {
         for (int facingIndex = 0; facingIndex < ModelQuadFacing.COUNT; facingIndex++) {
             int vertexCount = vertexCounts[facingIndex];
 
-            if (vertexCount == -1) {
-                vertexCount = 0;
-            }
-
             SectionRenderDataUnsafe.setVertexOffset(pMeshData, facingIndex, vertexOffset);
             SectionRenderDataUnsafe.setElementCount(pMeshData, facingIndex, (vertexCount >> 2) * 6);
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/data/SectionRenderDataStorage.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/data/SectionRenderDataStorage.java
@@ -1,7 +1,6 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.data;
 
 import net.caffeinemc.mods.sodium.client.gl.arena.GlBufferSegment;
-import net.caffeinemc.mods.sodium.client.gl.util.VertexRange;
 import net.caffeinemc.mods.sodium.client.model.quad.properties.ModelQuadFacing;
 import net.caffeinemc.mods.sodium.client.render.chunk.region.RenderRegion;
 import org.jetbrains.annotations.NotNull;
@@ -47,7 +46,7 @@ public class SectionRenderDataStorage {
     }
 
     public void setVertexData(int localSectionIndex,
-            GlBufferSegment allocation, VertexRange[] ranges) {
+            GlBufferSegment allocation, int[] vertexCounts) {
         GlBufferSegment prev = this.vertexAllocations[localSectionIndex];
 
         if (prev != null) {
@@ -62,12 +61,9 @@ public class SectionRenderDataStorage {
         int vertexOffset = allocation.getOffset();
 
         for (int facingIndex = 0; facingIndex < ModelQuadFacing.COUNT; facingIndex++) {
-            VertexRange vertexRange = ranges[facingIndex];
-            int vertexCount;
+            int vertexCount = vertexCounts[facingIndex];
 
-            if (vertexRange != null) {
-                vertexCount = vertexRange.vertexCount();
-            } else {
+            if (vertexCount == -1) {
                 vertexCount = 0;
             }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/region/RenderRegion.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/region/RenderRegion.java
@@ -115,7 +115,7 @@ public class RenderRegion {
         var storage = this.sectionRenderData.get(pass);
 
         if (storage == null) {
-            storage = new SectionRenderDataStorage(pass == DefaultTerrainRenderPasses.TRANSLUCENT);
+            storage = new SectionRenderDataStorage(pass.isTranslucent());
             this.sectionRenderData.put(pass, storage);
         }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/region/RenderRegionManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/region/RenderRegionManager.java
@@ -124,7 +124,7 @@ public class RenderRegionManager {
             for (PendingSectionMeshUpload upload : uploads) {
                 var storage = region.createStorage(upload.pass);
                 storage.setVertexData(upload.section.getSectionIndex(),
-                        upload.vertexUpload.getResult(), upload.meshData.getVertexRanges());
+                        upload.vertexUpload.getResult(), upload.meshData.getVertexCounts());
             }
         }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/TranslucentGeometryCollector.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/TranslucentGeometryCollector.java
@@ -35,8 +35,8 @@ import java.util.Arrays;
  * type is determined with a heuristic based on the collected metrics. This
  * determines if block face culling can be enabled.
  * - Now the {@link BuiltSectionMeshParts} is generated, which yields the vertex
- * ranges.
- * 3. The vertex ranges and the mesh parts object are used by the collector in
+ * counts.
+ * 3. The vertex counts and the mesh parts object are used by the collector in
  * the construction of the {@link TranslucentData} object. The data object
  * allocates memory for the index data and performs the first (and for static
  * sort types, only) sort.
@@ -534,7 +534,7 @@ public class TranslucentGeometryCollector {
             // doesn't matter
             if (this.sortType == SortType.NONE && oldData instanceof AnyOrderData oldAnyData
                     && oldAnyData.getQuadCount() == this.quads.length
-                    && Arrays.equals(oldAnyData.getVertexRanges(), translucentMesh.getVertexRanges())) {
+                    && Arrays.equals(oldAnyData.getVertexCounts(), translucentMesh.getVertexCounts())) {
                 return oldAnyData;
             }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/bsp_tree/InnerPartitionBSPNode.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/bsp_tree/InnerPartitionBSPNode.java
@@ -183,12 +183,17 @@ abstract class InnerPartitionBSPNode extends BSPNode {
         return oldNode;
     }
 
+    /**
+     * Encoding with {@link MathUtil#floatToComparableInt(float)} is necessary here to ensure negative distances are not sorted backwards. Simply converting potentially negative floats to int bits using {@link Float#floatToRawIntBits(float)} would sort negative floats backwards amongst themselves.
+     * <p>
+     * Note that negative floats convert to negative integers with this method which is ok, since it yields an overall negative long that gets sorted correctly before the longs that encode positive floats as distances.
+     */
     private static long encodeIntervalPoint(float distance, int quadIndex, int type) {
-        return ((long) Float.floatToRawIntBits(distance) << 32) | ((long) type << 30) | quadIndex;
+        return ((long) MathUtil.floatToComparableInt(distance) << 32) | ((long) type << 30) | quadIndex;
     }
 
     private static float decodeDistance(long encoded) {
-        return Float.intBitsToFloat((int) (encoded >>> 32));
+        return MathUtil.comparableIntToFloat((int) (encoded >>> 32));
     }
 
     private static int decodeQuadIndex(long encoded) {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/AnyOrderData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/AnyOrderData.java
@@ -1,6 +1,5 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data;
 
-import net.caffeinemc.mods.sodium.client.render.chunk.data.BuiltSectionMeshParts;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.SortType;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.TQuad;
 import net.minecraft.core.SectionPos;
@@ -44,16 +43,15 @@ public class AnyOrderData extends SplitDirectionData {
     /**
      * Important: The vertex indexes must start at zero for each facing.
      */
-    public static AnyOrderData fromMesh(BuiltSectionMeshParts translucentMesh,
-            TQuad[] quads, SectionPos sectionPos) {
-        var vertexCounts = translucentMesh.getVertexCounts();
+    public static AnyOrderData fromMesh(int[] vertexCounts,
+                                        TQuad[] quads, SectionPos sectionPos) {
         var anyOrderData = new AnyOrderData(sectionPos, vertexCounts, quads.length);
         var sorter = new StaticSorter(quads.length);
         anyOrderData.sorterOnce = sorter;
         var indexBuffer = sorter.getIntBuffer();
 
         for (var vertexCount : vertexCounts) {
-            if (vertexCount == -1) {
+            if (vertexCount <= 0) {
                 continue;
             }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/AnyOrderData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/AnyOrderData.java
@@ -1,10 +1,8 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data;
 
-import net.caffeinemc.mods.sodium.client.gl.util.VertexRange;
 import net.caffeinemc.mods.sodium.client.render.chunk.data.BuiltSectionMeshParts;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.SortType;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.TQuad;
-import net.caffeinemc.mods.sodium.client.util.NativeBuffer;
 import net.minecraft.core.SectionPos;
 
 /**
@@ -24,8 +22,8 @@ import net.minecraft.core.SectionPos;
 public class AnyOrderData extends SplitDirectionData {
     private Sorter sorterOnce;
 
-    AnyOrderData(SectionPos sectionPos, VertexRange[] ranges, int quadCount) {
-        super(sectionPos, ranges, quadCount);
+    AnyOrderData(SectionPos sectionPos, int[] vertexCounts, int quadCount) {
+        super(sectionPos, vertexCounts, quadCount);
     }
 
     @Override
@@ -48,18 +46,18 @@ public class AnyOrderData extends SplitDirectionData {
      */
     public static AnyOrderData fromMesh(BuiltSectionMeshParts translucentMesh,
             TQuad[] quads, SectionPos sectionPos) {
-        var ranges = translucentMesh.getVertexRanges();
-        var anyOrderData = new AnyOrderData(sectionPos, ranges, quads.length);
+        var vertexCounts = translucentMesh.getVertexCounts();
+        var anyOrderData = new AnyOrderData(sectionPos, vertexCounts, quads.length);
         var sorter = new StaticSorter(quads.length);
         anyOrderData.sorterOnce = sorter;
         var indexBuffer = sorter.getIntBuffer();
 
-        for (var range : ranges) {
-            if (range == null) {
+        for (var vertexCount : vertexCounts) {
+            if (vertexCount == -1) {
                 continue;
             }
 
-            int count = TranslucentData.vertexCountToQuadCount(range.vertexCount());
+            int count = TranslucentData.vertexCountToQuadCount(vertexCount);
             for (int i = 0; i < count; i++) {
                 TranslucentData.writeQuadVertexIndexes(indexBuffer, i);
             }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicBSPData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicBSPData.java
@@ -41,7 +41,7 @@ public class DynamicBSPData extends DynamicData {
         return new DynamicBSPSorter(this.getQuadCount());
     }
 
-    public static DynamicBSPData fromMesh(BuiltSectionMeshParts translucentMesh,
+    public static DynamicBSPData fromMesh(int vertexCount,
                                           CombinedCameraPos cameraPos, TQuad[] quads, SectionPos sectionPos,
                                           TranslucentData oldData) {
         BSPNode oldRoot = null;
@@ -56,8 +56,6 @@ public class DynamicBSPData extends DynamicData {
             prepareNodeReuse = generation >= NODE_REUSE_MIN_GENERATION;
         }
         var result = BSPNode.buildBSP(quads, sectionPos, oldRoot, prepareNodeReuse);
-
-        int vertexCount = TranslucentData.getUnassignedVertexCount(translucentMesh);
 
         var dynamicData = new DynamicBSPData(sectionPos, vertexCount, result, cameraPos.getAbsoluteCameraPos(), quads, generation);
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicBSPData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicBSPData.java
@@ -1,6 +1,5 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data;
 
-import net.caffeinemc.mods.sodium.client.gl.util.VertexRange;
 import net.caffeinemc.mods.sodium.client.render.chunk.data.BuiltSectionMeshParts;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.TQuad;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.bsp_tree.BSPNode;
@@ -20,8 +19,8 @@ public class DynamicBSPData extends DynamicData {
     private final BSPNode rootNode;
     private final int generation;
 
-    private DynamicBSPData(SectionPos sectionPos, VertexRange range, BSPResult result, Vector3dc initialCameraPos, TQuad[] quads, int generation) {
-        super(sectionPos, range, quads.length, result, initialCameraPos);
+    private DynamicBSPData(SectionPos sectionPos, int vertexCount, BSPResult result, Vector3dc initialCameraPos, TQuad[] quads, int generation) {
+        super(sectionPos, vertexCount, quads.length, result, initialCameraPos);
         this.rootNode = result.getRootNode();
         this.generation = generation;
     }
@@ -58,9 +57,9 @@ public class DynamicBSPData extends DynamicData {
         }
         var result = BSPNode.buildBSP(quads, sectionPos, oldRoot, prepareNodeReuse);
 
-        VertexRange range = TranslucentData.getUnassignedVertexRange(translucentMesh);
+        int vertexCount = TranslucentData.getUnassignedVertexCount(translucentMesh);
 
-        var dynamicData = new DynamicBSPData(sectionPos, range, result, cameraPos.getAbsoluteCameraPos(), quads, generation);
+        var dynamicData = new DynamicBSPData(sectionPos, vertexCount, result, cameraPos.getAbsoluteCameraPos(), quads, generation);
 
         // prepare geometry planes for integration into GFNI triggering
         result.prepareIntegration();

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicData.java
@@ -1,6 +1,5 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data;
 
-import net.caffeinemc.mods.sodium.client.gl.util.VertexRange;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.SortType;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.trigger.GeometryPlanes;
 import net.minecraft.core.SectionPos;
@@ -10,8 +9,8 @@ public abstract class DynamicData extends MixedDirectionData {
     private GeometryPlanes geometryPlanes;
     private final Vector3dc initialCameraPos;
 
-    DynamicData(SectionPos sectionPos, VertexRange range, int quadCount, GeometryPlanes geometryPlanes, Vector3dc initialCameraPos) {
-        super(sectionPos, range, quadCount);
+    DynamicData(SectionPos sectionPos, int vertexCount, int quadCount, GeometryPlanes geometryPlanes, Vector3dc initialCameraPos) {
+        super(sectionPos, vertexCount, quadCount);
         this.geometryPlanes = geometryPlanes;
         this.initialCameraPos = initialCameraPos;
     }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicTopoData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicTopoData.java
@@ -250,11 +250,10 @@ public class DynamicTopoData extends DynamicData {
         }
     }
 
-    public static DynamicTopoData fromMesh(BuiltSectionMeshParts translucentMesh,
+    public static DynamicTopoData fromMesh(int vertexCount,
                                            CombinedCameraPos cameraPos, TQuad[] quads, SectionPos sectionPos,
                                            GeometryPlanes geometryPlanes) {
         var distancesByNormal = geometryPlanes.prepareAndGetDistances();
-        int vertexCount = TranslucentData.getUnassignedVertexCount(translucentMesh);
 
         return new DynamicTopoData(sectionPos, vertexCount, quads, geometryPlanes,
                 cameraPos.getAbsoluteCameraPos(), distancesByNormal);

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicTopoData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicTopoData.java
@@ -1,7 +1,6 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data;
 
 import it.unimi.dsi.fastutil.objects.Object2ReferenceOpenHashMap;
-import net.caffeinemc.mods.sodium.client.gl.util.VertexRange;
 import net.caffeinemc.mods.sodium.client.render.chunk.data.BuiltSectionMeshParts;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.TQuad;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.trigger.GeometryPlanes;
@@ -47,10 +46,10 @@ public class DynamicTopoData extends DynamicData {
     private final TQuad[] quads;
     private final Object2ReferenceOpenHashMap<Vector3fc, float[]> distancesByNormal;
 
-    private DynamicTopoData(SectionPos sectionPos, VertexRange range, TQuad[] quads,
+    private DynamicTopoData(SectionPos sectionPos, int vertexCount, TQuad[] quads,
                             GeometryPlanes geometryPlanes, Vector3dc initialCameraPos,
                             Object2ReferenceOpenHashMap<Vector3fc, float[]> distancesByNormal) {
-        super(sectionPos, range, quads.length, geometryPlanes, initialCameraPos);
+        super(sectionPos, vertexCount, quads.length, geometryPlanes, initialCameraPos);
         this.quads = quads;
         this.distancesByNormal = distancesByNormal;
 
@@ -255,9 +254,9 @@ public class DynamicTopoData extends DynamicData {
                                            CombinedCameraPos cameraPos, TQuad[] quads, SectionPos sectionPos,
                                            GeometryPlanes geometryPlanes) {
         var distancesByNormal = geometryPlanes.prepareAndGetDistances();
-        VertexRange range = TranslucentData.getUnassignedVertexRange(translucentMesh);
+        int vertexCount = TranslucentData.getUnassignedVertexCount(translucentMesh);
 
-        return new DynamicTopoData(sectionPos, range, quads, geometryPlanes,
+        return new DynamicTopoData(sectionPos, vertexCount, quads, geometryPlanes,
                 cameraPos.getAbsoluteCameraPos(), distancesByNormal);
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/MixedDirectionData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/MixedDirectionData.java
@@ -1,20 +1,18 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data;
 
-import net.caffeinemc.mods.sodium.client.gl.util.VertexRange;
 import net.caffeinemc.mods.sodium.client.model.quad.properties.ModelQuadFacing;
-import net.caffeinemc.mods.sodium.client.util.NativeBuffer;
 import net.minecraft.core.SectionPos;
 
 public abstract class MixedDirectionData extends PresentTranslucentData {
-    private final VertexRange[] ranges = new VertexRange[ModelQuadFacing.COUNT];
+    private final int[] vertexCounts = new int[ModelQuadFacing.COUNT];
 
-    MixedDirectionData(SectionPos sectionPos, VertexRange range, int quadCount) {
+    MixedDirectionData(SectionPos sectionPos, int vertexCount, int quadCount) {
         super(sectionPos, quadCount);
-        this.ranges[ModelQuadFacing.UNASSIGNED.ordinal()] = range;
+        this.vertexCounts[ModelQuadFacing.UNASSIGNED.ordinal()] = vertexCount;
     }
 
     @Override
-    public VertexRange[] getVertexRanges() {
-        return this.ranges;
+    public int[] getVertexCounts() {
+        return this.vertexCounts;
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/PresentTranslucentData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/PresentTranslucentData.java
@@ -1,6 +1,5 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data;
 
-import net.caffeinemc.mods.sodium.client.gl.util.VertexRange;
 import net.minecraft.core.SectionPos;
 
 /**
@@ -15,7 +14,7 @@ public abstract class PresentTranslucentData extends TranslucentData {
         this.quadCount = quadCount;
     }
 
-    public abstract VertexRange[] getVertexRanges();
+    public abstract int[] getVertexCounts();
 
     public abstract Sorter getSorter();
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/SplitDirectionData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/SplitDirectionData.java
@@ -1,7 +1,5 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data;
 
-import net.caffeinemc.mods.sodium.client.gl.util.VertexRange;
-import net.caffeinemc.mods.sodium.client.util.NativeBuffer;
 import net.minecraft.core.SectionPos;
 
 /**
@@ -10,15 +8,15 @@ import net.minecraft.core.SectionPos;
  * starting at zero for each facing.
  */
 public abstract class SplitDirectionData extends PresentTranslucentData {
-    private final VertexRange[] ranges;
+    private final int[] vertexCounts;
 
-    public SplitDirectionData(SectionPos sectionPos, VertexRange[] ranges, int quadCount) {
+    public SplitDirectionData(SectionPos sectionPos, int[] vertexCounts, int quadCount) {
         super(sectionPos, quadCount);
-        this.ranges = ranges;
+        this.vertexCounts = vertexCounts;
     }
 
     @Override
-    public VertexRange[] getVertexRanges() {
-        return this.ranges;
+    public int[] getVertexCounts() {
+        return this.vertexCounts;
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/StaticNormalRelativeData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/StaticNormalRelativeData.java
@@ -38,8 +38,8 @@ public class StaticNormalRelativeData extends SplitDirectionData {
         return sorter;
     }
 
-    private static StaticNormalRelativeData fromDoubleUnaligned(BuiltSectionMeshParts translucentMesh, TQuad[] quads, SectionPos sectionPos) {
-        var snrData = new StaticNormalRelativeData(sectionPos, translucentMesh.getVertexCounts(), quads.length);
+    private static StaticNormalRelativeData fromDoubleUnaligned(int[] vertexCounts, TQuad[] quads, SectionPos sectionPos) {
+        var snrData = new StaticNormalRelativeData(sectionPos, vertexCounts, quads.length);
         var sorter = new StaticSorter(quads.length);
         snrData.sorterOnce = sorter;
         var indexBuffer = sorter.getIntBuffer();
@@ -79,17 +79,16 @@ public class StaticNormalRelativeData extends SplitDirectionData {
     /**
      * Important: The vertex indexes must start at zero for each facing.
      */
-    private static StaticNormalRelativeData fromMixed(BuiltSectionMeshParts translucentMesh,
+    private static StaticNormalRelativeData fromMixed(int[] vertexCounts,
                                                       TQuad[] quads, SectionPos sectionPos) {
-        var snrData = new StaticNormalRelativeData(sectionPos, translucentMesh.getVertexCounts(), quads.length);
+        var snrData = new StaticNormalRelativeData(sectionPos, vertexCounts, quads.length);
         var sorter = new StaticSorter(quads.length);
         snrData.sorterOnce = sorter;
         var indexBuffer = sorter.getIntBuffer();
 
-        var counts = translucentMesh.getVertexCounts();
         var maxQuadCount = 0;
         boolean anyNeedsSortData = false;
-        for (var vertexCount : counts) {
+        for (var vertexCount : vertexCounts) {
             if (vertexCount != -1) {
                 var quadCount = TranslucentData.vertexCountToQuadCount(vertexCount);
                 maxQuadCount = Math.max(maxQuadCount, quadCount);
@@ -103,7 +102,7 @@ public class StaticNormalRelativeData extends SplitDirectionData {
         }
 
         int quadIndex = 0;
-        for (var vertexCount : counts) {
+        for (var vertexCount : vertexCounts) {
             if (vertexCount == -1 || vertexCount == 0) {
                 continue;
             }
@@ -145,12 +144,12 @@ public class StaticNormalRelativeData extends SplitDirectionData {
         return snrData;
     }
 
-    public static StaticNormalRelativeData fromMesh(BuiltSectionMeshParts translucentMesh,
+    public static StaticNormalRelativeData fromMesh(int[] vertexCounts,
             TQuad[] quads, SectionPos sectionPos, boolean isDoubleUnaligned) {
         if (isDoubleUnaligned) {
-            return fromDoubleUnaligned(translucentMesh, quads, sectionPos);
+            return fromDoubleUnaligned(vertexCounts, quads, sectionPos);
         } else {
-            return fromMixed(translucentMesh, quads, sectionPos);
+            return fromMixed(vertexCounts, quads, sectionPos);
         }
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/StaticTopoData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/StaticTopoData.java
@@ -42,8 +42,7 @@ public class StaticTopoData extends MixedDirectionData {
         }
     }
 
-    public static StaticTopoData fromMesh(BuiltSectionMeshParts translucentMesh, TQuad[] quads, SectionPos sectionPos) {
-        int vertexCount = TranslucentData.getUnassignedVertexCount(translucentMesh);
+    public static StaticTopoData fromMesh(int vertexCount, TQuad[] quads, SectionPos sectionPos) {
         var sorter = new StaticSorter(quads.length);
         var indexWriter = new QuadIndexConsumerIntoBuffer(sorter.getIntBuffer());
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/StaticTopoData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/StaticTopoData.java
@@ -1,6 +1,5 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data;
 
-import net.caffeinemc.mods.sodium.client.gl.util.VertexRange;
 import net.caffeinemc.mods.sodium.client.render.chunk.data.BuiltSectionMeshParts;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.SortType;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.TQuad;
@@ -17,8 +16,8 @@ import java.util.function.IntConsumer;
 public class StaticTopoData extends MixedDirectionData {
     private Sorter sorterOnce;
 
-    StaticTopoData(SectionPos sectionPos, VertexRange range, int quadCount) {
-        super(sectionPos, range, quadCount);
+    StaticTopoData(SectionPos sectionPos, int vertexCount, int quadCount) {
+        super(sectionPos, vertexCount, quadCount);
     }
 
     @Override
@@ -44,7 +43,7 @@ public class StaticTopoData extends MixedDirectionData {
     }
 
     public static StaticTopoData fromMesh(BuiltSectionMeshParts translucentMesh, TQuad[] quads, SectionPos sectionPos) {
-        VertexRange range = TranslucentData.getUnassignedVertexRange(translucentMesh);
+        int vertexCount = TranslucentData.getUnassignedVertexCount(translucentMesh);
         var sorter = new StaticSorter(quads.length);
         var indexWriter = new QuadIndexConsumerIntoBuffer(sorter.getIntBuffer());
 
@@ -53,7 +52,7 @@ public class StaticTopoData extends MixedDirectionData {
             return null;
         }
 
-        var staticTopoData = new StaticTopoData(sectionPos, range, quads.length);
+        var staticTopoData = new StaticTopoData(sectionPos, vertexCount, quads.length);
         staticTopoData.sorterOnce = sorter;
         return staticTopoData;
     }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/TranslucentData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/TranslucentData.java
@@ -2,9 +2,6 @@ package net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data;
 
 import java.nio.IntBuffer;
 
-import org.joml.Vector3fc;
-
-import net.caffeinemc.mods.sodium.client.gl.util.VertexRange;
 import net.caffeinemc.mods.sodium.client.model.quad.properties.ModelQuadFacing;
 import net.caffeinemc.mods.sodium.client.render.chunk.data.BuiltSectionMeshParts;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.SortType;
@@ -68,13 +65,13 @@ public abstract class TranslucentData {
         }
     }
 
-    static VertexRange getUnassignedVertexRange(BuiltSectionMeshParts translucentMesh) {
-        VertexRange range = translucentMesh.getVertexRanges()[ModelQuadFacing.UNASSIGNED.ordinal()];
+    static int getUnassignedVertexCount(BuiltSectionMeshParts translucentMesh) {
+        int vertexCount = translucentMesh.getVertexCounts()[ModelQuadFacing.UNASSIGNED.ordinal()];
 
-        if (range == null) {
+        if (vertexCount == -1) {
             throw new IllegalStateException("No unassigned data in mesh");
         }
 
-        return range;
+        return vertexCount;
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/TranslucentData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/TranslucentData.java
@@ -3,7 +3,6 @@ package net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data;
 import java.nio.IntBuffer;
 
 import net.caffeinemc.mods.sodium.client.model.quad.properties.ModelQuadFacing;
-import net.caffeinemc.mods.sodium.client.render.chunk.data.BuiltSectionMeshParts;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.SortType;
 import net.minecraft.core.SectionPos;
 
@@ -63,15 +62,5 @@ public abstract class TranslucentData {
         for (int quadIndexPos = 0; quadIndexPos < quadIndexes.length; quadIndexPos++) {
             writeQuadVertexIndexes(intBuffer, quadIndexes[quadIndexPos]);
         }
-    }
-
-    static int getUnassignedVertexCount(BuiltSectionMeshParts translucentMesh) {
-        int vertexCount = translucentMesh.getVertexCounts()[ModelQuadFacing.UNASSIGNED.ordinal()];
-
-        if (vertexCount == -1) {
-            throw new IllegalStateException("No unassigned data in mesh");
-        }
-
-        return vertexCount;
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/util/MathUtil.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/util/MathUtil.java
@@ -12,9 +12,6 @@ public class MathUtil {
         return bytes / (1024L * 1024L); // 1 MiB = 1048576 (2^20) bytes
     }
 
-    private static final int BIT_COUNT = 32;
-    private static final int FLIP_SIGN_MASK = 1 << (BIT_COUNT - 1);
-
     /**
      * Converts a float to a comparable integer value. This is used to compare
      * floating point values by their int bits (for example packed in a long).
@@ -23,10 +20,11 @@ public class MathUtil {
      * floats from the smallest negative to the largest positive value.
      */
     public static int floatToComparableInt(float f) {
-        // // uses Float.compare to avoid issues comparing -0.0f and 0.0f
-        // return Float.floatToRawIntBits(f) ^ (Float.compare(f, 0f) > 0 ? 0x80000000 : 0xffffffff);
-
         var bits = Float.floatToRawIntBits(f);
-        return bits ^ ((bits >> (BIT_COUNT - 1)) | FLIP_SIGN_MASK);
+        return bits ^ ((bits >> 31) & 0x7FFFFFFF);
+    }
+
+    public static float comparableIntToFloat(int i) {
+        return Float.intBitsToFloat(i ^ ((i >> 31) & 0x7FFFFFFF));
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/util/MathUtil.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/util/MathUtil.java
@@ -15,9 +15,11 @@ public class MathUtil {
     /**
      * Converts a float to a comparable integer value. This is used to compare
      * floating point values by their int bits (for example packed in a long).
-     * 
+     * <p>
      * The resulting integer can be treated as if it's unsigned and numbers the
      * floats from the smallest negative to the largest positive value.
+     * <p>
+     * Reference: <a href="https://stackoverflow.com/questions/23900328/are-floats-bit-patterns-ordered">StackOverflow Answer</a>
      */
     public static int floatToComparableInt(float f) {
         var bits = Float.floatToRawIntBits(f);


### PR DESCRIPTION
- Delete `VertexRange` as since the introduction of the translucency sorting system its first `offset` field wasn't getting used anymore. It can simply be calculated on the fly as a prefix sum. Currently missing vertex ranges are replicated as `-1` lengths which are distinct from a length of zero. I don't know if this is actually necessary or if we can just use a zero length as the default.
- Use the `isTranslucent` method on terrain render passes and materials instead of checking equality
- Fix a crash related to translucency sorting that happened during the initial sort in the meshing task. This bug was triggered when a certain model (I don't know which one) on MCC Island was being sorted. Importantly, it extended outside of the chunk so that the dot products of its quads were negative with the axes. The partition tree building algorithm incorrectly handled negative dot products and produced a partition tree with duplicate nodes, which in turn led to a buffer overflow since too many quad indexes were being written.
- Fixed `floatToComparableInt` to actually be correct, it doesn't seem to have been correct previously.