### PR TITLE
Hide the TS option to only be visible in dev environments

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -14,6 +14,7 @@ import net.caffeinemc.mods.sodium.client.gui.options.control.TickBoxControl;
 import net.caffeinemc.mods.sodium.client.gui.options.storage.MinecraftOptionsStorage;
 import net.caffeinemc.mods.sodium.client.gui.options.storage.SodiumOptionsStorage;
 import net.caffeinemc.mods.sodium.client.compatibility.workarounds.Workarounds;
+import net.caffeinemc.mods.sodium.client.services.PlatformRuntimeInformation;
 import net.minecraft.client.AttackIndicatorStatus;
 import net.minecraft.client.CloudStatus;
 import net.minecraft.client.GraphicsStatus;
@@ -312,16 +313,18 @@ public class SodiumGameOptionPages {
                         .build())
                 .build());
 
-        groups.add(OptionGroup.createBuilder()
-                .add(OptionImpl.createBuilder(boolean.class, sodiumOpts)
-                        .setName(Component.translatable("sodium.options.sort_behavior.name"))
-                        .setTooltip(Component.translatable("sodium.options.sort_behavior.tooltip"))
-                        .setControl(TickBoxControl::new)
-                        .setBinding((opts, value) -> opts.performance.sortingEnabled = value, opts -> opts.performance.sortingEnabled)
-                        .setImpact(OptionImpact.LOW)
-                        .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)
-                        .build())
-                .build());
+        if (PlatformRuntimeInformation.getInstance().isDevelopmentEnvironment()) {
+            groups.add(OptionGroup.createBuilder()
+                    .add(OptionImpl.createBuilder(boolean.class, sodiumOpts)
+                            .setName(Component.translatable("sodium.options.sort_behavior.name"))
+                            .setTooltip(Component.translatable("sodium.options.sort_behavior.tooltip"))
+                            .setControl(TickBoxControl::new)
+                            .setBinding((opts, value) -> opts.performance.sortingEnabled = value, opts -> opts.performance.sortingEnabled)
+                            .setImpact(OptionImpact.LOW)
+                            .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)
+                            .build())
+                    .build());
+        }
 
         return new OptionPage(Component.translatable("sodium.options.pages.performance"), ImmutableList.copyOf(groups));
     }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumGameOptions.java
@@ -46,6 +46,7 @@ public class SodiumGameOptions {
         public boolean useBlockFaceCulling = true;
         public boolean useNoErrorGLContext = true;
 
+        @SerializedName("sorting_enabled_v2") // reset the older option in configs before we started hiding it
         public boolean sortingEnabled = true;
 
         public SortBehavior getSortBehavior() {


### PR DESCRIPTION
- Hide the TS option to only be visible in dev environments
- Rename the option in config files to reset it after having hidden it. (to prevent people who've turned it off from being unable to turn it on again)