### PR TITLE
Fix some cases of large BEs not rendering

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/occlusion/OcclusionCuller.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/occlusion/OcclusionCuller.java
@@ -37,6 +37,8 @@ public class OcclusionCuller {
         while (queues.flip()) {
             processQueue(visitor, viewport, searchDistance, useOcclusionCulling, frame, queues.read(), queues.write());
         }
+
+        this.fixOriginNeighbors(visitor, viewport, searchDistance, frame);
     }
 
     private static void processQueue(Visitor visitor,
@@ -208,11 +210,75 @@ public class OcclusionCuller {
     // The bounding box of a chunk section must be large enough to contain all possible geometry within it. Block models
     // can extend outside a block volume by +/- 1.0 blocks on all axis. Additionally, we make use of a small epsilon
     // to deal with floating point imprecision during a frustum check (see GH#2132).
-    private static final float CHUNK_SECTION_SIZE = 8.0f /* chunk bounds */ + 1.0f /* maximum model extent */ + 0.125f /* epsilon */;
+    private static final float CHUNK_SECTION_BASE = 8.0f /* chunk bounds */;
+    private static final float CHUNK_SECTION_SIZE = CHUNK_SECTION_BASE + 1.0f /* maximum model extent */ + 0.125f /* epsilon */;
+    private static final float CHUNK_SECTION_SIZE_NEIGHBOR = CHUNK_SECTION_BASE + 2.0f /* bigger model extent */ + 0.125f /* epsilon */;
 
     public static boolean isWithinFrustum(Viewport viewport, RenderSection section) {
         return viewport.isBoxVisible(section.getCenterX(), section.getCenterY(), section.getCenterZ(),
                 CHUNK_SECTION_SIZE, CHUNK_SECTION_SIZE, CHUNK_SECTION_SIZE);
+    }
+
+    private static boolean isNeighborSectionVisible(RenderSection section, Viewport viewport, float maxDistance) {
+        return isWithinRenderDistance(viewport.getTransform(), section, maxDistance) && isWithinNeighborFrustum(viewport, section);
+    }
+
+    public static boolean isWithinNeighborFrustum(Viewport viewport, RenderSection section) {
+        return viewport.isBoxVisible(section.getCenterX(), section.getCenterY(), section.getCenterZ(),
+                CHUNK_SECTION_SIZE_NEIGHBOR, CHUNK_SECTION_SIZE_NEIGHBOR, CHUNK_SECTION_SIZE_NEIGHBOR);
+    }
+
+    private void fixOriginNeighbors(Visitor visitor, Viewport viewport, float searchDistance, int frame) {
+        var origin = viewport.getChunkCoord();
+        var originX = origin.getX();
+        var originY = origin.getY();
+        var originZ = origin.getZ();
+
+        // face-touching neighbors
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX - 1, originY, originZ);
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX + 1, originY, originZ);
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX, originY - 1, originZ);
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX, originY + 1, originZ);
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX, originY, originZ - 1);
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX, originY, originZ + 1);
+
+        // edge-touching neighbors
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX - 1, originY - 1, originZ);
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX + 1, originY - 1, originZ);
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX - 1, originY + 1, originZ);
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX + 1, originY + 1, originZ);
+
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX - 1, originY, originZ - 1);
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX + 1, originY, originZ - 1);
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX - 1, originY, originZ + 1);
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX + 1, originY, originZ + 1);
+
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX, originY - 1, originZ - 1);
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX, originY + 1, originZ - 1);
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX, originY - 1, originZ + 1);
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX, originY + 1, originZ + 1);
+
+        // corner-touching neighbors
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX - 1, originY - 1, originZ - 1);
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX + 1, originY - 1, originZ - 1);
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX - 1, originY + 1, originZ - 1);
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX + 1, originY + 1, originZ - 1);
+
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX - 1, originY - 1, originZ + 1);
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX + 1, originY - 1, originZ + 1);
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX - 1, originY + 1, originZ + 1);
+        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX + 1, originY + 1, originZ + 1);
+    }
+
+    private void visitOriginNeighbor(Visitor visitor, Viewport viewport, float searchDistance, int frame, int x, int y, int z) {
+        var section = this.getRenderSection(x, y, z);
+
+        if (section != null && section.getLastVisibleFrame() != frame && isNeighborSectionVisible(section, viewport, searchDistance)) {
+            // reset state on first visit, but don't enqueue
+            section.setLastVisibleFrame(frame);
+
+            visitor.visit(section, true);
+        }
     }
 
     private void init(Visitor visitor,

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/occlusion/OcclusionCuller.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/occlusion/OcclusionCuller.java
@@ -234,50 +234,24 @@ public class OcclusionCuller {
         var originY = origin.getY();
         var originZ = origin.getZ();
 
-        // face-touching neighbors
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX - 1, originY, originZ);
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX + 1, originY, originZ);
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX, originY - 1, originZ);
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX, originY + 1, originZ);
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX, originY, originZ - 1);
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX, originY, originZ + 1);
+        for (var dx = -1; dx <= 1; dx++) {
+            for (var dy = -1; dy <= 1; dy++) {
+                for (var dz = -1; dz <= 1; dz++) {
+                    if (dx == 0 && dy == 0 && dz == 0) {
+                        continue;
+                    }
 
-        // edge-touching neighbors
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX - 1, originY - 1, originZ);
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX + 1, originY - 1, originZ);
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX - 1, originY + 1, originZ);
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX + 1, originY + 1, originZ);
+                    var section = this.getRenderSection(originX + dx, originY + dy, originZ + dz);
 
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX - 1, originY, originZ - 1);
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX + 1, originY, originZ - 1);
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX - 1, originY, originZ + 1);
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX + 1, originY, originZ + 1);
+                    // additionally render not yet visited but visible sections
+                    if (section != null && section.getLastVisibleFrame() != frame && isNeighborSectionVisible(section, viewport, searchDistance)) {
+                        // reset state on first visit, but don't enqueue
+                        section.setLastVisibleFrame(frame);
 
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX, originY - 1, originZ - 1);
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX, originY + 1, originZ - 1);
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX, originY - 1, originZ + 1);
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX, originY + 1, originZ + 1);
-
-        // corner-touching neighbors
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX - 1, originY - 1, originZ - 1);
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX + 1, originY - 1, originZ - 1);
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX - 1, originY + 1, originZ - 1);
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX + 1, originY + 1, originZ - 1);
-
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX - 1, originY - 1, originZ + 1);
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX + 1, originY - 1, originZ + 1);
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX - 1, originY + 1, originZ + 1);
-        visitOriginNeighbor(visitor, viewport, searchDistance, frame, originX + 1, originY + 1, originZ + 1);
-    }
-
-    private void visitOriginNeighbor(Visitor visitor, Viewport viewport, float searchDistance, int frame, int x, int y, int z) {
-        var section = this.getRenderSection(x, y, z);
-
-        if (section != null && section.getLastVisibleFrame() != frame && isNeighborSectionVisible(section, viewport, searchDistance)) {
-            // reset state on first visit, but don't enqueue
-            section.setLastVisibleFrame(frame);
-
-            visitor.visit(section, true);
+                        visitor.visit(section, true);
+                    }
+                }
+            }
         }
     }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/occlusion/OcclusionCuller.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/occlusion/OcclusionCuller.java
@@ -221,7 +221,7 @@ public class OcclusionCuller {
     // this bigger chunk section size is only used for frustum-testing nearby sections with large models
     private static final float CHUNK_SECTION_SIZE_NEARBY = CHUNK_SECTION_RADIUS + 2.0f /* bigger model extent */ + 0.125f /* epsilon */;
     
-    public static boolean isWithinNeighborFrustum(Viewport viewport, RenderSection section) {
+    public static boolean isWithinNearbySectionFrustum(Viewport viewport, RenderSection section) {
         return viewport.isBoxVisible(section.getCenterX(), section.getCenterY(), section.getCenterZ(),
                 CHUNK_SECTION_SIZE_NEARBY, CHUNK_SECTION_SIZE_NEARBY, CHUNK_SECTION_SIZE_NEARBY);
     }
@@ -247,7 +247,7 @@ public class OcclusionCuller {
                     var section = this.getRenderSection(originX + dx, originY + dy, originZ + dz);
 
                     // additionally render not yet visited but visible sections
-                    if (section != null && section.getLastVisibleFrame() != frame && isWithinNeighborFrustum(viewport, section)) {
+                    if (section != null && section.getLastVisibleFrame() != frame && isWithinNearbySectionFrustum(viewport, section)) {
                         // reset state on first visit, but don't enqueue
                         section.setLastVisibleFrame(frame);
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/occlusion/OcclusionCuller.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/occlusion/OcclusionCuller.java
@@ -251,7 +251,7 @@ public class OcclusionCuller {
                         // reset state on first visit, but don't enqueue
                         section.setLastVisibleFrame(frame);
 
-                        visitor.visit(section, true);
+                        visitor.visit(section);
                     }
                 }
             }


### PR DESCRIPTION
Uses a model margin of 2 for neighboring sections. Do we want to also apply this to all other sections, or use a different value?