### PR TITLE
Update compatible Minecraft versions

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -70,6 +70,7 @@
     "sodium-fabric.mixins.json"
   ],
   "depends" : {
+    "minecraft" : ["1.21", "1.21.1"],
     "fabricloader" : ">=0.12.0",
     "fabric-block-view-api-v2" : "*",
     "fabric-renderer-api-v1" : "*",

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -26,7 +26,7 @@ provides = ["indium"]
 [[dependencies.sodium]]
 modId = "minecraft"
 type = "required"
-versionRange = "[1.20.4,1.21.1)"
+versionRange = "[1.21,1.21.1]"
 ordering = "NONE"
 side = "CLIENT"
 


### PR DESCRIPTION
Fabric was missing the Minecraft dependency and NeoForge's needed fixing