### PR TITLE
fix: mark sprites wrapped in a SpriteCoordinateExpander as active

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/textures/animations/tracking/TextureAtlasSpriteMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/textures/animations/tracking/TextureAtlasSpriteMixin.java
@@ -1,0 +1,17 @@
+package net.caffeinemc.mods.sodium.mixin.features.textures.animations.tracking;
+
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.caffeinemc.mods.sodium.api.texture.SpriteUtil;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(TextureAtlasSprite.class)
+public abstract class TextureAtlasSpriteMixin {
+    @Inject(method = "wrap", at = @At("HEAD"))
+    private void markSpriteAsActive(CallbackInfoReturnable<VertexConsumer> cir) {
+        SpriteUtil.INSTANCE.markSpriteActive((TextureAtlasSprite) (Object) this);
+    }
+}

--- a/common/src/main/resources/sodium-common.mixins.json
+++ b/common/src/main/resources/sodium-common.mixins.json
@@ -76,6 +76,7 @@
     "features.textures.animations.tracking.ModelBlockRendererMixin",
     "features.textures.animations.tracking.GuiGraphicsMixin",
     "features.textures.animations.tracking.TextureAtlasMixin",
+    "features.textures.animations.tracking.TextureAtlasSpriteMixin",
     "features.textures.animations.tracking.TextureSheetParticleMixin",
     "features.textures.animations.tracking.AnimatedTextureAccessor",
     "features.textures.animations.tracking.SpriteContentsFrameInfoAccessor",


### PR DESCRIPTION
Mark sprites as active when they are wrapped in a delegate vertex consumer.
There is no case in vanilla where this sprite hasn't been marked as active yet, but it improves mod compatibility, namely Elytra Trims.

Closes https://github.com/CaffeineMC/sodium/issues/2601