### PR TITLE
no-op when being used on a server

### DIFF
--- a/neoforge/src/main/java/net/caffeinemc/mods/sodium/neoforge/SodiumForgeMod.java
+++ b/neoforge/src/main/java/net/caffeinemc/mods/sodium/neoforge/SodiumForgeMod.java
@@ -4,13 +4,14 @@ import net.caffeinemc.mods.sodium.client.gui.SodiumOptionsGUI;
 import net.caffeinemc.mods.sodium.client.render.frapi.SodiumRenderer;
 import net.caffeinemc.mods.sodium.client.render.texture.SpriteFinderCache;
 import net.fabricmc.fabric.api.renderer.v1.RendererAccess;
+import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.client.event.RegisterClientReloadListenersEvent;
 import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
 
-@Mod("sodium")
+@Mod(value = "sodium", dist = Dist.CLIENT)
 public class SodiumForgeMod {
     public SodiumForgeMod(IEventBus bus, ModContainer modContainer) {
         modContainer.registerExtensionPoint(IConfigScreenFactory.class, (minecraft, screen) -> SodiumOptionsGUI.createScreen(screen));


### PR DESCRIPTION
Mods should not crash on servers even if they are purely client only, they should simply do nothing.