### PR TITLE
Combine the vertex position attributes for performance

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/ShaderChunkRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/ShaderChunkRenderer.java
@@ -42,7 +42,7 @@ public abstract class ShaderChunkRenderer implements ChunkRenderer {
 
         GlShader vertShader = ShaderLoader.loadShader(ShaderType.VERTEX,
                 ResourceLocation.fromNamespaceAndPath("sodium", path + ".vsh"), constants);
-        
+
         GlShader fragShader = ShaderLoader.loadShader(ShaderType.FRAGMENT,
                 ResourceLocation.fromNamespaceAndPath("sodium", path + ".fsh"), constants);
 
@@ -50,8 +50,7 @@ public abstract class ShaderChunkRenderer implements ChunkRenderer {
             return GlProgram.builder(ResourceLocation.fromNamespaceAndPath("sodium", "chunk_shader"))
                     .attachShader(vertShader)
                     .attachShader(fragShader)
-                    .bindAttribute("a_PositionHi", ChunkShaderBindingPoints.ATTRIBUTE_POSITION_HI)
-                    .bindAttribute("a_PositionLo", ChunkShaderBindingPoints.ATTRIBUTE_POSITION_LO)
+                    .bindAttribute("a_Position", ChunkShaderBindingPoints.ATTRIBUTE_POSITION)
                     .bindAttribute("a_Color", ChunkShaderBindingPoints.ATTRIBUTE_COLOR)
                     .bindAttribute("a_TexCoord", ChunkShaderBindingPoints.ATTRIBUTE_TEXTURE)
                     .bindAttribute("a_LightAndData", ChunkShaderBindingPoints.ATTRIBUTE_LIGHT_MATERIAL_INDEX)

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/shader/ChunkShaderBindingPoints.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/shader/ChunkShaderBindingPoints.java
@@ -1,11 +1,10 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.shader;
 
 public class ChunkShaderBindingPoints {
-    public static final int ATTRIBUTE_POSITION_HI = 0;
-    public static final int ATTRIBUTE_POSITION_LO = 1;
-    public static final int ATTRIBUTE_COLOR = 2;
-    public static final int ATTRIBUTE_TEXTURE = 3;
-    public static final int ATTRIBUTE_LIGHT_MATERIAL_INDEX = 4;
+    public static final int ATTRIBUTE_POSITION = 0;
+    public static final int ATTRIBUTE_COLOR = 1;
+    public static final int ATTRIBUTE_TEXTURE = 2;
+    public static final int ATTRIBUTE_LIGHT_MATERIAL_INDEX = 3;
 
     public static final int FRAG_COLOR = 0;
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/vertex/format/impl/CompactChunkVertex.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/vertex/format/impl/CompactChunkVertex.java
@@ -12,8 +12,7 @@ public class CompactChunkVertex implements ChunkVertexType {
     public static final int STRIDE = 20;
 
     public static final GlVertexFormat VERTEX_FORMAT = GlVertexFormat.builder(STRIDE)
-            .addElement(DefaultChunkMeshAttributes.POSITION_HI, ChunkShaderBindingPoints.ATTRIBUTE_POSITION_HI, 0)
-            .addElement(DefaultChunkMeshAttributes.POSITION_LO, ChunkShaderBindingPoints.ATTRIBUTE_POSITION_LO, 4)
+            .addElement(DefaultChunkMeshAttributes.POSITION, ChunkShaderBindingPoints.ATTRIBUTE_POSITION, 0)
             .addElement(DefaultChunkMeshAttributes.COLOR, ChunkShaderBindingPoints.ATTRIBUTE_COLOR, 8)
             .addElement(DefaultChunkMeshAttributes.TEXTURE, ChunkShaderBindingPoints.ATTRIBUTE_TEXTURE, 12)
             .addElement(DefaultChunkMeshAttributes.LIGHT_MATERIAL_INDEX, ChunkShaderBindingPoints.ATTRIBUTE_LIGHT_MATERIAL_INDEX, 16)

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/vertex/format/impl/DefaultChunkMeshAttributes.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/vertex/format/impl/DefaultChunkMeshAttributes.java
@@ -4,8 +4,7 @@ import net.caffeinemc.mods.sodium.client.gl.attribute.GlVertexAttributeFormat;
 import net.caffeinemc.mods.sodium.client.render.vertex.VertexFormatAttribute;
 
 public class DefaultChunkMeshAttributes {
-    public static final VertexFormatAttribute POSITION_HI = new VertexFormatAttribute("POSITION_HI", GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true);
-    public static final VertexFormatAttribute POSITION_LO = new VertexFormatAttribute("POSITION_LO", GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true);
+    public static final VertexFormatAttribute POSITION = new VertexFormatAttribute("POSITION", GlVertexAttributeFormat.UNSIGNED_INT, 2, false, true);
     public static final VertexFormatAttribute COLOR = new VertexFormatAttribute("COLOR", GlVertexAttributeFormat.UNSIGNED_BYTE, 4, true, false);
     public static final VertexFormatAttribute TEXTURE = new VertexFormatAttribute("TEXTURE", GlVertexAttributeFormat.UNSIGNED_SHORT, 2, false, true);
     public static final VertexFormatAttribute LIGHT_MATERIAL_INDEX = new VertexFormatAttribute("LIGHT_MATERIAL_INDEX", GlVertexAttributeFormat.UNSIGNED_BYTE, 4, false, true);

--- a/common/src/main/resources/assets/sodium/shaders/include/chunk_vertex.glsl
+++ b/common/src/main/resources/assets/sodium/shaders/include/chunk_vertex.glsl
@@ -32,15 +32,14 @@ const float VERTEX_OFFSET = -8.0;
 const float TEXTURE_FUZZ_AMOUNT = 1.0 / 64.0;
 const float TEXTURE_GROW_FACTOR = (1.0 - TEXTURE_FUZZ_AMOUNT) / TEXTURE_MAX_COORD;
 
-in uint a_PositionHi;
-in uint a_PositionLo;
+in uvec2 a_Position;
 in vec4 a_Color;
 in uvec2 a_TexCoord;
 in uvec4 a_LightAndData;
 
-uvec3 _deinterleave_u20x3(uint packed_hi, uint packed_lo) {
-    uvec3 hi = (uvec3(packed_hi) >> uvec3(0u, 10u, 20u)) & 0x3FFu;
-    uvec3 lo = (uvec3(packed_lo) >> uvec3(0u, 10u, 20u)) & 0x3FFu;
+uvec3 _deinterleave_u20x3(uvec2 data) {
+    uvec3 hi = (uvec3(data.x) >> uvec3(0u, 10u, 20u)) & 0x3FFu;
+    uvec3 lo = (uvec3(data.y) >> uvec3(0u, 10u, 20u)) & 0x3FFu;
 
     return (hi << 10u) | lo;
 }
@@ -54,7 +53,7 @@ vec2 _get_texcoord_bias() {
 }
 
 void _vert_init() {
-    _vert_position = ((_deinterleave_u20x3(a_PositionHi, a_PositionLo) * VERTEX_SCALE) + VERTEX_OFFSET);
+    _vert_position = (_deinterleave_u20x3(a_Position) * VERTEX_SCALE) + VERTEX_OFFSET;
     _vert_color = a_Color;
     _vert_tex_diffuse_coord = _get_texcoord() + _get_texcoord_bias();
 


### PR DESCRIPTION
This improves terrain rendering performance significantly for me, with Intel Xe-LP graphics under Linux.

1280x720: 204 fps -> 238 fps (+16%)
2256x1504: 155 fps -> 168 fps (+8%) 