### PR TITLE
Fix Missed Sort From Combined Rebuild Task

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/ChunkUpdateType.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/ChunkUpdateType.java
@@ -3,30 +3,58 @@ package net.caffeinemc.mods.sodium.client.render.chunk;
 import net.caffeinemc.mods.sodium.client.render.chunk.compile.executor.ChunkBuilder;
 
 public enum ChunkUpdateType {
-    SORT(Integer.MAX_VALUE, ChunkBuilder.LOW_EFFORT),
-    INITIAL_BUILD(128, ChunkBuilder.HIGH_EFFORT),
-    REBUILD(Integer.MAX_VALUE, ChunkBuilder.HIGH_EFFORT),
-    IMPORTANT_REBUILD(Integer.MAX_VALUE, ChunkBuilder.HIGH_EFFORT),
-    IMPORTANT_SORT(Integer.MAX_VALUE, ChunkBuilder.LOW_EFFORT);
+    SORT(ChunkUpdateType.TYPE_SORT, Integer.MAX_VALUE, ChunkBuilder.LOW_EFFORT),
+    REBUILD(ChunkUpdateType.TYPE_REBUILD, Integer.MAX_VALUE, ChunkBuilder.HIGH_EFFORT),
+    REBUILD_WITH_SORT(ChunkUpdateType.TYPE_SORT | ChunkUpdateType.TYPE_REBUILD, Integer.MAX_VALUE, ChunkBuilder.HIGH_EFFORT),
+    IMPORTANT_SORT(ChunkUpdateType.TYPE_SORT | ChunkUpdateType.TYPE_IMPORTANT, Integer.MAX_VALUE, ChunkBuilder.LOW_EFFORT),
+    IMPORTANT_REBUILD(ChunkUpdateType.TYPE_REBUILD | ChunkUpdateType.TYPE_IMPORTANT, Integer.MAX_VALUE, ChunkBuilder.HIGH_EFFORT),
+    IMPORTANT_REBUILD_WITH_SORT(ChunkUpdateType.TYPE_IMPORTANT | ChunkUpdateType.TYPE_SORT | ChunkUpdateType.TYPE_REBUILD, Integer.MAX_VALUE, ChunkBuilder.HIGH_EFFORT),
+    INITIAL_BUILD(ChunkUpdateType.TYPE_INITIAL_REBUILD, 128, ChunkBuilder.HIGH_EFFORT);
 
+    private static final int TYPE_SORT = 0b001;
+    private static final int TYPE_REBUILD = 0b010;
+    private static final int TYPE_IMPORTANT = 0b100;
+    private static final int TYPE_INITIAL_REBUILD = 0b1111;
+
+    private final int typeFlags;
     private final int maximumQueueSize;
     private final int taskEffort;
 
-    ChunkUpdateType(int maximumQueueSize, int taskEffort) {
+    ChunkUpdateType(int typeFlags, int maximumQueueSize, int taskEffort) {
+        this.typeFlags = typeFlags;
         this.maximumQueueSize = maximumQueueSize;
         this.taskEffort = taskEffort;
     }
 
-    public static ChunkUpdateType getPromotionUpdateType(ChunkUpdateType prev, ChunkUpdateType next) {
-        if (prev == null || prev == SORT || prev == next) {
-            return next;
+    public static ChunkUpdateType getPromotedUpdateType(ChunkUpdateType prev, ChunkUpdateType next) {
+        var joined = joinTypes(prev, next);
+        if (joined == prev) {
+            return null;
         }
-        if (next == IMPORTANT_REBUILD
-                || (prev == IMPORTANT_SORT && next == REBUILD)
-                || (prev == REBUILD && next == IMPORTANT_SORT)) {
-            return IMPORTANT_REBUILD;
+        return joined;
+    }
+
+    private static ChunkUpdateType joinTypes(ChunkUpdateType a, ChunkUpdateType b) {
+        if (a == b) {
+            return a;
         }
-        return null;
+        if (a == null) {
+            return b;
+        }
+        if (b == null) {
+            return a;
+        }
+
+        return switch (a.typeFlags | b.typeFlags) {
+            case TYPE_INITIAL_REBUILD -> INITIAL_BUILD;
+            case TYPE_SORT -> SORT;
+            case TYPE_REBUILD -> REBUILD;
+            case TYPE_SORT | TYPE_REBUILD -> REBUILD_WITH_SORT;
+            case TYPE_SORT | TYPE_IMPORTANT -> IMPORTANT_SORT;
+            case TYPE_REBUILD | TYPE_IMPORTANT -> IMPORTANT_REBUILD;
+            case TYPE_SORT | TYPE_REBUILD | TYPE_IMPORTANT -> IMPORTANT_REBUILD_WITH_SORT;
+            default -> throw new IllegalStateException("Unexpected value: " + (a.typeFlags | b.typeFlags));
+        };
     }
 
     public int getMaximumQueueSize() {
@@ -34,7 +62,11 @@ public enum ChunkUpdateType {
     }
 
     public boolean isImportant() {
-        return this == IMPORTANT_REBUILD || this == IMPORTANT_SORT;
+        return this == IMPORTANT_REBUILD || this == IMPORTANT_SORT || this == IMPORTANT_REBUILD_WITH_SORT;
+    }
+
+    public boolean isRebuildWithSort() {
+        return this == REBUILD_WITH_SORT || this == IMPORTANT_REBUILD_WITH_SORT;
     }
 
     public int getTaskEffort() {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -460,7 +460,7 @@ public class RenderSectionManager {
 
             // stop if the section is in this list but doesn't have this update type
             var pendingUpdate = section.getPendingUpdate();
-            if (pendingUpdate != null && pendingUpdate != type) {
+            if (pendingUpdate != type) {
                 continue;
             }
 
@@ -472,6 +472,7 @@ public class RenderSectionManager {
                 if (task == null) {
                     // when a sort task is null it means the render section has no dynamic data and
                     // doesn't need to be sorted. Nothing needs to be done.
+                    section.setPendingUpdate(null);
                     continue;
                 }
             } else {
@@ -505,6 +506,12 @@ public class RenderSectionManager {
 
             section.setLastSubmittedFrame(frame);
             section.setPendingUpdate(null);
+        }
+        
+        // if the queue is not empty that means there's still sections with tasks that haven't been processed,
+        // since tasks lists are flushed every frame, the graph needs to remain dirty so that they get processed in the next frame
+        if (!queue.isEmpty()) {
+            this.markGraphDirty();
         }
     }
 
@@ -588,6 +595,9 @@ public class RenderSectionManager {
             if (pendingUpdate != null) {
                 section.setPendingUpdate(pendingUpdate);
                 section.prepareTrigger(isDirectTrigger);
+
+                // update graph to pick up the sort task on this section
+                this.needsGraphUpdate = true;
             }
         }
     }
@@ -612,7 +622,7 @@ public class RenderSectionManager {
             if (pendingUpdate != null) {
                 section.setPendingUpdate(pendingUpdate);
 
-                // force update to schedule rebuild task on this section
+                // update graph to pick up the rebuild task on this section
                 this.needsGraphUpdate = true;
             }
         }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderMeshingTask.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderMeshingTask.java
@@ -52,10 +52,12 @@ import java.util.Map;
  */
 public class ChunkBuilderMeshingTask extends ChunkBuilderTask<ChunkBuildOutput> {
     private final ChunkRenderContext renderContext;
+    private final boolean forceSort;
 
-    public ChunkBuilderMeshingTask(RenderSection render, int buildTime, Vector3dc absoluteCameraPos, ChunkRenderContext renderContext) {
+    public ChunkBuilderMeshingTask(RenderSection render, int buildTime, Vector3dc absoluteCameraPos, ChunkRenderContext renderContext, boolean forceSort) {
         super(render, buildTime, absoluteCameraPos);
         this.renderContext = renderContext;
+        this.forceSort = forceSort;
     }
 
     @Override
@@ -197,7 +199,7 @@ public class ChunkBuilderMeshingTask extends ChunkBuilderTask<ChunkBuildOutput> 
             var oldData = this.render.getTranslucentData();
             translucentData = collector.getTranslucentData(
                     oldData, meshes.get(DefaultTerrainRenderPasses.TRANSLUCENT), this);
-            reuseUploadedData = translucentData == oldData;
+            reuseUploadedData = !this.forceSort && translucentData == oldData;
         }
 
         var output = new ChunkBuildOutput(this.render, this.submitTime, translucentData, renderData.build(), meshes);

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/VisibleChunkCollector.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/VisibleChunkCollector.java
@@ -57,7 +57,11 @@ public class VisibleChunkCollector implements OcclusionCuller.Visitor {
     private void addToRebuildLists(RenderSection section) {
         ChunkUpdateType type = section.getPendingUpdate();
 
-        if (type != null && section.getTaskCancellationToken() == null) {
+        // if there's a pending update, add this section to the rebuild lists.
+        // this happens even if there's already a pending task,
+        // because that pending task may have been scheduled for an older version of the chunk,
+        // and it has since been marked as needing another update.
+        if (type != null) {
             Queue<RenderSection> queue = this.sortedRebuildLists.get(type);
 
             if (queue.size() < type.getMaximumQueueSize()) {


### PR DESCRIPTION
Fix a bug where sections that have a pending sort task don't get sorted when the sort type gets updated to rebuild but then the rebuild task may not do any sorting because it can reuse already uploaded index data.

This changes chunk update types to add an option for rebuilding with forced sorting, which is used as the combined task type when sorting and rebuilding tasks are combined. A caveat is that this expands the ChunkUpdateType by two members, which means there are also more task lists, but it's largely unproblematic as this combined update type will only get used occasionally.

The way ChunkUpdateType calculates joined types is also more straightforward now.