### PR TITLE
Fix Local Indexing Flag Overwriting

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/data/SectionRenderDataUnsafe.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/data/SectionRenderDataUnsafe.java
@@ -86,7 +86,10 @@ public class SectionRenderDataUnsafe {
     }
 
     public static void setFacingList(long ptr, long facingList) {
+        // rescue and re-write the local indexing flag to prevent it from being lost when a whole long is written for the facing list
+        byte isLocalIndexByte = MemoryUtil.memGetByte(ptr + OFFSET_IS_LOCAL_INDEX);
         MemoryUtil.memPutLong(ptr + OFFSET_FACING_LIST, facingList);
+        MemoryUtil.memPutByte(ptr + OFFSET_IS_LOCAL_INDEX, isLocalIndexByte);
     }
 
     public static long getFacingList(long ptr) {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/SortType.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/SortType.java
@@ -3,6 +3,8 @@ package net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting;
 /**
  * What type of sorting to use for a section. Calculated by a heuristic after
  * building a section.
+ *
+ * Invariant: !(needsDirectionMixing && allowSliceReordering)
  */
 public enum SortType {
     /**
@@ -21,39 +23,34 @@ public enum SortType {
     NONE(false, true),
 
     /**
-     * There is only one sort order. No active sorting is required, but an initial
+     * There is only one sort order. No active sorting is required, except for an initial
      * sort where quads of each facing are sorted according to their distances in
      * regard to their normal.
-     * 
-     * Currently assumes that there are no UNASSIGNED quads present. If this
-     * changes, remove this note and adjust StaticTranslucentData and anything that
-     * reads from it to handle UNASSIGNED quads.
      */
-    STATIC_NORMAL_RELATIVE(false),
+    STATIC_NORMAL_RELATIVE(false, false),
 
     /**
      * There is only one sort order and not active sorting is required, but
      * determining the static sort order involves doing a toplogical sort of the
      * quads.
      */
-    STATIC_TOPO(true),
+    STATIC_TOPO(true, false),
 
     /**
      * There are multiple sort orders. Sorting is required every time GFNI triggers
      * this section.
      */
-    DYNAMIC(true);
+    DYNAMIC(true, false);
 
     public final boolean needsDirectionMixing;
     public final boolean allowSliceReordering;
 
-    SortType(boolean needsDirectionMixing) {
-        this.needsDirectionMixing = needsDirectionMixing;
-        this.allowSliceReordering = false;
-    }
-
     SortType(boolean needsDirectionMixing, boolean allowSliceReordering) {
         this.needsDirectionMixing = needsDirectionMixing;
         this.allowSliceReordering = allowSliceReordering;
+
+        if (needsDirectionMixing && allowSliceReordering) {
+            throw new IllegalArgumentException("Invalid sort type");
+        }
     }
 }


### PR DESCRIPTION
Sections that don't upload another index buffer but change their vertex data inadvertently overwrite the flag that signals whether they use local or shared indexing, which led to visual corruption.
Also fixed the documentation in `SortType`.