### PR TITLE
fix: mark sprites rendered in gui as active

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/textures/animations/tracking/GuiGraphicsMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/textures/animations/tracking/GuiGraphicsMixin.java
@@ -1,14 +1,27 @@
 package net.caffeinemc.mods.sodium.mixin.features.textures.animations.tracking;
 
-import net.caffeinemc.mods.sodium.client.render.texture.SpriteUtil;
+import net.caffeinemc.mods.sodium.api.texture.SpriteUtil;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.resources.ResourceLocation;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.function.Function;
+
 @Mixin(GuiGraphics.class)
 public class GuiGraphicsMixin {
-    // TODO 24w34a
+
+    @Inject(method = "blitSprite(Ljava/util/function/Function;Lnet/minecraft/client/renderer/texture/TextureAtlasSprite;IIIII)V", at = @At("HEAD"))
+    private void preDrawSprite(Function<ResourceLocation, RenderType> renderTypeGetter, TextureAtlasSprite sprite, int x, int y, int width, int height, int blitOffset, CallbackInfo ci) {
+        SpriteUtil.INSTANCE.markSpriteActive(sprite);
+    }
+
+    @Inject(method = "blitSprite(Ljava/util/function/Function;Lnet/minecraft/client/renderer/texture/TextureAtlasSprite;IIIIIIIII)V", at = @At("HEAD"))
+    private void preDrawSprite(Function<ResourceLocation, RenderType> renderTypeGetter, TextureAtlasSprite sprite, int textureWidth, int textureHeight, int uPosition, int vPosition, int x, int y, int uWidth, int vHeight, int blitOffset, CallbackInfo ci) {
+        SpriteUtil.INSTANCE.markSpriteActive(sprite);
+    }
 }


### PR DESCRIPTION
Fix sprites drawn through `GuiGraphics#blitSprite` not being marked as active, this seems to have been missed during a port at some point.

Closes https://github.com/CaffeineMC/sodium/issues/3058 and https://github.com/CaffeineMC/sodium/issues/3081.