### PR TITLE
fix: don't show fabulous on unsupported systems

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -163,7 +163,13 @@ public class SodiumGameOptionPages {
                 .add(OptionImpl.createBuilder(GraphicsStatus.class, vanillaOpts)
                         .setName(Component.translatable("options.graphics"))
                         .setTooltip(Component.translatable("sodium.options.graphics_quality.tooltip"))
-                        .setControl(option -> new CyclingControl<>(option, GraphicsStatus.class, new Component[] { Component.translatable("options.graphics.fast"), Component.translatable("options.graphics.fancy"), Component.translatable("options.graphics.fabulous") }))
+                        .setControl(option -> {
+                            GraphicsStatus[] allowedValues = GraphicsStatus.values();
+                            if (Minecraft.getInstance().isRunning() && Minecraft.getInstance().getGpuWarnlistManager().isSkippingFabulous()) {
+                                allowedValues = new GraphicsStatus[] { GraphicsStatus.FAST, GraphicsStatus.FANCY };
+                            }
+                            return new CyclingControl<>(option, allowedValues, new Component[] { Component.translatable("options.graphics.fast"), Component.translatable("options.graphics.fancy"), Component.translatable("options.graphics.fabulous") });
+                        })
                         .setBinding(
                                 (opts, value) -> opts.graphicsMode().set(value),
                                 opts -> opts.graphicsMode().get())

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/CyclingControl.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/CyclingControl.java
@@ -50,6 +50,12 @@ public class CyclingControl<T extends Enum<T>> implements Control<T> {
         }
     }
 
+    public CyclingControl(Option<T> option, T[] allowedValues, Component[] names) {
+        this.option = option;
+        this.allowedValues = allowedValues;
+        this.names = names;
+    }
+
     @Override
     public Option<T> getOption() {
         return this.option;

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/CyclingControl.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/CyclingControl.java
@@ -36,7 +36,7 @@ public class CyclingControl<T extends Enum<T>> implements Control<T> {
         Validate.notEmpty(allowedValues, "The allowedValues array must contain at least one item");
         Validate.isTrue(Arrays.stream(allowedValues).allMatch(Objects::nonNull), "The allowedValues array must not contain null");
         Validate.isTrue(Arrays.stream(allowedValues).distinct().count() == allowedValues.length, "The allowedValues array must not contain duplicates");
-        Validate.isTrue(Arrays.stream(allowedValues).map(Enum::getDeclaringClass).distinct().count() == 1, "The allowedValues array must contain items of the same type");
+        Validate.isTrue(Arrays.stream(allowedValues).map(Enum::getDeclaringClass).allMatch(enumType::equals), "The allowedValues array must contain items of the given type");
 
         T[] universe = enumType.getEnumConstants();
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/CyclingControl.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/CyclingControl.java
@@ -9,6 +9,9 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import org.apache.commons.lang3.Validate;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 public class CyclingControl<T extends Enum<T>> implements Control<T> {
     private final Option<T> option;
     private final T[] allowedValues;
@@ -30,6 +33,11 @@ public class CyclingControl<T extends Enum<T>> implements Control<T> {
     }
 
     public CyclingControl(Option<T> option, Class<T> enumType, T[] allowedValues) {
+        Validate.notEmpty(allowedValues, "The allowedValues array must contain at least one item");
+        Validate.isTrue(Arrays.stream(allowedValues).allMatch(Objects::nonNull), "The allowedValues array must not contain null");
+        Validate.isTrue(Arrays.stream(allowedValues).distinct().count() == allowedValues.length, "The allowedValues array must not contain duplicates");
+        Validate.isTrue(Arrays.stream(allowedValues).map(Enum::getDeclaringClass).distinct().count() == 1, "The allowedValues array must contain items of the same type");
+
         T[] universe = enumType.getEnumConstants();
 
         this.option = option;
@@ -51,6 +59,15 @@ public class CyclingControl<T extends Enum<T>> implements Control<T> {
     }
 
     public CyclingControl(Option<T> option, T[] allowedValues, Component[] names) {
+        Validate.notEmpty(allowedValues, "The allowedValues array must contain at least one item");
+        Validate.isTrue(Arrays.stream(allowedValues).allMatch(Objects::nonNull), "The allowedValues array must not contain null");
+        Validate.isTrue(Arrays.stream(allowedValues).distinct().count() == allowedValues.length, "The allowedValues array must not contain duplicates");
+        Validate.isTrue(Arrays.stream(allowedValues).map(Enum::getDeclaringClass).distinct().count() == 1, "The allowedValues array must contain items of the same type");
+
+        T[] universe = allowedValues[0].getDeclaringClass().getEnumConstants();
+
+        Validate.isTrue(universe.length == names.length, "Mismatch between universe length and names array length");
+
         this.option = option;
         this.allowedValues = allowedValues;
         this.names = names;


### PR DESCRIPTION
Vanilla hides "Fabulous!" on unsupported GPU's, this simply copies the check used by vanilla.
Works correctly even when the value is set to fabulous through options.txt, the sodium menu will simply display "Fabulous!", then when pressed skip to fancy -> fast -> fancy -> fast -> ...