### PR TITLE
Fix Translucency Sort Triggering at Very High Camera Coordinates

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/trigger/NormalList.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/trigger/NormalList.java
@@ -6,6 +6,7 @@ import it.unimi.dsi.fastutil.objects.Object2ReferenceOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ReferenceArraySet;
 import it.unimi.dsi.fastutil.objects.ReferenceLinkedOpenHashSet;
 import net.caffeinemc.mods.sodium.client.model.quad.properties.ModelQuadFacing;
+import net.caffeinemc.mods.sodium.client.util.MathUtil;
 import net.caffeinemc.mods.sodium.client.util.interval_tree.DoubleInterval;
 import net.caffeinemc.mods.sodium.client.util.interval_tree.Interval;
 import net.caffeinemc.mods.sodium.client.util.interval_tree.Interval.Bounded;
@@ -58,8 +59,8 @@ public class NormalList {
     /**
      * Constructs a new normal list with the given unit normal vector and aligned
      * normal index.
-     * 
-     * @param normal       The unit normal vector
+     *
+     * @param normal The unit normal vector
      */
     NormalList(Vector3fc normal, int alignedDirection) {
         this.normal = normal;
@@ -78,18 +79,12 @@ public class NormalList {
         return this.alignedDirection;
     }
 
-    private double normalDotDouble(Vector3dc v) {
-        return org.joml.Math.fma(this.normal.x(), v.x(),
-                org.joml.Math.fma(this.normal.y(), v.y(),
-                        this.normal.z() * v.z()));
-    }
-
     void processMovement(SortTriggering ts, CameraMovement movement) {
         // calculate the distance range of the movement with respect to the normal
-        double start = this.normalDotDouble(movement.start());
-        double end = this.normalDotDouble(movement.end());
+        double start = MathUtil.floatDoubleDot(this.normal, movement.start());
+        double end = MathUtil.floatDoubleDot(this.normal, movement.end());
 
-        // stop if the movement is reverse with regards to the normal
+        // stop if the movement is reverse in regard to the normal
         // since this means it's moving against the normal
         if (start >= end) {
             return;
@@ -106,11 +101,13 @@ public class NormalList {
     }
 
     void processCatchup(SortTriggering ts, CameraMovement movement, long sectionPos) {
-        double start = this.normalDotDouble(movement.start());
-        double end = this.normalDotDouble(movement.end());
+        double start = MathUtil.floatDoubleDot(this.normal, movement.start());
+        double end = MathUtil.floatDoubleDot(this.normal, movement.end());
+
         if (start >= end) {
             return;
         }
+
         var group = this.groupsBySection.get(sectionPos);
         if (group != null) {
             group.triggerRange(ts, start, end);

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/trigger/NormalPlanes.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/trigger/NormalPlanes.java
@@ -3,6 +3,7 @@ package net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.trigg
 import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
 import it.unimi.dsi.fastutil.objects.Object2ReferenceMap;
 import net.caffeinemc.mods.sodium.client.model.quad.properties.ModelQuadFacing;
+import net.caffeinemc.mods.sodium.client.util.MathUtil;
 import net.caffeinemc.mods.sodium.client.util.interval_tree.DoubleInterval;
 import net.caffeinemc.mods.sodium.client.util.interval_tree.Interval.Bounded;
 import net.minecraft.core.SectionPos;
@@ -66,8 +67,8 @@ public class NormalPlanes {
         // sort the array ascending
         Arrays.sort(this.relativeDistances);
 
-        this.baseDistance = this.normal.dot(
-                this.sectionPos.minBlockX(), this.sectionPos.minBlockY(), this.sectionPos.minBlockZ());
+        // make sure to use double-based dot product math here to prevent incorrect sort triggering
+        this.baseDistance = MathUtil.floatDoubleDot(this.normal, this.sectionPos.minBlockX(), this.sectionPos.minBlockY(), this.sectionPos.minBlockZ());
         this.distanceRange = new DoubleInterval(
                 this.relativeDistances[0] + this.baseDistance,
                 this.relativeDistances[size - 1] + this.baseDistance,

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/util/MathUtil.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/util/MathUtil.java
@@ -1,5 +1,10 @@
 package net.caffeinemc.mods.sodium.client.util;
 
+import org.joml.Vector3dc;
+import org.joml.Vector3fc;
+
+import static org.joml.Math.fma;
+
 public class MathUtil {
     /**
      * @return True if the specified number is greater than zero and is a power of two, otherwise false
@@ -42,5 +47,13 @@ public class MathUtil {
 
     public static float comparableIntToFloat(int i) {
         return Float.intBitsToFloat(i ^ ((i >> 31) & 0x7FFFFFFF));
+    }
+
+    public static double floatDoubleDot(Vector3fc a, Vector3dc b) {
+        return fma(a.x(), b.x(), fma(a.y(), b.y(), a.z() * b.z()));
+    }
+
+    public static double floatDoubleDot(Vector3fc a, double bx, double by, double bz) {
+        return fma(a.x(), bx, fma(a.y(), by, a.z() * bz));
     }
 }


### PR DESCRIPTION
Fix translucency sort triggering at very high camera coordinates (like around 16 million) by using full double precision in the calculation of the NormalPlanes's dot product offset.