### PR TITLE
Fix Section Sorting by Using the Correct Section Coordinate

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/ChunkRenderList.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/ChunkRenderList.java
@@ -4,10 +4,10 @@ import net.caffeinemc.mods.sodium.client.render.chunk.LocalSectionIndex;
 import net.caffeinemc.mods.sodium.client.render.chunk.RenderSection;
 import net.caffeinemc.mods.sodium.client.render.chunk.RenderSectionFlags;
 import net.caffeinemc.mods.sodium.client.render.chunk.region.RenderRegion;
-import net.caffeinemc.mods.sodium.client.render.viewport.CameraTransform;
 import net.caffeinemc.mods.sodium.client.util.iterator.ByteArrayIterator;
 import net.caffeinemc.mods.sodium.client.util.iterator.ByteIterator;
 import net.caffeinemc.mods.sodium.client.util.iterator.ReversibleByteArrayIterator;
+import net.minecraft.core.SectionPos;
 import net.minecraft.util.Mth;
 import org.jetbrains.annotations.Nullable;
 
@@ -43,10 +43,10 @@ public class ChunkRenderList {
     // clamping the relative camera position to the region bounds means there can only be very few different distances
     private static final int SORTING_HISTOGRAM_SIZE = RenderRegion.REGION_WIDTH + RenderRegion.REGION_HEIGHT + RenderRegion.REGION_LENGTH - 2;
 
-    public void sortSections(CameraTransform transform, int[] sortItems) {
-        var cameraX = Mth.clamp((transform.intX >> 4) - this.region.getChunkX(), 0, RenderRegion.REGION_WIDTH - 1);
-        var cameraY = Mth.clamp((transform.intY >> 4) - this.region.getChunkY(), 0, RenderRegion.REGION_HEIGHT - 1);
-        var cameraZ = Mth.clamp((transform.intZ >> 4) - this.region.getChunkZ(), 0, RenderRegion.REGION_LENGTH - 1);
+    public void sortSections(SectionPos cameraPos, int[] sortItems) {
+        var cameraX = Mth.clamp(cameraPos.getX() - this.region.getChunkX(), 0, RenderRegion.REGION_WIDTH - 1);
+        var cameraY = Mth.clamp(cameraPos.getY() - this.region.getChunkY(), 0, RenderRegion.REGION_HEIGHT - 1);
+        var cameraZ = Mth.clamp(cameraPos.getZ() - this.region.getChunkZ(), 0, RenderRegion.REGION_LENGTH - 1);
 
         int[] histogram = new int[SORTING_HISTOGRAM_SIZE];
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/VisibleChunkCollector.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/VisibleChunkCollector.java
@@ -8,7 +8,10 @@ import net.caffeinemc.mods.sodium.client.render.chunk.occlusion.OcclusionCuller;
 import net.caffeinemc.mods.sodium.client.render.chunk.region.RenderRegion;
 import net.caffeinemc.mods.sodium.client.render.viewport.Viewport;
 
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Queue;
 
 /**
  * The visible chunk collector is passed to the occlusion graph search culler to
@@ -67,10 +70,10 @@ public class VisibleChunkCollector implements OcclusionCuller.Visitor {
 
     public SortedRenderLists createRenderLists(Viewport viewport) {
         // sort the regions by distance to fix rare region ordering bugs
-        var transform = viewport.getTransform();
-        var cameraX = transform.intX >> (4 + RenderRegion.REGION_WIDTH_SH);
-        var cameraY = transform.intY >> (4 + RenderRegion.REGION_HEIGHT_SH);
-        var cameraZ = transform.intZ >> (4 + RenderRegion.REGION_LENGTH_SH);
+        var sectionPos = viewport.getChunkCoord();
+        var cameraX = sectionPos.getX() >> RenderRegion.REGION_WIDTH_SH;
+        var cameraY = sectionPos.getY() >> RenderRegion.REGION_HEIGHT_SH;
+        var cameraZ = sectionPos.getZ() >> RenderRegion.REGION_LENGTH_SH;
         var size = this.sortedRenderLists.size();
 
         if (sortItems.length < size) {
@@ -95,7 +98,7 @@ public class VisibleChunkCollector implements OcclusionCuller.Visitor {
         }
 
         for (var list : sorted) {
-            list.sortSections(transform, sortItems);
+            list.sortSections(sectionPos, sortItems);
         }
 
         return new SortedRenderLists(sorted);


### PR DESCRIPTION
Fix section and region sorting by using the correct section coordinate instead of the integer part of the camera transform which is incorrect near the origin.

Fixes #2918