### PR TITLE
Add epsilon to section distance check

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/occlusion/OcclusionCuller.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/occlusion/OcclusionCuller.java
@@ -158,11 +158,10 @@ public class OcclusionCuller {
 
         // coordinates of the point to compare (in view space)
         // this is the closest point within the bounding box to the center (0, 0, 0)
-        float dx = nearestToZero(ox, ox + 16) - camera.fracX;
-        float dy = nearestToZero(oy, oy + 16) - camera.fracY;
-        float dz = nearestToZero(oz, oz + 16) - camera.fracZ;
-
-        maxDistance += DISTANCE_EPSILON;
+        // the bounding box is expanded by 1 block in each direction due to the maximum allowed size of block models.
+        float dx = nearestToZero(ox - 1, ox + 17) - camera.fracX;
+        float dy = nearestToZero(oy - 1, oy + 17) - camera.fracY;
+        float dz = nearestToZero(oz - 1, oz + 17) - camera.fracZ;
 
         // vanilla's "cylindrical fog" algorithm
         // max(length(distance.xz), abs(distance.y))
@@ -182,11 +181,6 @@ public class OcclusionCuller {
     // can extend outside a block volume by +/- 1.0 blocks on all axis. Additionally, we make use of a small epsilon
     // to deal with floating point imprecision during a frustum check (see GH#2132).
     private static final float CHUNK_SECTION_SIZE = 8.0f /* chunk bounds */ + 1.0f /* maximum model extent */
-            + 0.125f /* fp error epsilon */;
-
-    // Because we're working in 3 axis, we need to use the distance formula to get the maximum distance
-    // a model can extend out of a chunk.
-    public static final float DISTANCE_EPSILON = Math.sqrt(3.0f) /* maximum model extent distance */
             + 0.125f /* fp error epsilon */;
 
     public static boolean isWithinFrustum(Viewport viewport, RenderSection section) {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/occlusion/OcclusionCuller.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/occlusion/OcclusionCuller.java
@@ -162,6 +162,8 @@ public class OcclusionCuller {
         float dy = nearestToZero(oy, oy + 16) - camera.fracY;
         float dz = nearestToZero(oz, oz + 16) - camera.fracZ;
 
+        maxDistance += DISTANCE_EPSILON;
+
         // vanilla's "cylindrical fog" algorithm
         // max(length(distance.xz), abs(distance.y))
         return (((dx * dx) + (dz * dz)) < (maxDistance * maxDistance)) && (Math.abs(dy) < maxDistance);
@@ -179,7 +181,13 @@ public class OcclusionCuller {
     // The bounding box of a chunk section must be large enough to contain all possible geometry within it. Block models
     // can extend outside a block volume by +/- 1.0 blocks on all axis. Additionally, we make use of a small epsilon
     // to deal with floating point imprecision during a frustum check (see GH#2132).
-    private static final float CHUNK_SECTION_SIZE = 8.0f /* chunk bounds */ + 1.0f /* maximum model extent */ + 0.125f /* epsilon */;
+    private static final float CHUNK_SECTION_SIZE = 8.0f /* chunk bounds */ + 1.0f /* maximum model extent */
+            + 0.125f /* fp error epsilon */;
+
+    // Because we're working in 3 axis, we need to use the distance formula to get the maximum distance
+    // a model can extend out of a chunk.
+    public static final float DISTANCE_EPSILON = Math.sqrt(3.0f) /* maximum model extent distance */
+            + 0.125f /* fp error epsilon */;
 
     public static boolean isWithinFrustum(Viewport viewport, RenderSection section) {
         return viewport.isBoxVisible(section.getCenterX(), section.getCenterY(), section.getCenterZ(),

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/occlusion/OcclusionCuller.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/occlusion/OcclusionCuller.java
@@ -180,8 +180,7 @@ public class OcclusionCuller {
     // The bounding box of a chunk section must be large enough to contain all possible geometry within it. Block models
     // can extend outside a block volume by +/- 1.0 blocks on all axis. Additionally, we make use of a small epsilon
     // to deal with floating point imprecision during a frustum check (see GH#2132).
-    private static final float CHUNK_SECTION_SIZE = 8.0f /* chunk bounds */ + 1.0f /* maximum model extent */
-            + 0.125f /* fp error epsilon */;
+    private static final float CHUNK_SECTION_SIZE = 8.0f /* chunk bounds */ + 1.0f /* maximum model extent */ + 0.125f /* epsilon */;
 
     public static boolean isWithinFrustum(Viewport viewport, RenderSection section) {
         return viewport.isBoxVisible(section.getCenterX(), section.getCenterY(), section.getCenterZ(),


### PR DESCRIPTION
This is done to for parity with the epsilon used on frustum culling. ~~The epsilon is pretty pessimistic, and can be less pessimistic if the algorithm is changed slightly. I chose not to do this because it may make the function slower.~~

~~I chose not to add this value to the `searchDistance` value provided to `OcclusionCuller.findVisible`, because that could potentially change the sections traversed by the BFS, which I'm not sure we want.~~

The epsilon used for this function is `1.0` on each axis, enough to account for large block models, while the the frustum cull uses `1.125`. The extra `0.125` exists in the epsilon of the frustum cull due to floating point imprecision, which shouldn't come up with the minimal amount of floating point operations in the distance check.

With this used, I think the `+ 0.5` epsilon [here](https://github.com/CaffeineMC/sodium-fabric/blob/dd25399c139004e863beb8a2195b9d80b847d95c/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java#L639) may be able to be removed, also. I need confirmation on this to be sure.