### PR TITLE
Fix compiler warnings

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -25,6 +25,9 @@ dependencies {
     annotationProcessor("io.github.llamalad7:mixinextras-common:0.3.5")
     compileOnly("net.fabricmc:sponge-mixin:0.13.2+mixin.0.8.5")
 
+    // Fixes warning spam about an unknown enum constant pulled in by Fabric API
+    compileOnly("net.fabricmc:fabric-loader:$FABRIC_LOADER_VERSION")
+
     fun addDependentFabricModule(name: String) {
         val module = fabricApi.module(name, FABRIC_API_VERSION)
         modCompileOnly(module)

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/core/render/world/LevelRendererMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/core/render/world/LevelRendererMixin.java
@@ -6,7 +6,6 @@ import net.caffeinemc.mods.sodium.client.gl.device.RenderDevice;
 import net.caffeinemc.mods.sodium.client.render.SodiumWorldRenderer;
 import net.caffeinemc.mods.sodium.client.render.chunk.ChunkRenderMatrices;
 import net.caffeinemc.mods.sodium.client.render.viewport.ViewportProvider;
-import net.caffeinemc.mods.sodium.client.services.PlatformLevelAccess;
 import net.caffeinemc.mods.sodium.client.services.PlatformLevelRenderHooks;
 import net.caffeinemc.mods.sodium.client.util.FlawlessFrames;
 import net.caffeinemc.mods.sodium.client.world.LevelRendererExtension;
@@ -25,8 +24,6 @@ import net.minecraft.client.renderer.culling.Frustum;
 import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.BlockDestructionProgress;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix4f;
 import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
@@ -35,7 +32,6 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.SortedSet;
-import java.util.function.Consumer;
 
 @Mixin(LevelRenderer.class)
 public abstract class LevelRendererMixin implements LevelRendererExtension {
@@ -46,10 +42,6 @@ public abstract class LevelRendererMixin implements LevelRendererExtension {
     @Shadow
     @Final
     private Long2ObjectMap<SortedSet<BlockDestructionProgress>> destructionProgress;
-
-    @Shadow
-    @Nullable
-    private ClientLevel level;
 
     @Shadow
     private int ticks;
@@ -209,15 +201,6 @@ public abstract class LevelRendererMixin implements LevelRendererExtension {
     @Inject(method = "renderLevel", at = @At(value = "FIELD", target = "Lnet/minecraft/client/renderer/LevelRenderer;globalBlockEntities:Ljava/util/Set;", shift = At.Shift.BEFORE, ordinal = 0))
     private void onRenderBlockEntities(DeltaTracker deltaTracker, boolean bl, Camera camera, GameRenderer gameRenderer, LightTexture lightTexture, Matrix4f matrix4f, Matrix4f matrix4f2, CallbackInfo ci) {
         this.renderer.renderBlockEntities(new PoseStack(), this.renderBuffers, this.destructionProgress, camera, deltaTracker.getGameTimeDeltaPartialTick(false));
-    }
-
-    // Exclusive to NeoForge, allow to fail.
-    @SuppressWarnings("all")
-    @Inject(method = "iterateVisibleBlockEntities", at = @At("HEAD"), cancellable = true, require = 0)
-    public void replaceBlockEntityIteration(Consumer<BlockEntity> blockEntityConsumer, CallbackInfo ci) {
-        ci.cancel();
-
-        this.renderer.iterateVisibleBlockEntities(blockEntityConsumer);
     }
 
     /**

--- a/common/src/main/resources/sodium.mixins.json
+++ b/common/src/main/resources/sodium.mixins.json
@@ -11,7 +11,6 @@
   },
   "client": [
     "core.MinecraftMixin",
-    "core.WindowMixin",
     "core.gui.LevelLoadStatusManagerMixin",
     "core.model.colors.BlockColorsMixin",
     "core.model.colors.ItemColorsMixin",
@@ -35,7 +34,6 @@
     "core.world.map.ClientLevelMixin",
     "features.gui.hooks.console.GameRendererMixin",
     "features.gui.hooks.debug.DebugScreenOverlayMixin",
-    "features.gui.hooks.settings.OptionsScreenMixin",
     "features.gui.screen.LevelLoadingScreenMixin",
     "features.options.overlays.GuiMixin",
     "features.options.render_layers.LeavesBlockMixin",

--- a/fabric/src/main/java/net/caffeinemc/mods/sodium/mixin/fabric/core/WindowMixin.java
+++ b/fabric/src/main/java/net/caffeinemc/mods/sodium/mixin/fabric/core/WindowMixin.java
@@ -1,21 +1,19 @@
-package net.caffeinemc.mods.sodium.mixin.core;
+package net.caffeinemc.mods.sodium.mixin.fabric.core;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.mojang.blaze3d.platform.Window;
 import net.caffeinemc.mods.sodium.client.SodiumClientMod;
 import net.caffeinemc.mods.sodium.client.compatibility.workarounds.Workarounds;
-import net.caffeinemc.mods.sodium.client.services.PlatformRuntimeInformation;
 import org.lwjgl.glfw.GLFW;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(Window.class)
 public class WindowMixin {
-    @WrapOperation(method = "<init>", at = @At(value = "INVOKE", target = "Lorg/lwjgl/glfw/GLFW;glfwCreateWindow(IILjava/lang/CharSequence;JJ)J"), require = 0)
+    @WrapOperation(method = "<init>", at = @At(value = "INVOKE", target = "Lorg/lwjgl/glfw/GLFW;glfwCreateWindow(IILjava/lang/CharSequence;JJ)J"), remap = false)
     public long setAdditionalWindowHints(int titleEncoded, int width, CharSequence height, long title, long monitor, Operation<Long> original) {
-        if (!PlatformRuntimeInformation.getInstance().platformHasEarlyLoadingScreen() && SodiumClientMod.options().performance.useNoErrorGLContext &&
+        if (SodiumClientMod.options().performance.useNoErrorGLContext &&
                 !Workarounds.isWorkaroundEnabled(Workarounds.Reference.NO_ERROR_CONTEXT_UNSUPPORTED)) {
             GLFW.glfwWindowHint(GLFW.GLFW_CONTEXT_NO_ERROR, GLFW.GLFW_TRUE);
         }

--- a/fabric/src/main/java/net/caffeinemc/mods/sodium/mixin/fabric/features/gui/hooks/settings/OptionsScreenMixin.java
+++ b/fabric/src/main/java/net/caffeinemc/mods/sodium/mixin/fabric/features/gui/hooks/settings/OptionsScreenMixin.java
@@ -1,4 +1,4 @@
-package net.caffeinemc.mods.sodium.mixin.features.gui.hooks.settings;
+package net.caffeinemc.mods.sodium.mixin.fabric.features.gui.hooks.settings;
 
 import net.caffeinemc.mods.sodium.client.gui.SodiumOptionsGUI;
 import net.minecraft.client.gui.screens.Screen;
@@ -17,10 +17,7 @@ public class OptionsScreenMixin extends Screen {
     }
 
     @Dynamic
-    @Inject(method = {
-            "method_19828",
-            "lambda$init$2"
-    }, require = 1, at = @At("HEAD"), cancellable = true)
+    @Inject(method = "method_19828", at = @At("HEAD"), cancellable = true)
     private void open(CallbackInfoReturnable<Screen> ci) {
         ci.setReturnValue(SodiumOptionsGUI.createScreen(this));
     }

--- a/fabric/src/main/java/net/caffeinemc/mods/sodium/mixin/fabric/workarounds/context_creation/WindowMixin.java
+++ b/fabric/src/main/java/net/caffeinemc/mods/sodium/mixin/fabric/workarounds/context_creation/WindowMixin.java
@@ -1,0 +1,29 @@
+package net.caffeinemc.mods.sodium.mixin.fabric.workarounds.context_creation;
+
+import com.mojang.blaze3d.platform.Window;
+import net.caffeinemc.mods.sodium.client.compatibility.workarounds.Workarounds;
+import net.caffeinemc.mods.sodium.client.compatibility.workarounds.nvidia.NvidiaWorkarounds;
+import org.lwjgl.glfw.GLFW;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(Window.class)
+public class WindowMixin {
+    @Redirect(method = "<init>", at = @At(value = "INVOKE", target = "Lorg/lwjgl/glfw/GLFW;glfwCreateWindow(IILjava/lang/CharSequence;JJ)J"), remap = false)
+    private long wrapGlfwCreateWindow(int width, int height, CharSequence title, long monitor, long share) {
+        final boolean applyNvidiaWorkarounds = Workarounds.isWorkaroundEnabled(Workarounds.Reference.NVIDIA_THREADED_OPTIMIZATIONS);
+
+        if (applyNvidiaWorkarounds) {
+            NvidiaWorkarounds.install();
+        }
+
+        try {
+            return GLFW.glfwCreateWindow(width, height, title, monitor, share);
+        } finally {
+            if (applyNvidiaWorkarounds) {
+                NvidiaWorkarounds.uninstall();
+            }
+        }
+    }
+}

--- a/fabric/src/main/resources/sodium-fabric.mixins.json
+++ b/fabric/src/main/resources/sodium-fabric.mixins.json
@@ -10,9 +10,12 @@
     "conformVisibility": true
   },
   "client": [
+    "core.WindowMixin",
     "core.model.quad.BakedQuadMixin",
+    "features.gui.hooks.settings.OptionsScreenMixin",
     "features.model.MultiPartBakedModelMixin",
     "features.model.WeightedBakedModelMixin",
-    "features.render.model.block.ModelBlockRendererMixin"
+    "features.render.model.block.ModelBlockRendererMixin",
+    "workarounds.context_creation.WindowMixin"
   ]
 }

--- a/neoforge/src/main/java/net/caffeinemc/mods/sodium/neoforge/mixin/core/render/world/LevelRendererMixin.java
+++ b/neoforge/src/main/java/net/caffeinemc/mods/sodium/neoforge/mixin/core/render/world/LevelRendererMixin.java
@@ -4,18 +4,18 @@ import net.caffeinemc.mods.sodium.client.render.SodiumWorldRenderer;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.Overwrite;
 
 import java.util.function.Consumer;
 
 @Mixin(LevelRenderer.class)
 public class LevelRendererMixin {
-    @Inject(method = "iterateVisibleBlockEntities", at = @At("HEAD"), cancellable = true)
-    public void replaceBlockEntityIteration(Consumer<BlockEntity> blockEntityConsumer, CallbackInfo ci) {
-        ci.cancel();
-
+    /**
+     * @author MrMangoHands
+     * @reason Redirect iteration of visible block entities to our renderer
+     */
+    @Overwrite
+    public void iterateVisibleBlockEntities(Consumer<BlockEntity> blockEntityConsumer) {
         SodiumWorldRenderer.instance().iterateVisibleBlockEntities(blockEntityConsumer);
     }
 }

--- a/neoforge/src/main/java/net/caffeinemc/mods/sodium/neoforge/mixin/core/render/world/LevelRendererMixin.java
+++ b/neoforge/src/main/java/net/caffeinemc/mods/sodium/neoforge/mixin/core/render/world/LevelRendererMixin.java
@@ -1,0 +1,21 @@
+package net.caffeinemc.mods.sodium.neoforge.mixin.core.render.world;
+
+import net.caffeinemc.mods.sodium.client.render.SodiumWorldRenderer;
+import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.function.Consumer;
+
+@Mixin(LevelRenderer.class)
+public class LevelRendererMixin {
+    @Inject(method = "iterateVisibleBlockEntities", at = @At("HEAD"), cancellable = true)
+    public void replaceBlockEntityIteration(Consumer<BlockEntity> blockEntityConsumer, CallbackInfo ci) {
+        ci.cancel();
+
+        SodiumWorldRenderer.instance().iterateVisibleBlockEntities(blockEntityConsumer);
+    }
+}

--- a/neoforge/src/main/java/net/caffeinemc/mods/sodium/neoforge/mixin/features/gui/hooks/settings/OptionsScreenMixin.java
+++ b/neoforge/src/main/java/net/caffeinemc/mods/sodium/neoforge/mixin/features/gui/hooks/settings/OptionsScreenMixin.java
@@ -1,0 +1,24 @@
+package net.caffeinemc.mods.sodium.neoforge.mixin.features.gui.hooks.settings;
+
+import net.caffeinemc.mods.sodium.client.gui.SodiumOptionsGUI;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.options.OptionsScreen;
+import net.minecraft.network.chat.Component;
+import org.spongepowered.asm.mixin.Dynamic;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(OptionsScreen.class)
+public class OptionsScreenMixin extends Screen {
+    protected OptionsScreenMixin(Component title) {
+        super(title);
+    }
+
+    @Dynamic
+    @Inject(method = "lambda$init$2", at = @At("HEAD"), cancellable = true)
+    private void open(CallbackInfoReturnable<Screen> ci) {
+        ci.setReturnValue(SodiumOptionsGUI.createScreen(this));
+    }
+}

--- a/neoforge/src/main/java/net/caffeinemc/mods/sodium/neoforge/mixin/features/options/render_layers/ItemBlockRenderTypesMixin.java
+++ b/neoforge/src/main/java/net/caffeinemc/mods/sodium/neoforge/mixin/features/options/render_layers/ItemBlockRenderTypesMixin.java
@@ -1,4 +1,4 @@
-package net.caffeinemc.mods.sodium.mixin.features.options.render_layers;
+package net.caffeinemc.mods.sodium.neoforge.mixin.features.options.render_layers;
 
 import net.caffeinemc.mods.sodium.client.SodiumClientMod;
 import net.minecraft.client.GraphicsStatus;
@@ -16,9 +16,8 @@ public class ItemBlockRenderTypesMixin {
     private static boolean leavesFancy;
 
     // getRenderLayers is a NeoForge only function required for the leaves to properly work.
-    @SuppressWarnings("all")
     @Redirect(
-            method = { "getChunkRenderType", "getMovingBlockRenderType" },
+            method = { "getRenderLayers" },
             at = @At(value = "FIELD", target = "Lnet/minecraft/client/renderer/ItemBlockRenderTypes;renderCutout:Z"))
     private static boolean redirectLeavesShouldBeFancy() {
         return leavesFancy;

--- a/neoforge/src/main/java/net/caffeinemc/mods/sodium/neoforge/mixin/workarounds/context_creation/WindowMixin.java
+++ b/neoforge/src/main/java/net/caffeinemc/mods/sodium/neoforge/mixin/workarounds/context_creation/WindowMixin.java
@@ -1,0 +1,34 @@
+package net.caffeinemc.mods.sodium.neoforge.mixin.workarounds.context_creation;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.blaze3d.platform.Window;
+import net.caffeinemc.mods.sodium.client.compatibility.workarounds.Workarounds;
+import net.caffeinemc.mods.sodium.client.compatibility.workarounds.nvidia.NvidiaWorkarounds;
+import net.caffeinemc.mods.sodium.client.services.PlatformRuntimeInformation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.function.IntSupplier;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+@Mixin(Window.class)
+public class WindowMixin {
+    @WrapOperation(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/neoforged/fml/loading/ImmediateWindowHandler;setupMinecraftWindow(Ljava/util/function/IntSupplier;Ljava/util/function/IntSupplier;Ljava/util/function/Supplier;Ljava/util/function/LongSupplier;)J"), remap = false)
+    private long wrapGlfwCreateWindowForge(final IntSupplier width, final IntSupplier height, final Supplier<String> title, final LongSupplier monitor, Operation<Long> op) {
+        final boolean applyNvidiaWorkarounds = Workarounds.isWorkaroundEnabled(Workarounds.Reference.NVIDIA_THREADED_OPTIMIZATIONS);
+
+        if (applyNvidiaWorkarounds && !PlatformRuntimeInformation.getInstance().platformHasEarlyLoadingScreen()) {
+            NvidiaWorkarounds.install();
+        }
+
+        try {
+            return op.call(width, height, title, monitor);
+        } finally {
+            if (applyNvidiaWorkarounds) {
+                NvidiaWorkarounds.uninstall();
+            }
+        }
+    }
+}

--- a/neoforge/src/main/resources/sodium-forge.mixins.json
+++ b/neoforge/src/main/resources/sodium-forge.mixins.json
@@ -11,9 +11,13 @@
   },
   "client" : [
     "core.model.quad.BakedQuadMixin",
+    "core.render.world.LevelRendererMixin",
+    "features.gui.hooks.settings.OptionsScreenMixin",
     "features.model.MultiPartBakedModelMixin",
     "features.model.WeightedBakedModelMixin",
+    "features.options.render_layers.ItemBlockRenderTypesMixin",
     "features.render.model.block.ModelBlockRendererMixin",
+    "workarounds.context_creation.WindowMixin",
     "AbstractBlockRenderContextMixin",
     "AuxiliaryLightManagerMixin",
     "ChunkRenderTypeSetAccessor",


### PR DESCRIPTION
The common project includes Sodium's Fabric API integration, which can be used on either loader. The Fabric API modules reference Fabric Loader's API classes, so we need to include it to prevent warning spam about an unknown enum constant.

This PR also splits out the remaining platform specific code from common, and adds `remap = false` where necessary to fix warnings.