### PR TITLE
Sort render lists for regions and sections after traversal (#2266)

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSection.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSection.java
@@ -69,9 +69,9 @@ public class RenderSection {
         this.chunkY = chunkY;
         this.chunkZ = chunkZ;
 
-        int rX = this.getChunkX() & (RenderRegion.REGION_WIDTH - 1);
-        int rY = this.getChunkY() & (RenderRegion.REGION_HEIGHT - 1);
-        int rZ = this.getChunkZ() & (RenderRegion.REGION_LENGTH - 1);
+        int rX = this.getChunkX() & RenderRegion.REGION_WIDTH_M;
+        int rY = this.getChunkY() & RenderRegion.REGION_HEIGHT_M;
+        int rZ = this.getChunkZ() & RenderRegion.REGION_LENGTH_M;
 
         this.sectionIndex = LocalSectionIndex.pack(rX, rY, rZ);
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -146,7 +146,7 @@ public class RenderSectionManager {
 
         this.occlusionCuller.findVisible(visitor, viewport, searchDistance, useOcclusionCulling, frame);
 
-        this.renderLists = visitor.createRenderLists();
+        this.renderLists = visitor.createRenderLists(viewport);
         this.taskLists = visitor.getRebuildLists();
     }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/ChunkRenderList.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/ChunkRenderList.java
@@ -1,11 +1,14 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.lists;
 
+import net.caffeinemc.mods.sodium.client.render.chunk.LocalSectionIndex;
 import net.caffeinemc.mods.sodium.client.render.chunk.RenderSection;
 import net.caffeinemc.mods.sodium.client.render.chunk.RenderSectionFlags;
+import net.caffeinemc.mods.sodium.client.render.chunk.region.RenderRegion;
+import net.caffeinemc.mods.sodium.client.render.viewport.CameraTransform;
+import net.caffeinemc.mods.sodium.client.util.iterator.ByteArrayIterator;
 import net.caffeinemc.mods.sodium.client.util.iterator.ByteIterator;
 import net.caffeinemc.mods.sodium.client.util.iterator.ReversibleByteArrayIterator;
-import net.caffeinemc.mods.sodium.client.util.iterator.ByteArrayIterator;
-import net.caffeinemc.mods.sodium.client.render.chunk.region.RenderRegion;
+import net.minecraft.util.Mth;
 import org.jetbrains.annotations.Nullable;
 
 public class ChunkRenderList {
@@ -35,6 +38,39 @@ public class ChunkRenderList {
 
         this.size = 0;
         this.lastVisibleFrame = frame;
+    }
+
+    // clamping the relative camera position to the region bounds means there can only be very few different distances
+    private static final int SORTING_HISTOGRAM_SIZE = RenderRegion.REGION_WIDTH + RenderRegion.REGION_HEIGHT + RenderRegion.REGION_LENGTH - 2;
+
+    public void sortSections(CameraTransform transform, int[] sortItems) {
+        var cameraX = Mth.clamp((transform.intX >> 4) - this.region.getChunkX(), 0, RenderRegion.REGION_WIDTH - 1);
+        var cameraY = Mth.clamp((transform.intY >> 4) - this.region.getChunkY(), 0, RenderRegion.REGION_HEIGHT - 1);
+        var cameraZ = Mth.clamp((transform.intZ >> 4) - this.region.getChunkZ(), 0, RenderRegion.REGION_LENGTH - 1);
+
+        int[] histogram = new int[SORTING_HISTOGRAM_SIZE];
+
+        for (int i = 0; i < this.sectionsWithGeometryCount; i++) {
+            var index = this.sectionsWithGeometry[i] & 0xFF; // makes sure the byte -> int conversion is unsigned
+            var x = Math.abs(LocalSectionIndex.unpackX(index) - cameraX);
+            var y = Math.abs(LocalSectionIndex.unpackY(index) - cameraY);
+            var z = Math.abs(LocalSectionIndex.unpackZ(index) - cameraZ);
+
+            var distance = x + y + z;
+            histogram[distance]++;
+            sortItems[i] = distance << 8 | index;
+        }
+
+        // prefix sum to calculate indexes
+        for (int i = 1; i < SORTING_HISTOGRAM_SIZE; i++) {
+            histogram[i] += histogram[i - 1];
+        }
+
+        for (int i = 0; i < this.sectionsWithGeometryCount; i++) {
+            var item = sortItems[i];
+            var distance = item >>> 8;
+            this.sectionsWithGeometry[--histogram[distance]] = (byte) item;
+        }
     }
 
     public void add(RenderSection render) {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/SortedRenderLists.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/SortedRenderLists.java
@@ -1,9 +1,7 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.lists;
 
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
-import net.caffeinemc.mods.sodium.client.render.chunk.RenderSection;
 import net.caffeinemc.mods.sodium.client.util.iterator.ReversibleObjectArrayIterator;
-import net.caffeinemc.mods.sodium.client.render.chunk.region.RenderRegion;
 
 /**
  * Stores one render list of sections per region, sorted by the order in which
@@ -26,45 +24,5 @@ public class SortedRenderLists implements ChunkRenderListIterable {
 
     public static SortedRenderLists empty() {
         return EMPTY;
-    }
-
-    public static class Builder {
-        private final ObjectArrayList<ChunkRenderList> lists = new ObjectArrayList<>();
-        private final int frame;
-
-        public Builder(int frame) {
-            this.frame = frame;
-        }
-
-        public void add(RenderSection section) {
-            RenderRegion region = section.getRegion();
-            ChunkRenderList list = region.getRenderList();
-
-            // Even if a section does not have render objects, we must ensure the render list is initialized and put
-            // into the sorted queue of lists, so that we maintain the correct order of draw calls.
-            if (list.getLastVisibleFrame() != this.frame) {
-                list.reset(this.frame);
-
-                this.lists.add(list);
-            }
-
-            // Only add the section to the render list if it actually contains render objects
-            if (section.getFlags() != 0) {
-                list.add(section);
-            }
-        }
-
-        public SortedRenderLists build() {
-            var filtered = new ObjectArrayList<ChunkRenderList>(this.lists.size());
-
-            // Filter any empty render lists
-            for (var list : this.lists) {
-                if (list.size() > 0) {
-                    filtered.add(list);
-                }
-            }
-
-            return new SortedRenderLists(filtered);
-        }
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/VisibleChunkCollector.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/VisibleChunkCollector.java
@@ -73,9 +73,9 @@ public class VisibleChunkCollector implements OcclusionCuller.Visitor {
         var items = new int[size];
         for (var i = 0; i < size; i++) {
             var region = this.sortedRenderLists.get(i).getRegion();
-            var x = Math.abs(region.getRawX() - cameraX);
-            var y = Math.abs(region.getRawY() - cameraY);
-            var z = Math.abs(region.getRawZ() - cameraZ);
+            var x = Math.abs(region.getX() - cameraX);
+            var y = Math.abs(region.getY() - cameraY);
+            var z = Math.abs(region.getZ() - cameraZ);
             items[i] = (x + y + z) << 16 | i;
         }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/VisibleChunkCollector.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/VisibleChunkCollector.java
@@ -32,22 +32,22 @@ public class VisibleChunkCollector implements OcclusionCuller.Visitor {
     }
 
     @Override
-    public void visit(RenderSection section, boolean visible) {
-        RenderRegion region = section.getRegion();
-        ChunkRenderList renderList = region.getRenderList();
+    public void visit(RenderSection section) {
+        // only process section (and associated render list) if it has content that needs rendering
+        if (section.getFlags() != 0) {
+            RenderRegion region = section.getRegion();
+            ChunkRenderList renderList = region.getRenderList();
 
-        // Even if a section does not have render objects, we must ensure the render list is initialized and put
-        // into the sorted queue of lists, so that we maintain the correct order of draw calls.
-        if (renderList.getLastVisibleFrame() != this.frame) {
-            renderList.reset(this.frame);
+            if (renderList.getLastVisibleFrame() != this.frame) {
+                renderList.reset(this.frame);
 
-            this.sortedRenderLists.add(renderList);
-        }
+                this.sortedRenderLists.add(renderList);
+            }
 
-        if (visible && section.getFlags() != 0) {
             renderList.add(section);
         }
 
+        // always add to rebuild lists though, because it might just not be built yet
         this.addToRebuildLists(section);
     }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/occlusion/OcclusionCuller.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/occlusion/OcclusionCuller.java
@@ -50,12 +50,11 @@ public class OcclusionCuller {
         RenderSection section;
 
         while ((section = readQueue.dequeue()) != null) {
-            boolean visible = isSectionVisible(section, viewport, searchDistance);
-            visitor.visit(section, visible);
-
-            if (!visible) {
+            if (!isSectionVisible(section, viewport, searchDistance)) {
                 continue;
             }
+
+            visitor.visit(section);
 
             int connections;
 
@@ -249,7 +248,7 @@ public class OcclusionCuller {
         section.setLastVisibleFrame(frame);
         section.setIncomingDirections(GraphDirectionSet.NONE);
 
-        visitor.visit(section, true);
+        visitor.visit(section);
 
         int outgoing;
 
@@ -335,6 +334,6 @@ public class OcclusionCuller {
     }
 
     public interface Visitor {
-        void visit(RenderSection section, boolean visible);
+        void visit(RenderSection section);
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/region/RenderRegion.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/region/RenderRegion.java
@@ -64,15 +64,15 @@ public class RenderRegion {
         return SectionPos.asLong(x, y, z);
     }
 
-    public int getRawX() {
+    public int getX() {
         return this.x;
     }
 
-    public int getRawY() {
+    public int getY() {
         return this.y;
     }
 
-    public int getRawZ() {
+    public int getZ() {
         return this.z;
     }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/region/RenderRegion.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/region/RenderRegion.java
@@ -24,13 +24,13 @@ public class RenderRegion {
     public static final int REGION_HEIGHT = 4;
     public static final int REGION_LENGTH = 8;
 
-    private static final int REGION_WIDTH_M = RenderRegion.REGION_WIDTH - 1;
-    private static final int REGION_HEIGHT_M = RenderRegion.REGION_HEIGHT - 1;
-    private static final int REGION_LENGTH_M = RenderRegion.REGION_LENGTH - 1;
+    public static final int REGION_WIDTH_M = RenderRegion.REGION_WIDTH - 1;
+    public static final int REGION_HEIGHT_M = RenderRegion.REGION_HEIGHT - 1;
+    public static final int REGION_LENGTH_M = RenderRegion.REGION_LENGTH - 1;
 
-    protected static final int REGION_WIDTH_SH = Integer.bitCount(REGION_WIDTH_M);
-    protected static final int REGION_HEIGHT_SH = Integer.bitCount(REGION_HEIGHT_M);
-    protected static final int REGION_LENGTH_SH = Integer.bitCount(REGION_LENGTH_M);
+    public static final int REGION_WIDTH_SH = Integer.bitCount(REGION_WIDTH_M);
+    public static final int REGION_HEIGHT_SH = Integer.bitCount(REGION_HEIGHT_M);
+    public static final int REGION_LENGTH_SH = Integer.bitCount(REGION_LENGTH_M);
 
     public static final int REGION_SIZE = REGION_WIDTH * REGION_HEIGHT * REGION_LENGTH;
 
@@ -62,6 +62,18 @@ public class RenderRegion {
 
     public static long key(int x, int y, int z) {
         return SectionPos.asLong(x, y, z);
+    }
+
+    public int getRawX() {
+        return this.x;
+    }
+
+    public int getRawY() {
+        return this.y;
+    }
+
+    public int getRawZ() {
+        return this.z;
     }
 
     public int getChunkX() {


### PR DESCRIPTION
This fixes #2266 by sorting regions after render list generation. The summary of the bug is that it happens because from certain points of view, the frustum is such that the order in which two regions are visited by equally distant sections depends solely on their order in the queue. See [the analysis here](https://discord.com/channels/602796788608401408/651120262129123330/1289730901487652928) for more details and images.

My measurements suggest that sorting regions by distance takes around 5µs and in total generating render lists takes around 1200µs for this scene. So the cost of sorting regions is around 0.5% which seems very acceptable. Measuring something that only takes 5µs with nanoTime is probably not the most precise, but it's averaged and very fast either way.

Obviated by https://github.com/CaffeineMC/sodium/pull/2887, but I hope this PR can be merged far earlier than the other one so that rendering is less broken until it gets merged. I'll resolve conflicts when the time comes.