### PR TITLE
Avoid Unnecessary Graph Searches by Checking for State Changes

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSection.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSection.java
@@ -139,30 +139,44 @@ public class RenderSection {
         this.disposed = true;
     }
 
-    public void setInfo(@Nullable BuiltSectionInfo info) {
+    public boolean setInfo(@Nullable BuiltSectionInfo info) {
         if (info != null) {
-            this.setRenderState(info);
+            return this.setRenderState(info);
         } else {
-            this.clearRenderState();
+            return this.clearRenderState();
         }
     }
 
-    private void setRenderState(@NotNull BuiltSectionInfo info) {
+    private boolean setRenderState(@NotNull BuiltSectionInfo info) {
+        var prevBuilt = this.built;
+        var prevFlags = this.flags;
+        var prevVisibilityData = this.visibilityData;
+
         this.built = true;
         this.flags = info.flags;
         this.visibilityData = info.visibilityData;
+
         this.globalBlockEntities = info.globalBlockEntities;
         this.culledBlockEntities = info.culledBlockEntities;
         this.animatedSprites = info.animatedSprites;
+
+        // the section is marked as having received graph-relevant changes if it's build state, flags, or connectedness has changed.
+        // the entities and sprites don't need to be checked since whether they exist is encoded in the flags.
+        return !prevBuilt || prevFlags != this.flags || prevVisibilityData != this.visibilityData;
     }
 
-    private void clearRenderState() {
+    private boolean clearRenderState() {
+        var wasBuilt = this.built;
+
         this.built = false;
         this.flags = RenderSectionFlags.NONE;
         this.visibilityData = VisibilityEncoding.NULL;
         this.globalBlockEntities = null;
         this.culledBlockEntities = null;
         this.animatedSprites = null;
+
+        // changes to data if it moves from built to not built don't matter, so only build state changes matter
+        return wasBuilt;
     }
 
     /**


### PR DESCRIPTION
Avoids rebuilding the render lists and doing a graph search more often than necessary by checking if the section actually changed in a way that's relevant to the graph search. For worlds that update their blocks frequently (every tick or every redstone tick) this avoids half the graph searches. Some graph searches are still necessary to schedule rebuild tasks, but when the task results come back, this doesn't do another graph search unless the section's visibility data or build state changed in a way that needs the render list to be updated.

In combination with [async frustum culling](https://github.com/douira/sodium/tree/decoupled-frustum-test) where task collection is not bound to the graph search, this is even more effective.