### PR TITLE
Fix draw batch caching missing some chunks because of incomplete cache invalidation

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/VisibleChunkCollector.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/VisibleChunkCollector.java
@@ -97,8 +97,9 @@ public class VisibleChunkCollector implements OcclusionCuller.Visitor {
             sorted.add(renderList);
         }
 
+        // sort sections and invalidate batch caches if the render lists changed
         for (var list : sorted) {
-            list.sortSections(sectionPos, sortItems);
+            list.prepareForRender(sectionPos, sortItems);
         }
 
         return new SortedRenderLists(sorted);

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/region/RenderRegion.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/region/RenderRegion.java
@@ -131,18 +131,15 @@ public class RenderRegion {
     }
 
     public void clearCachedBatchFor(TerrainRenderPass pass) {
-        var batch = this.cachedBatches.remove(pass);
+        var batch = this.cachedBatches.get(pass);
         if (batch != null) {
-            batch.delete();
+            batch.clear();
         }
     }
 
     public MultiDrawBatch getCachedBatch(TerrainRenderPass pass) {
         MultiDrawBatch batch = this.cachedBatches.get(pass);
         if (batch != null) {
-            if (this.renderList.getAndResetCacheInvalidation()) {
-                batch.clear();
-            }
             return batch;
         }
 


### PR DESCRIPTION
Also generally improves the way the batch cache is invalidated and drastically improves cache hit rates during movement.