### PR TITLE
Fix Maven Publishing ArifactId

### DIFF
--- a/buildSrc/src/main/kotlin/multiloader-platform.gradle.kts
+++ b/buildSrc/src/main/kotlin/multiloader-platform.gradle.kts
@@ -34,7 +34,7 @@ publishing {
     publications {
         create<MavenPublication>("maven") {
             groupId = project.group as String
-            artifactId = project.name as String
+            artifactId = rootProject.name + "-" + project.name
             version = version
 
             from(components["java"])


### PR DESCRIPTION
Change maven publishing artifact id to be of the form `sodium-platform-version` instead of just `fabric-version`