### PR TITLE
Use hardware copy for render target blits where possible

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/data/config/MixinConfig.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/data/config/MixinConfig.java
@@ -49,6 +49,8 @@ public class MixinConfig {
 
         this.addMixinRule("features.render", true);
 
+        this.addMixinRule("features.render.compositing", true);
+
         this.addMixinRule("features.render.entity", true);
         this.addMixinRule("features.render.entity.cull", true);
         this.addMixinRule("features.render.entity.shadow", true);

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/compositing/RenderTargetMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/compositing/RenderTargetMixin.java
@@ -1,0 +1,44 @@
+package net.caffeinemc.mods.sodium.mixin.features.render.compositing;
+
+
+import com.mojang.blaze3d.pipeline.RenderTarget;
+import org.lwjgl.opengl.GL32C;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(RenderTarget.class)
+public class RenderTargetMixin {
+    @Shadow
+    public int frameBufferId;
+
+    @Shadow
+    public int width;
+
+    @Shadow
+    public int height;
+
+    /**
+     * @author JellySquid
+     * @reason Use fixed function hardware for framebuffer blits
+     */
+    @Inject(method = "blitToScreen(IIZ)V", at = @At("HEAD"), cancellable = true)
+    public void blitToScreen(int width, int height, boolean disableBlend, CallbackInfo ci) {
+        if (disableBlend) {
+            ci.cancel();
+
+            // When blending is not used, we can directly copy the contents of one
+            // framebuffer to another using the blitting engine. This can save a lot of time
+            // when compared to going through the rasterization pipeline.
+            GL32C.glBindFramebuffer(GL32C.GL_READ_FRAMEBUFFER, this.frameBufferId);
+            GL32C.glBlitFramebuffer(
+                    0, 0, width, height,
+                    0, 0, width, height,
+                    GL32C.GL_COLOR_BUFFER_BIT, GL32C.GL_LINEAR);
+            GL32C.glBindFramebuffer(GL32C.GL_READ_FRAMEBUFFER, 0);
+        }
+    }
+
+}

--- a/common/src/main/resources/sodium.mixins.json
+++ b/common/src/main/resources/sodium.mixins.json
@@ -41,6 +41,7 @@
     "features.options.render_layers.LeavesBlockMixin",
     "features.options.render_layers.ItemBlockRenderTypesMixin",
     "features.options.weather.LevelRendererMixin",
+    "features.render.compositing.RenderTargetMixin",
     "features.render.entity.CubeMixin",
     "features.render.entity.ModelPartMixin",
     "features.render.entity.cull.EntityRendererMixin",


### PR DESCRIPTION
Minecraft performs a blit using a fragment shader, which is unnecessary when blending is not used. Using the fixed function hardware to perform the blit is much faster and doesn't utilize the rasterization engine.