### PR TITLE
[TS] Fix sorting failures on rotated cuboids

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/bsp_tree/BSPNode.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/bsp_tree/BSPNode.java
@@ -65,7 +65,7 @@ public abstract class BSPNode {
             // opposite normal (distance irrelevant)
             if (NormI8.isOpposite(packedNormalA, packedNormalB)
                     // same normal and same distance
-                    || packedNormalA == packedNormalB && quadA.getDotProduct() == quadB.getDotProduct()) {
+                    || packedNormalA == packedNormalB && quadA.getAccurateDotProduct() == quadB.getAccurateDotProduct()) {
                 return true;
             }
         }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/bsp_tree/InnerPartitionBSPNode.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/bsp_tree/InnerPartitionBSPNode.java
@@ -540,7 +540,7 @@ abstract class InnerPartitionBSPNode extends BSPNode {
 
             for (int i = 0; i < indexes.size(); i++) {
                 var quadIndex = indexes.getInt(i);
-                keys[i] = MathUtil.floatToComparableInt(workspace.quads[quadIndex].getDotProduct());
+                keys[i] = MathUtil.floatToComparableInt(workspace.quads[quadIndex].getAccurateDotProduct());
             }
 
             quadIndexes = RadixSort.sort(keys);
@@ -553,7 +553,7 @@ abstract class InnerPartitionBSPNode extends BSPNode {
 
             for (int i = 0; i < indexes.size(); i++) {
                 var quadIndex = indexes.getInt(i);
-                int dotProductComponent = MathUtil.floatToComparableInt(workspace.quads[quadIndex].getDotProduct());
+                int dotProductComponent = MathUtil.floatToComparableInt(workspace.quads[quadIndex].getAccurateDotProduct());
                 sortData[i] = (long) dotProductComponent << 32 | quadIndex;
             }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicTopoData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicTopoData.java
@@ -1,7 +1,6 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data;
 
 import it.unimi.dsi.fastutil.objects.Object2ReferenceOpenHashMap;
-import net.caffeinemc.mods.sodium.client.render.chunk.data.BuiltSectionMeshParts;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.TQuad;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.trigger.GeometryPlanes;
 import net.caffeinemc.mods.sodium.client.util.sorting.RadixSort;

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/StaticNormalRelativeData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/StaticNormalRelativeData.java
@@ -1,6 +1,5 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data;
 
-import net.caffeinemc.mods.sodium.client.render.chunk.data.BuiltSectionMeshParts;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.SortType;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.TQuad;
 import net.caffeinemc.mods.sodium.client.util.MathUtil;
@@ -50,7 +49,7 @@ public class StaticNormalRelativeData extends SplitDirectionData {
             final var keys = new int[quads.length];
 
             for (int q = 0; q < quads.length; q++) {
-                keys[q] = MathUtil.floatToComparableInt(quads[q].getDotProduct());
+                keys[q] = MathUtil.floatToComparableInt(quads[q].getAccurateDotProduct());
             }
 
             var indices = RadixSort.sort(keys);
@@ -62,7 +61,7 @@ public class StaticNormalRelativeData extends SplitDirectionData {
             final var sortData = new long[quads.length];
 
             for (int q = 0; q < quads.length; q++) {
-                int dotProductComponent = MathUtil.floatToComparableInt(quads[q].getDotProduct());
+                int dotProductComponent = MathUtil.floatToComparableInt(quads[q].getAccurateDotProduct());
                 sortData[q] = (long) dotProductComponent << 32 | q;
             }
 
@@ -116,7 +115,7 @@ public class StaticNormalRelativeData extends SplitDirectionData {
                 final var keys = new int[count];
 
                 for (int q = 0; q < count; q++) {
-                    keys[q] = MathUtil.floatToComparableInt(quads[quadIndex++].getDotProduct());
+                    keys[q] = MathUtil.floatToComparableInt(quads[quadIndex++].getAccurateDotProduct());
                 }
 
                 var indices = RadixSort.sort(keys);
@@ -127,7 +126,7 @@ public class StaticNormalRelativeData extends SplitDirectionData {
             } else {
                 for (int i = 0; i < count; i++) {
                     var quad = quads[quadIndex++];
-                    int dotProductComponent = MathUtil.floatToComparableInt(quad.getDotProduct());
+                    int dotProductComponent = MathUtil.floatToComparableInt(quad.getAccurateDotProduct());
                     sortData[i] = (long) dotProductComponent << 32 | i;
                 }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/trigger/GeometryPlanes.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/trigger/GeometryPlanes.java
@@ -92,9 +92,9 @@ public class GeometryPlanes {
     public void addQuadPlane(SectionPos sectionPos, TQuad quad) {
         var facing = quad.useQuantizedFacing();
         if (facing.isAligned()) {
-            this.addAlignedPlane(sectionPos, facing.ordinal(), quad.getDotProduct());
+            this.addAlignedPlane(sectionPos, facing.ordinal(), quad.getQuantizedDotProduct());
         } else {
-            this.addUnalignedPlane(sectionPos, quad.getQuantizedNormal(), quad.getDotProduct());
+            this.addUnalignedPlane(sectionPos, quad.getQuantizedNormal(), quad.getQuantizedDotProduct());
         }
     }
 


### PR DESCRIPTION
Fix sorting failures on rotated cuboids by using accurate vertex positions for unaligned and aligned but rotated quads.