### PR TITLE
Include Fabric Loader in common build to fix warnings

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -25,6 +25,9 @@ dependencies {
     annotationProcessor("io.github.llamalad7:mixinextras-common:0.3.5")
     compileOnly("net.fabricmc:sponge-mixin:0.13.2+mixin.0.8.5")
 
+    // Fixes warning spam about an unknown enum constant pulled in by Fabric API
+    modCompileOnly("net.fabricmc:fabric-loader:$FABRIC_LOADER_VERSION")
+
     fun addDependentFabricModule(name: String) {
         val module = fabricApi.module(name, FABRIC_API_VERSION)
         modCompileOnly(module)


### PR DESCRIPTION
The common project includes Sodium's Fabric API integration, which can be used on either loader. The Fabric API modules reference Fabric Loader's API classes, so we need to include it to prevent warning spam about an unknown enum constant.