### PR TITLE
Convert max position coordinate to float in vertex scale calculation

### DIFF
--- a/common/src/main/resources/assets/sodium/shaders/include/chunk_vertex.glsl
+++ b/common/src/main/resources/assets/sodium/shaders/include/chunk_vertex.glsl
@@ -25,7 +25,7 @@ const uint TEXTURE_BITS         = 15u;
 const uint TEXTURE_MAX_COORD    = 1u << TEXTURE_BITS;
 const uint TEXTURE_MAX_VALUE    = TEXTURE_MAX_COORD - 1u;
 
-const float VERTEX_SCALE = 32.0 / POSITION_MAX_COORD;
+const float VERTEX_SCALE = 32.0 / float(POSITION_MAX_COORD);
 const float VERTEX_OFFSET = -8.0;
 
 // The amount of inset the texture coordinates from the edges of the texture, to avoid texture bleeding


### PR DESCRIPTION
Fixes #2678

Implicit conversion fails in some niche scenarios, like launching the game from IDEA with the nvidia hint on an optimus laptop. For some reason launching from prism with the hint works fine, as does launching from IDEA with the hint disabled. Adding the explicit conversion fixes the issue though so we don't need to worry about the specifics too much.