### PR TITLE
Cache multi draw batches on regions

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gl/device/GLRenderDevice.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gl/device/GLRenderDevice.java
@@ -274,7 +274,7 @@ public class GLRenderDevice implements RenderDevice {
                     batch.pElementCount,
                     indexType.getFormatId(),
                     batch.pElementPointer,
-                    batch.size(),
+                    batch.size,
                     batch.pBaseVertex);
         }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gl/device/MultiDrawBatch.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gl/device/MultiDrawBatch.java
@@ -14,9 +14,8 @@ public final class MultiDrawBatch {
     public final long pElementCount;
     public final long pBaseVertex;
 
-    private final int capacity;
-
     public int size;
+    public boolean isFilled;
 
     public MultiDrawBatch(int capacity) {
         this.pElementPointer = MemoryUtil.nmemAlignedAlloc(32, (long) capacity * Pointer.POINTER_SIZE);
@@ -24,20 +23,11 @@ public final class MultiDrawBatch {
 
         this.pElementCount = MemoryUtil.nmemAlignedAlloc(32, (long) capacity * Integer.BYTES);
         this.pBaseVertex = MemoryUtil.nmemAlignedAlloc(32, (long) capacity * Integer.BYTES);
-
-        this.capacity = capacity;
-    }
-
-    public int size() {
-        return this.size;
-    }
-
-    public int capacity() {
-        return this.capacity;
     }
 
     public void clear() {
         this.size = 0;
+        this.isFilled = false;
     }
 
     public void delete() {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/DefaultChunkRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/DefaultChunkRenderer.java
@@ -28,14 +28,11 @@ import org.lwjgl.system.Pointer;
 import java.util.Iterator;
 
 public class DefaultChunkRenderer extends ShaderChunkRenderer {
-    private final MultiDrawBatch batch;
-
     private final SharedQuadIndexBuffer sharedIndexBuffer;
 
     public DefaultChunkRenderer(RenderDevice device, ChunkVertexType vertexType) {
         super(device, vertexType);
 
-        this.batch = new MultiDrawBatch((ModelQuadFacing.COUNT * RenderRegion.REGION_SIZE) + 1);
         this.sharedIndexBuffer = new SharedQuadIndexBuffer(device.createCommandList(), SharedQuadIndexBuffer.IndexType.INTEGER);
     }
 
@@ -71,16 +68,19 @@ public class DefaultChunkRenderer extends ShaderChunkRenderer {
                 continue;
             }
 
-            fillCommandBuffer(this.batch, region, storage, renderList, camera, renderPass, useBlockFaceCulling, useIndexedTessellation);
+            var batch = region.getCachedBatch(renderPass);
+            if (!batch.isFilled) {
+                fillCommandBuffer(batch, region, storage, renderList, camera, renderPass, useBlockFaceCulling, useIndexedTessellation);
+            }
 
-            if (this.batch.isEmpty()) {
+            if (batch.isEmpty()) {
                 continue;
             }
 
             // When the shared index buffer is being used, we must ensure the storage has been allocated *before*
             // the tessellation is prepared.
             if (!useIndexedTessellation) {
-                this.sharedIndexBuffer.ensureCapacity(commandList, this.batch.getIndexBufferSize());
+                this.sharedIndexBuffer.ensureCapacity(commandList, batch.getIndexBufferSize());
             }
 
             GlTessellation tessellation;
@@ -92,7 +92,7 @@ public class DefaultChunkRenderer extends ShaderChunkRenderer {
             }
 
             setModelMatrixUniforms(shader, region, camera);
-            executeDrawBatch(commandList, tessellation, this.batch);
+            executeDrawBatch(commandList, tessellation, batch);
         }
 
         super.end(renderPass);
@@ -110,7 +110,7 @@ public class DefaultChunkRenderer extends ShaderChunkRenderer {
                                           TerrainRenderPass pass,
                                           boolean useBlockFaceCulling,
                                           boolean useIndexedTessellation) {
-        batch.clear();
+        batch.isFilled = true;
 
         var iterator = renderList.sectionsWithGeometryIterator(pass.isTranslucent());
 
@@ -362,6 +362,5 @@ public class DefaultChunkRenderer extends ShaderChunkRenderer {
         super.delete(commandList);
 
         this.sharedIndexBuffer.delete(commandList);
-        this.batch.delete();
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/ChunkRenderList.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/ChunkRenderList.java
@@ -16,6 +16,7 @@ public class ChunkRenderList {
 
     private final byte[] sectionsWithGeometry = new byte[RenderRegion.REGION_SIZE];
     private int sectionsWithGeometryCount = 0;
+    private int prevSectionsWithGeometryCount = 0;
 
     private final byte[] sectionsWithSprites = new byte[RenderRegion.REGION_SIZE];
     private int sectionsWithSpritesCount = 0;
@@ -32,6 +33,8 @@ public class ChunkRenderList {
     }
 
     public void reset(int frame) {
+        this.prevSectionsWithGeometryCount = this.sectionsWithGeometryCount;
+
         this.sectionsWithGeometryCount = 0;
         this.sectionsWithSpritesCount = 0;
         this.sectionsWithEntitiesCount = 0;
@@ -83,14 +86,26 @@ public class ChunkRenderList {
         int index = render.getSectionIndex();
         int flags = render.getFlags();
 
-        this.sectionsWithGeometry[this.sectionsWithGeometryCount] = (byte) index;
-        this.sectionsWithGeometryCount += (flags >>> RenderSectionFlags.HAS_BLOCK_GEOMETRY) & 1;
+        if (((flags >>> RenderSectionFlags.HAS_BLOCK_GEOMETRY) & 1) != 0) {
+            var byteIndex = (byte) index;
+            if (this.sectionsWithGeometry[this.sectionsWithGeometryCount] != byteIndex) {
+                this.sectionsWithGeometry[this.sectionsWithGeometryCount] = byteIndex;
+                this.prevSectionsWithGeometryCount = -1;
+            }
+            this.sectionsWithGeometryCount++;
+        }
 
         this.sectionsWithSprites[this.sectionsWithSpritesCount] = (byte) index;
         this.sectionsWithSpritesCount += (flags >>> RenderSectionFlags.HAS_ANIMATED_SPRITES) & 1;
 
         this.sectionsWithEntities[this.sectionsWithEntitiesCount] = (byte) index;
         this.sectionsWithEntitiesCount += (flags >>> RenderSectionFlags.HAS_BLOCK_ENTITIES) & 1;
+    }
+
+    public boolean getAndResetCacheInvalidation() {
+        var cacheIsInvalidated = this.prevSectionsWithGeometryCount != this.sectionsWithGeometryCount;
+        this.prevSectionsWithGeometryCount = this.sectionsWithGeometryCount;
+        return cacheIsInvalidated;
     }
 
     public @Nullable ByteIterator sectionsWithGeometryIterator(boolean reverse) {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/region/RenderRegion.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/region/RenderRegion.java
@@ -5,7 +5,9 @@ import net.caffeinemc.mods.sodium.client.gl.arena.GlBufferArena;
 import net.caffeinemc.mods.sodium.client.gl.arena.staging.StagingBuffer;
 import net.caffeinemc.mods.sodium.client.gl.buffer.GlBuffer;
 import net.caffeinemc.mods.sodium.client.gl.device.CommandList;
+import net.caffeinemc.mods.sodium.client.gl.device.MultiDrawBatch;
 import net.caffeinemc.mods.sodium.client.gl.tessellation.GlTessellation;
+import net.caffeinemc.mods.sodium.client.model.quad.properties.ModelQuadFacing;
 import net.caffeinemc.mods.sodium.client.render.chunk.RenderSection;
 import net.caffeinemc.mods.sodium.client.render.chunk.data.SectionRenderDataStorage;
 import net.caffeinemc.mods.sodium.client.render.chunk.lists.ChunkRenderList;
@@ -50,6 +52,8 @@ public class RenderRegion {
 
     private final Map<TerrainRenderPass, SectionRenderDataStorage> sectionRenderData = new Reference2ReferenceOpenHashMap<>();
     private DeviceResources resources;
+
+    private final Map<TerrainRenderPass, MultiDrawBatch> cachedBatches = new Reference2ReferenceOpenHashMap<>();
 
     public RenderRegion(int x, int y, int z, StagingBuffer stagingBuffer) {
         this.x = x;
@@ -113,6 +117,38 @@ public class RenderRegion {
         }
 
         Arrays.fill(this.sections, null);
+
+        for (var batch : this.cachedBatches.values()) {
+            batch.delete();
+        }
+        this.cachedBatches.clear();
+    }
+
+    public void clearAllCachedBatches() {
+        for (var batch : this.cachedBatches.values()) {
+            batch.clear();
+        }
+    }
+
+    public void clearCachedBatchFor(TerrainRenderPass pass) {
+        var batch = this.cachedBatches.remove(pass);
+        if (batch != null) {
+            batch.delete();
+        }
+    }
+
+    public MultiDrawBatch getCachedBatch(TerrainRenderPass pass) {
+        MultiDrawBatch batch = this.cachedBatches.get(pass);
+        if (batch != null) {
+            if (this.renderList.getAndResetCacheInvalidation()) {
+                batch.clear();
+            }
+            return batch;
+        }
+
+        batch = new MultiDrawBatch((ModelQuadFacing.COUNT * RenderRegion.REGION_SIZE) + 1);
+        this.cachedBatches.put(pass, batch);
+        return batch;
     }
 
     public boolean isEmpty() {


### PR DESCRIPTION
I get an improvement of around 7% by caching multi draw batches on each region. The margin is somewhat smaller when in motion, but often the batch can still be reused. The increase in memory use seems to be minimal.

If only one section in the region changed, only re-writing the command buffer starting at that section might bring an improvement of 50% on average for regions with block updates, but the metadata management for such partial buffer writes is somewhat complicated and may not be worth it if we're going to be changing this part of the renderer anyway.

dev
![dev](https://github.com/user-attachments/assets/ff9059ef-55b1-49a9-991b-d7265ad56d05)

dev with this patch
![dev with patch](https://github.com/user-attachments/assets/34120280-f518-4a69-b74c-4da9e7fa430d)

