### PR TITLE
Change how hollow cage-like blocks are culled

### DIFF
--- a/common/src/main/resources/assets/minecraft/models/block/cube_all_inner_faces.json
+++ b/common/src/main/resources/assets/minecraft/models/block/cube_all_inner_faces.json
@@ -1,29 +1,29 @@
 {
-	"parent": "block/cube_all",
-	"elements": [
-		{
-			"from": [0, 0, 0],
-			"to": [16, 16, 16],
-			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#all", "cullface": "north"},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#all", "cullface": "east"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#all", "cullface": "south"},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#all", "cullface": "west"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#all", "cullface": "up"},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#all", "cullface": "down"}
-			}
-		},
-		{
-			"from": [15.998, 0.002, 0.002],
-			"to": [0.002, 15.998, 15.998],
-			"faces": {
-				"north": {"uv": [16, 0, 0, 16], "texture": "#all", "cullface": "north"},
-				"east": {"uv": [16, 0, 0, 16], "texture": "#all", "cullface": "west"},
-				"south": {"uv": [16, 0, 0, 16], "texture": "#all", "cullface": "south"},
-				"west": {"uv": [16, 0, 0, 16], "texture": "#all", "cullface": "east"},
-				"up": {"uv": [16, 0, 0, 16], "texture": "#all", "cullface": "up"},
-				"down": {"uv": [16, 0, 0, 16], "texture": "#all", "cullface": "down"}
-			}
-		}
-	]
+    "parent": "block/cube_all",
+    "elements": [
+        {
+            "from": [ 0, 0, 0 ],
+            "to": [ 16, 16, 16 ],
+            "faces": {
+                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#all", "cullface": "north" },
+                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#all", "cullface": "east" },
+                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#all", "cullface": "south" },
+                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#all", "cullface": "west" },
+                "up": { "uv": [ 0, 0, 16, 16 ], "texture": "#all", "cullface": "up" },
+                "down": { "uv": [ 0, 0, 16, 16 ], "texture": "#all", "cullface": "down" }
+            }
+        },
+        {
+            "from": [ 15.998, 0.002, 0.002 ],
+            "to": [ 0.002, 15.998, 15.998 ],
+            "faces": {
+                "north": { "uv": [ 16, 0, 0, 16 ], "texture": "#all", "cullface": "north" },
+                "east": { "uv": [ 16, 0, 0, 16 ], "texture": "#all", "cullface": "west" },
+                "south": { "uv": [ 16, 0, 0, 16 ], "texture": "#all", "cullface": "south" },
+                "west": { "uv": [ 16, 0, 0, 16 ], "texture": "#all", "cullface": "east" },
+                "up": { "uv": [ 16, 0, 0, 16 ], "texture": "#all", "cullface": "up" },
+                "down": { "uv": [ 16, 0, 0, 16 ], "texture": "#all", "cullface": "down" }
+            }
+        }
+    ]
 }

--- a/common/src/main/resources/assets/minecraft/models/block/cube_all_inner_faces.json
+++ b/common/src/main/resources/assets/minecraft/models/block/cube_all_inner_faces.json
@@ -1,0 +1,29 @@
+{
+	"parent": "block/cube_all",
+	"elements": [
+		{
+			"from": [0, 0, 0],
+			"to": [16, 16, 16],
+			"faces": {
+				"north": {"uv": [0, 0, 16, 16], "texture": "#all", "cullface": "north"},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#all", "cullface": "east"},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#all", "cullface": "south"},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#all", "cullface": "west"},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#all", "cullface": "up"},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#all", "cullface": "down"}
+			}
+		},
+		{
+			"from": [15.998, 0.002, 0.002],
+			"to": [0.002, 15.998, 15.998],
+			"faces": {
+				"north": {"uv": [16, 0, 0, 16], "texture": "#all", "cullface": "north"},
+				"east": {"uv": [16, 0, 0, 16], "texture": "#all", "cullface": "west"},
+				"south": {"uv": [16, 0, 0, 16], "texture": "#all", "cullface": "south"},
+				"west": {"uv": [16, 0, 0, 16], "texture": "#all", "cullface": "east"},
+				"up": {"uv": [16, 0, 0, 16], "texture": "#all", "cullface": "up"},
+				"down": {"uv": [16, 0, 0, 16], "texture": "#all", "cullface": "down"}
+			}
+		}
+	]
+}

--- a/common/src/main/resources/assets/minecraft/models/block/cube_bottom_top_inner_faces.json
+++ b/common/src/main/resources/assets/minecraft/models/block/cube_bottom_top_inner_faces.json
@@ -1,29 +1,29 @@
 {
-	"parent": "block/cube_bottom_top",
-	"elements": [
-		{
-			"from": [0, 0, 0],
-			"to": [16, 16, 16],
-			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#side", "cullface": "north"},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#side", "cullface": "east"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#side", "cullface": "south"},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#side", "cullface": "west"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#top", "cullface": "up"},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#bottom", "cullface": "down"}
-			}
-		},
-		{
-			"from": [15.998, 0.002, 0.002],
-			"to": [0.002, 15.998, 15.998],
-			"faces": {
-				"north": {"uv": [16, 0, 0, 16], "texture": "#side", "cullface": "north"},
-				"east": {"uv": [16, 0, 0, 16], "texture": "#side", "cullface": "west"},
-				"south": {"uv": [16, 0, 0, 16], "texture": "#side", "cullface": "south"},
-				"west": {"uv": [16, 0, 0, 16], "texture": "#side", "cullface": "east"},
-				"up": {"uv": [16, 0, 0, 16], "texture": "#top", "cullface": "up"},
-				"down": {"uv": [16, 0, 0, 16], "texture": "#bottom", "cullface": "down"}
-			}
-		}
-	]
+    "parent": "block/cube_bottom_top",
+    "elements": [
+        {
+            "from": [ 0, 0, 0 ],
+            "to": [ 16, 16, 16 ],
+            "faces": {
+                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "north" },
+                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "east" },
+                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "south" },
+                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "west" },
+                "up": { "uv": [ 0, 0, 16, 16 ], "texture": "#top", "cullface": "up" },
+                "down": { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom", "cullface": "down" }
+            }
+        },
+        {
+            "from": [ 15.998, 0.002, 0.002 ],
+            "to": [ 0.002, 15.998, 15.998 ],
+            "faces": {
+                "north": { "uv": [ 16, 0, 0, 16 ], "texture": "#side", "cullface": "north" },
+                "east": { "uv": [ 16, 0, 0, 16 ], "texture": "#side", "cullface": "west" },
+                "south": { "uv": [ 16, 0, 0, 16 ], "texture": "#side", "cullface": "south" },
+                "west": { "uv": [ 16, 0, 0, 16 ], "texture": "#side", "cullface": "east" },
+                "up": { "uv": [ 16, 0, 0, 16 ], "texture": "#top", "cullface": "up" },
+                "down": { "uv": [ 16, 0, 0, 16 ], "texture": "#bottom", "cullface": "down" }
+            }
+        }
+    ]
 }

--- a/common/src/main/resources/assets/minecraft/models/block/cube_bottom_top_inner_faces.json
+++ b/common/src/main/resources/assets/minecraft/models/block/cube_bottom_top_inner_faces.json
@@ -1,15 +1,11 @@
 {
-	"parent": "block/block",
-	"textures": {
-		"particle": "#side"
-	},
+	"parent": "block/cube_bottom_top",
 	"elements": [
 		{
-			"name": "cage",
 			"from": [0, 0, 0],
 			"to": [16, 16, 16],
 			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#front", "cullface": "north"},
+				"north": {"uv": [0, 0, 16, 16], "texture": "#side", "cullface": "north"},
 				"east": {"uv": [0, 0, 16, 16], "texture": "#side", "cullface": "east"},
 				"south": {"uv": [0, 0, 16, 16], "texture": "#side", "cullface": "south"},
 				"west": {"uv": [0, 0, 16, 16], "texture": "#side", "cullface": "west"},
@@ -18,16 +14,15 @@
 			}
 		},
 		{
-			"name": "cage_inverted_faces",
-			"from": [15.998, 3.002, 0.002],
+			"from": [15.998, 0.002, 0.002],
 			"to": [0.002, 15.998, 15.998],
 			"faces": {
-				"north": {"uv": [16, 0, 0, 13], "texture": "#front", "cullface": "north"},
-				"east": {"uv": [16, 0, 0, 13], "texture": "#side", "cullface": "west"},
-				"south": {"uv": [16, 0, 0, 13], "texture": "#side", "cullface": "south"},
-				"west": {"uv": [16, 0, 0, 13], "texture": "#side", "cullface": "east"},
+				"north": {"uv": [16, 0, 0, 16], "texture": "#side", "cullface": "north"},
+				"east": {"uv": [16, 0, 0, 16], "texture": "#side", "cullface": "west"},
+				"south": {"uv": [16, 0, 0, 16], "texture": "#side", "cullface": "south"},
+				"west": {"uv": [16, 0, 0, 16], "texture": "#side", "cullface": "east"},
 				"up": {"uv": [16, 0, 0, 16], "texture": "#top", "cullface": "up"},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#bottom"}
+				"down": {"uv": [16, 0, 0, 16], "texture": "#bottom", "cullface": "down"}
 			}
 		}
 	]

--- a/common/src/main/resources/assets/minecraft/models/block/template_vault.json
+++ b/common/src/main/resources/assets/minecraft/models/block/template_vault.json
@@ -1,34 +1,34 @@
 {
-	"parent": "block/block",
-	"textures": {
-		"particle": "#side"
-	},
-	"elements": [
-		{
-			"name": "cage",
-			"from": [0, 0, 0],
-			"to": [16, 16, 16],
-			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#front", "cullface": "north"},
-				"east": {"uv": [0, 0, 16, 16], "texture": "#side", "cullface": "east"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#side", "cullface": "south"},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#side", "cullface": "west"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#top", "cullface": "up"},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#bottom", "cullface": "down"}
-			}
-		},
-		{
-			"name": "cage_inverted_faces",
-			"from": [15.998, 3.002, 0.002],
-			"to": [0.002, 15.998, 15.998],
-			"faces": {
-				"north": {"uv": [16, 0, 0, 13], "texture": "#front", "cullface": "north"},
-				"east": {"uv": [16, 0, 0, 13], "texture": "#side", "cullface": "west"},
-				"south": {"uv": [16, 0, 0, 13], "texture": "#side", "cullface": "south"},
-				"west": {"uv": [16, 0, 0, 13], "texture": "#side", "cullface": "east"},
-				"up": {"uv": [16, 0, 0, 16], "texture": "#top", "cullface": "up"},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#bottom"}
-			}
-		}
-	]
+    "parent": "block/block",
+    "textures": {
+        "particle": "#side"
+    },
+    "elements": [
+        {
+            "name": "cage",
+            "from": [ 0, 0, 0 ],
+            "to": [ 16, 16, 16 ],
+            "faces": {
+                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#front", "cullface": "north" },
+                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "east" },
+                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "south" },
+                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "west" },
+                "up": { "uv": [ 0, 0, 16, 16 ], "texture": "#top", "cullface": "up" },
+                "down": { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom", "cullface": "down" }
+            }
+        },
+        {
+            "name": "cage_inverted_faces",
+            "from": [ 15.998, 3.002, 0.002 ],
+            "to": [ 0.002, 15.998, 15.998 ],
+            "faces": {
+                "north": { "uv": [ 16, 0, 0, 13 ], "texture": "#front", "cullface": "north" },
+                "east": { "uv": [ 16, 0, 0, 13 ], "texture": "#side", "cullface": "west" },
+                "south": { "uv": [ 16, 0, 0, 13 ], "texture": "#side", "cullface": "south" },
+                "west": { "uv": [ 16, 0, 0, 13 ], "texture": "#side", "cullface": "east" },
+                "up": { "uv": [ 16, 0, 0, 16 ], "texture": "#top", "cullface": "up" },
+                "down": { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom" }
+            }
+        }
+    ]
 }

--- a/common/src/main/resources/assets/minecraft/models/block/template_vault.json
+++ b/common/src/main/resources/assets/minecraft/models/block/template_vault.json
@@ -1,0 +1,1 @@
+again, I should know better, but it's what it's


### PR DESCRIPTION
This changes spawners, trial spawners and vaults:
- The cullface that spawners use is misconfigured, such that north and south occlusions cull the opposite face rather than the touching face, unlike the other two axes which behave as expected (https://bugs.mojang.com/browse/MC-266463).
- Vaults do not cull their insides at all in vanilla (https://bugs.mojang.com/browse/MC-268242), so I've defined face culling for these as well to be consistent with spawners.

Putting these in a separate PR from optimizations as these do in fact change how vanilla looks in a survival environment.