### PR TITLE
Faster Particle & Cuboid vertex build

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/model/EntityRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/model/EntityRenderer.java
@@ -122,14 +122,27 @@ public class EntityRenderer {
     }
 
     private static void prepareVertices(PoseStack.Pose matrices, ModelCuboid cuboid) {
-        buildVertexPosition(CUBE_CORNERS[VERTEX_X1_Y1_Z1], cuboid.x1, cuboid.y1, cuboid.z1, matrices.pose());
-        buildVertexPosition(CUBE_CORNERS[VERTEX_X2_Y1_Z1], cuboid.x2, cuboid.y1, cuboid.z1, matrices.pose());
-        buildVertexPosition(CUBE_CORNERS[VERTEX_X2_Y2_Z1], cuboid.x2, cuboid.y2, cuboid.z1, matrices.pose());
-        buildVertexPosition(CUBE_CORNERS[VERTEX_X1_Y2_Z1], cuboid.x1, cuboid.y2, cuboid.z1, matrices.pose());
-        buildVertexPosition(CUBE_CORNERS[VERTEX_X1_Y1_Z2], cuboid.x1, cuboid.y1, cuboid.z2, matrices.pose());
-        buildVertexPosition(CUBE_CORNERS[VERTEX_X2_Y1_Z2], cuboid.x2, cuboid.y1, cuboid.z2, matrices.pose());
-        buildVertexPosition(CUBE_CORNERS[VERTEX_X2_Y2_Z2], cuboid.x2, cuboid.y2, cuboid.z2, matrices.pose());
-        buildVertexPosition(CUBE_CORNERS[VERTEX_X1_Y2_Z2], cuboid.x1, cuboid.y2, cuboid.z2, matrices.pose());
+        Matrix4f pose = matrices.pose();
+
+        // Build a Cube from a Vertex and 3 Vectors
+        // The first vertex
+        CUBE_CORNERS[VERTEX_X1_Y1_Z1].x = MatrixHelper.transformPositionX(pose, cuboid.x1, cuboid.y1, cuboid.z1);
+        CUBE_CORNERS[VERTEX_X1_Y1_Z1].y = MatrixHelper.transformPositionY(pose, cuboid.x1, cuboid.y1, cuboid.z1);
+        CUBE_CORNERS[VERTEX_X1_Y1_Z1].z = MatrixHelper.transformPositionZ(pose, cuboid.x1, cuboid.y1, cuboid.z1);
+
+        // The rotated vectors
+        float vxx = pose.m00() * cuboid.sizeX, vxy = pose.m01() * cuboid.sizeX, vxz = pose.m02() * cuboid.sizeX;
+        float vyx = pose.m10() * cuboid.sizeY, vyy = pose.m11() * cuboid.sizeY, vyz = pose.m12() * cuboid.sizeY;
+        float vzx = pose.m20() * cuboid.sizeZ, vzy = pose.m21() * cuboid.sizeZ, vzz = pose.m22() * cuboid.sizeZ;
+
+        // Last 7 vertices are calculated from the first one
+        CUBE_CORNERS[VERTEX_X1_Y1_Z1].add(vxx, vxy, vxz, CUBE_CORNERS[VERTEX_X2_Y1_Z1]);
+        CUBE_CORNERS[VERTEX_X2_Y1_Z1].add(vyx, vyy, vyz, CUBE_CORNERS[VERTEX_X2_Y2_Z1]);
+        CUBE_CORNERS[VERTEX_X1_Y1_Z1].add(vyx, vyy, vyz, CUBE_CORNERS[VERTEX_X1_Y2_Z1]);
+        CUBE_CORNERS[VERTEX_X1_Y1_Z1].add(vzx, vzy, vzz, CUBE_CORNERS[VERTEX_X1_Y1_Z2]);
+        CUBE_CORNERS[VERTEX_X2_Y1_Z1].add(vzx, vzy, vzz, CUBE_CORNERS[VERTEX_X2_Y1_Z2]);
+        CUBE_CORNERS[VERTEX_X2_Y1_Z2].add(vyx, vyy, vyz, CUBE_CORNERS[VERTEX_X2_Y2_Z2]);
+        CUBE_CORNERS[VERTEX_X1_Y1_Z2].add(vyx, vyy, vyz, CUBE_CORNERS[VERTEX_X1_Y2_Z2]);
 
         buildVertexTexCoord(VERTEX_TEXTURES[FACE_NEG_Y], cuboid.u1, cuboid.v0, cuboid.u2, cuboid.v1);
         buildVertexTexCoord(VERTEX_TEXTURES[FACE_POS_Y], cuboid.u2, cuboid.v1, cuboid.u3, cuboid.v0);
@@ -158,12 +171,6 @@ public class EntityRenderer {
             CUBE_NORMALS_MIRRORED[FACE_POS_X] = CUBE_NORMALS[FACE_NEG_X]; // mirrored
             CUBE_NORMALS_MIRRORED[FACE_NEG_X] = CUBE_NORMALS[FACE_POS_X]; // mirrored
         }
-    }
-
-    private static void buildVertexPosition(Vector3f vector, float x, float y, float z, Matrix4f matrix) {
-        vector.x = MatrixHelper.transformPositionX(matrix, x, y, z);
-        vector.y = MatrixHelper.transformPositionY(matrix, x, y, z);
-        vector.z = MatrixHelper.transformPositionZ(matrix, x, y, z);
     }
 
     private static void buildVertexTexCoord(Vector2f[] uvs, float u1, float v1, float u2, float v2) {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/model/ModelCuboid.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/model/ModelCuboid.java
@@ -43,6 +43,7 @@ public class ModelCuboid {
 
         if (mirror) {
             x1 += extraSizeX;
+            extraSizeX = -extraSizeX;
         }
 
         this.x1 = x1 / 16.0f;

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/model/ModelCuboid.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/model/ModelCuboid.java
@@ -1,6 +1,7 @@
 package net.caffeinemc.mods.sodium.client.render.immediate.model;
 
 import java.util.Set;
+
 import net.minecraft.core.Direction;
 import org.jetbrains.annotations.NotNull;
 
@@ -16,7 +17,7 @@ public class ModelCuboid {
             FACE_POS_Z = 5; // SOUTH
 
     public final float x1, y1, z1;
-    public final float x2, y2, z2;
+    public final float sizeX, sizeY, sizeZ;
 
     public final float u0, u1, u2, u3, u4, u5;
     public final float v0, v1, v2;
@@ -32,31 +33,25 @@ public class ModelCuboid {
                        boolean mirror,
                        float textureWidth, float textureHeight,
                        Set<Direction> renderDirections) {
-        float x2 = x1 + sizeX;
-        float y2 = y1 + sizeY;
-        float z2 = z1 + sizeZ;
-
         x1 -= extraX;
         y1 -= extraY;
         z1 -= extraZ;
 
-        x2 += extraX;
-        y2 += extraY;
-        z2 += extraZ;
+        float extraSizeX = sizeX + extraX + extraX;
+        float extraSizeY = sizeY + extraY + extraY;
+        float extraSizeZ = sizeZ + extraZ + extraZ;
 
         if (mirror) {
-            float tmp = x2;
-            x2 = x1;
-            x1 = tmp;
+            x1 += extraSizeX;
         }
 
         this.x1 = x1 / 16.0f;
         this.y1 = y1 / 16.0f;
         this.z1 = z1 / 16.0f;
 
-        this.x2 = x2 / 16.0f;
-        this.y2 = y2 / 16.0f;
-        this.z2 = z2 / 16.0f;
+        this.sizeX = extraSizeX / 16.0f;
+        this.sizeY = extraSizeY / 16.0f;
+        this.sizeZ = extraSizeZ / 16.0f;
 
         var scaleU = 1.0f / textureWidth;
         var scaleV = 1.0f / textureHeight;

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/particle/SingleQuadParticleMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/particle/SingleQuadParticleMixin.java
@@ -1,12 +1,17 @@
 package net.caffeinemc.mods.sodium.mixin.features.render.particle;
 
+import net.caffeinemc.mods.sodium.api.vertex.buffer.VertexBufferWriter;
 import net.caffeinemc.mods.sodium.api.vertex.format.common.ParticleVertex;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.caffeinemc.mods.sodium.api.util.ColorABGR;
 import net.caffeinemc.mods.sodium.client.render.vertex.VertexConsumerUtils;
+import net.minecraft.client.Camera;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.Particle;
 import net.minecraft.client.particle.SingleQuadParticle;
+import net.minecraft.util.Mth;
+import net.minecraft.world.phys.Vec3;
+import org.joml.Math;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 import org.lwjgl.system.MemoryStack;
@@ -38,12 +43,13 @@ public abstract class SingleQuadParticleMixin extends Particle {
         super(level, x, y, z);
     }
 
+
     /**
-     * @reason Optimize function
-     * @author JellySquid
+     * @reason Build vertex data using the left and up vectors to avoid quaternion calculations
+     * @author MoePus
      */
-    @Inject(method = "renderRotatedQuad(Lcom/mojang/blaze3d/vertex/VertexConsumer;Lorg/joml/Quaternionf;FFFF)V", at = @At("HEAD"), cancellable = true)
-    protected void renderRotatedQuad(VertexConsumer vertexConsumer, Quaternionf quaternionf, float x, float y, float z, float tickDelta, CallbackInfo ci) {
+    @Inject(method = "render(Lcom/mojang/blaze3d/vertex/VertexConsumer;Lnet/minecraft/client/Camera;F)V", at = @At("HEAD"), cancellable = true)
+    protected void render(VertexConsumer vertexConsumer, Camera camera, float tickDelta, CallbackInfo ci) {
         final var writer = VertexConsumerUtils.convertOrLog(vertexConsumer);
 
         if (writer == null) {
@@ -53,45 +59,76 @@ public abstract class SingleQuadParticleMixin extends Particle {
         ci.cancel();
 
         float size = this.getQuadSize(tickDelta);
+        Vec3 position = camera.getPosition();
+        Vector3f left = new Vector3f(camera.getLeftVector()).mul(size);
+        Vector3f up = new Vector3f(camera.getUpVector()).mul(size);
+        if (this.roll != 0.0F) {
+            float roll = Mth.lerp(tickDelta, this.oRoll, this.roll);
+            float sinRoll = Math.sin(roll);
+            float cosRoll = Math.cosFromSin(sinRoll, roll);
+
+            float rv1x = Math.fma(cosRoll, left.x, sinRoll * up.x),
+                    rv1y = Math.fma(cosRoll, left.y, sinRoll * up.y),
+                    rv1z = Math.fma(cosRoll, left.z, sinRoll * up.z);
+            float rv2x = Math.fma(-sinRoll, left.x, cosRoll * up.x),
+                    rv2y = Math.fma(-sinRoll, left.y, cosRoll * up.y),
+                    rv2z = Math.fma(-sinRoll, left.z, cosRoll * up.z);
+            left.set(rv1x, rv1y, rv1z);
+            up.set(rv2x, rv2y, rv2z);
+        }
+
+        sodium$emitVertices(writer, position, left, up, tickDelta);
+    }
+
+    /**
+     * @reason Optimize function
+     * @author JellySquid
+     */
+    @Inject(method = "renderRotatedQuad(Lcom/mojang/blaze3d/vertex/VertexConsumer;Lnet/minecraft/client/Camera;Lorg/joml/Quaternionf;F)V", at = @At("HEAD"), cancellable = true)
+    protected void renderRotatedQuad(VertexConsumer vertexConsumer, Camera camera, Quaternionf quaternionf, float tickDelta, CallbackInfo ci) {
+        final var writer = VertexConsumerUtils.convertOrLog(vertexConsumer);
+
+        if (writer == null) {
+            return;
+        }
+
+        ci.cancel();
+
+        float size = this.getQuadSize(tickDelta);
+        Vec3 position = camera.getPosition();
+        Vector3f left = new Vector3f(-size, 0, 0).rotate(quaternionf);
+        Vector3f up = new Vector3f(0, size, 0).rotate(quaternionf);
+
+        sodium$emitVertices(writer, position, left, up, tickDelta);
+    }
+
+    @Unique
+    private void sodium$emitVertices(VertexBufferWriter writer, Vec3 position, Vector3f left, Vector3f up, float tickDelta) {
         float minU = this.getU0();
         float maxU = this.getU1();
         float minV = this.getV0();
         float maxV = this.getV1();
         int light = this.getLightColor(tickDelta);
-
         int color = ColorABGR.pack(this.rCol, this.gCol, this.bCol, this.alpha);
-
+        float x = (float) (Mth.lerp(tickDelta, this.xo, this.x) - position.x());
+        float y = (float) (Mth.lerp(tickDelta, this.yo, this.y) - position.y());
+        float z = (float) (Mth.lerp(tickDelta, this.zo, this.z) - position.z());
         try (MemoryStack stack = MemoryStack.stackPush()) {
             long buffer = stack.nmalloc(4 * ParticleVertex.STRIDE);
             long ptr = buffer;
 
-            this.sodium$writeVertex(ptr, quaternionf, x, y, z, 1.0F, -1.0F, size, maxU, maxV, color, light);
+            ParticleVertex.put(ptr, -left.x - up.x + x, -left.y - up.y + y, -left.z - up.z + z, maxU, maxV, color, light);
             ptr += ParticleVertex.STRIDE;
 
-            this.sodium$writeVertex(ptr, quaternionf, x, y, z, 1.0F, 1.0F, size, maxU, minV, color, light);
+            ParticleVertex.put(ptr, -left.x + up.x + x, -left.y + up.y + y, -left.z + up.z + z, maxU, minV, color, light);
             ptr += ParticleVertex.STRIDE;
 
-            this.sodium$writeVertex(ptr, quaternionf, x, y, z, -1.0F, 1.0F, size, minU, minV, color, light);
+            ParticleVertex.put(ptr, left.x + up.x + x, left.y + up.y + y, left.z + up.z + z, minU, minV, color, light);
             ptr += ParticleVertex.STRIDE;
 
-            this.sodium$writeVertex(ptr, quaternionf, x, y, z, -1.0F, -1.0F, size, minU, maxV, color, light);
-            ptr += ParticleVertex.STRIDE;
+            ParticleVertex.put(ptr, left.x - up.x + x, left.y - up.y + y, left.z - up.z + z, minU, maxV, color, light);
 
             writer.push(stack, buffer, 4, ParticleVertex.FORMAT);
         }
-    }
-
-    @Unique
-    private final Vector3f sodium$scratchVertex = new Vector3f(); // not thread-safe
-
-    @Unique
-    private void sodium$writeVertex(long ptr, Quaternionf quaternionf, float originX, float originY, float originZ, float posX, float posY, float size, float u, float v, int color, int light) {
-        final var vertex = this.sodium$scratchVertex;
-        vertex.set(posX, posY, 0.0f);
-        vertex.rotate(quaternionf);
-        vertex.mul(size);
-        vertex.add(originX, originY, originZ);
-
-        ParticleVertex.put(ptr, vertex.x(), vertex.y(), vertex.z(), u, v, color, light);
     }
 }


### PR DESCRIPTION
For particles: use camera's left vector and up vector to build vertices to avoid Quat transfroms.
For cuboids: use vectors to calc vertices to avoid some muls