### PR TITLE
Don't crash Minecraft if detected on Pojavlauncher 

### DIFF
--- a/common/src/workarounds/java/net/caffeinemc/mods/sodium/client/compatibility/checks/PostLaunchChecks.java
+++ b/common/src/workarounds/java/net/caffeinemc/mods/sodium/client/compatibility/checks/PostLaunchChecks.java
@@ -21,7 +21,8 @@ public class PostLaunchChecks {
 
         // FIXME: This can be determined earlier, but we can't access the GUI classes in pre-launch
         if (isUsingPojavLauncher()) {
-            throw new RuntimeException("It appears that you are using PojavLauncher, which is not supported when " +
+            // Only warn the user that theyre using pojav, trowing a new error will crash their game. 
+            LOGGER.warn("It appears that you are using PojavLauncher, which is not supported when " +
                     "using Sodium. Please check your mods list.");
         }
     }


### PR DESCRIPTION
Change the code so, instead of throwing a new error which, crashes the game, only show a warning. Which, is better since, sodium is not supported but, some Pojavlauncher users are asking why their game is crashing not knowing it's from sodium. 