### PR TITLE
fix: immediately upload sprites when they become visible again

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/texture/SpriteContentsExtension.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/texture/SpriteContentsExtension.java
@@ -5,4 +5,6 @@ public interface SpriteContentsExtension {
     boolean sodium$isActive();
 
     boolean sodium$hasAnimation();
+
+    void sodium$setTicker(TextureAtlasSpriteTickerExtension ticker);
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/texture/SpriteContentsTickerExtension.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/texture/SpriteContentsTickerExtension.java
@@ -1,0 +1,7 @@
+package net.caffeinemc.mods.sodium.client.render.texture;
+
+import net.minecraft.resources.ResourceLocation;
+
+public interface SpriteContentsTickerExtension {
+    void sodium$ensureUpload(ResourceLocation atlas, int x, int y);
+}

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/texture/TextureAtlasSpriteTickerExtension.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/texture/TextureAtlasSpriteTickerExtension.java
@@ -1,0 +1,5 @@
+package net.caffeinemc.mods.sodium.client.render.texture;
+
+public interface TextureAtlasSpriteTickerExtension {
+    void sodium$ensureUpload();
+}

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/textures/animations/tracking/AnimatedTextureAccessor.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/textures/animations/tracking/AnimatedTextureAccessor.java
@@ -5,9 +5,13 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 import java.util.List;
 import net.minecraft.client.renderer.texture.SpriteContents;
+import org.spongepowered.asm.mixin.gen.Invoker;
 
 @Mixin(SpriteContents.AnimatedTexture.class)
 public interface AnimatedTextureAccessor {
     @Accessor("frames")
-    List<SpriteContents.FrameInfo> getFrames();
+    List<SpriteContents.FrameInfo> sodium$getFrames();
+
+    @Invoker("uploadFrame")
+    void sodium$uploadFrame(int x, int y, int frameIndex);
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/textures/animations/tracking/InterpolationDataAccessor.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/textures/animations/tracking/InterpolationDataAccessor.java
@@ -1,0 +1,11 @@
+package net.caffeinemc.mods.sodium.mixin.features.textures.animations.tracking;
+
+import net.minecraft.client.renderer.texture.SpriteContents;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(SpriteContents.InterpolationData.class)
+public interface InterpolationDataAccessor {
+    @Invoker("uploadInterpolatedFrame")
+    void sodium$uploadInterpolatedFrame(int x, int y, SpriteContents.Ticker ticker);
+}

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/textures/animations/tracking/SpriteContentsMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/textures/animations/tracking/SpriteContentsMixin.java
@@ -1,6 +1,7 @@
 package net.caffeinemc.mods.sodium.mixin.features.textures.animations.tracking;
 
 import net.caffeinemc.mods.sodium.client.render.texture.SpriteContentsExtension;
+import net.caffeinemc.mods.sodium.client.render.texture.TextureAtlasSpriteTickerExtension;
 import net.minecraft.client.renderer.texture.SpriteContents;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
@@ -17,10 +18,15 @@ public abstract class SpriteContentsMixin implements SpriteContentsExtension {
 
     @Unique
     private boolean active;
+    @Unique
+    private TextureAtlasSpriteTickerExtension ticker;
 
     @Override
     public void sodium$setActive(boolean value) {
         this.active = value;
+        if (this.ticker != null && value) {
+            this.ticker.sodium$ensureUpload();
+        }
     }
 
     @Override
@@ -31,5 +37,10 @@ public abstract class SpriteContentsMixin implements SpriteContentsExtension {
     @Override
     public boolean sodium$isActive() {
         return this.active;
+    }
+
+    @Override
+    public void sodium$setTicker(TextureAtlasSpriteTickerExtension ticker) {
+        this.ticker = ticker;
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/textures/animations/tracking/SpriteContentsTickerMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/textures/animations/tracking/SpriteContentsTickerMixin.java
@@ -3,6 +3,7 @@ package net.caffeinemc.mods.sodium.mixin.features.textures.animations.tracking;
 import net.caffeinemc.mods.sodium.client.SodiumClientMod;
 import net.caffeinemc.mods.sodium.client.render.texture.SpriteContentsExtension;
 import net.minecraft.client.renderer.texture.SpriteContents;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -16,15 +17,24 @@ import java.util.List;
 @Mixin(SpriteContents.Ticker.class)
 public class SpriteContentsTickerMixin {
     @Shadow
+    int frame;
+    @Shadow
     int subFrame;
     @Shadow
     @Final
     SpriteContents.AnimatedTexture animationInfo;
     @Shadow
-    int frame;
+    @Final
+    @Nullable
+    private SpriteContents.InterpolationData interpolationData;
 
     @Unique
     private SpriteContents parent;
+
+    @Unique
+    private boolean skippedUpload;
+    @Unique
+    private int uploadedFrame;
 
     /**
      * @author IMS
@@ -36,19 +46,56 @@ public class SpriteContentsTickerMixin {
     }
 
     @Inject(method = "tickAndUpload", at = @At("HEAD"), cancellable = true)
-    private void preTick(CallbackInfo ci) {
+    private void preTick(int x, int y, CallbackInfo ci) {
         SpriteContentsExtension parent = (SpriteContentsExtension) this.parent;
 
         boolean onDemand = SodiumClientMod.options().performance.animateOnlyVisibleTextures;
 
         if (onDemand && !parent.sodium$isActive()) {
-            this.subFrame++;
-            List<SpriteContents.FrameInfo> frames = ((AnimatedTextureAccessor)this.animationInfo).getFrames();
-            if (this.subFrame >= ((SpriteContentsFrameInfoAccessor) (Object) frames.get(this.frame)).getTime()) {
-                this.frame = (this.frame + 1) % frames.size();
-                this.subFrame = 0;
+            if (!this.skippedUpload) {
+                this.uploadedFrame = this.frame;
+                this.skippedUpload = true;
             }
+            this.tickWithoutUpload();
             ci.cancel();
+            return;
+        }
+
+        // make sure image is uploaded immediately once it becomes visible again
+        // the vanilla logic would only update it on the next frame increment
+        if (this.skippedUpload) {
+            this.tickWithoutUpload();
+            this.ensureUpload(x, y);
+            this.skippedUpload = false;
+            ci.cancel();
+        }
+    }
+
+    @Unique
+    private void tickWithoutUpload() {
+        this.subFrame++;
+        List<SpriteContents.FrameInfo> frames = ((AnimatedTextureAccessor) this.animationInfo).sodium$getFrames();
+        if (this.subFrame >= ((SpriteContentsFrameInfoAccessor) (Object) frames.get(this.frame)).getTime()) {
+            this.frame = (this.frame + 1) % frames.size();
+            this.subFrame = 0;
+        }
+    }
+
+    @Unique
+    private void ensureUpload(int x, int y) {
+        List<SpriteContents.FrameInfo> frames = ((AnimatedTextureAccessor) this.animationInfo).sodium$getFrames();
+        int index = frames.get(this.frame).index();
+        if (this.interpolationData != null) {
+            if (this.subFrame == 0) {
+                ((AnimatedTextureAccessor) this.animationInfo).sodium$uploadFrame(x, y, index);
+            } else {
+                ((InterpolationDataAccessor) (Object) this.interpolationData).sodium$uploadInterpolatedFrame(x, y, (SpriteContents.Ticker) (Object) this);
+            }
+        } else {
+            int uploadedIndex = frames.get(this.uploadedFrame).index();
+            if (index != uploadedIndex) {
+                ((AnimatedTextureAccessor) this.animationInfo).sodium$uploadFrame(x, y, index);
+            }
         }
     }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/textures/animations/tracking/SpriteContentsTickerMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/textures/animations/tracking/SpriteContentsTickerMixin.java
@@ -2,7 +2,10 @@ package net.caffeinemc.mods.sodium.mixin.features.textures.animations.tracking;
 
 import net.caffeinemc.mods.sodium.client.SodiumClientMod;
 import net.caffeinemc.mods.sodium.client.render.texture.SpriteContentsExtension;
+import net.caffeinemc.mods.sodium.client.render.texture.SpriteContentsTickerExtension;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.SpriteContents;
+import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -15,7 +18,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import java.util.List;
 
 @Mixin(SpriteContents.Ticker.class)
-public class SpriteContentsTickerMixin {
+public abstract class SpriteContentsTickerMixin implements SpriteContentsTickerExtension {
     @Shadow
     int frame;
     @Shadow
@@ -56,33 +59,29 @@ public class SpriteContentsTickerMixin {
                 this.uploadedFrame = this.frame;
                 this.skippedUpload = true;
             }
-            this.tickWithoutUpload();
+            this.subFrame++;
+            List<SpriteContents.FrameInfo> frames = ((AnimatedTextureAccessor) this.animationInfo).sodium$getFrames();
+            if (this.subFrame >= ((SpriteContentsFrameInfoAccessor) (Object) frames.get(this.frame)).getTime()) {
+                this.frame = (this.frame + 1) % frames.size();
+                this.subFrame = 0;
+            }
             ci.cancel();
+        }
+    }
+
+    @Inject(method = "tickAndUpload", at = @At("TAIL"))
+    private void postTick(CallbackInfo ci) {
+        SpriteContentsExtension parent = (SpriteContentsExtension) this.parent;
+        parent.sodium$setActive(false);
+    }
+
+    @Override
+    public void sodium$ensureUpload(ResourceLocation atlas, int x, int y) {
+        if (!this.skippedUpload) {
             return;
         }
 
-        // make sure image is uploaded immediately once it becomes visible again
-        // the vanilla logic would only update it on the next frame increment
-        if (this.skippedUpload) {
-            this.tickWithoutUpload();
-            this.ensureUpload(x, y);
-            this.skippedUpload = false;
-            ci.cancel();
-        }
-    }
-
-    @Unique
-    private void tickWithoutUpload() {
-        this.subFrame++;
-        List<SpriteContents.FrameInfo> frames = ((AnimatedTextureAccessor) this.animationInfo).sodium$getFrames();
-        if (this.subFrame >= ((SpriteContentsFrameInfoAccessor) (Object) frames.get(this.frame)).getTime()) {
-            this.frame = (this.frame + 1) % frames.size();
-            this.subFrame = 0;
-        }
-    }
-
-    @Unique
-    private void ensureUpload(int x, int y) {
+        Minecraft.getInstance().getTextureManager().getTexture(atlas).bind();
         List<SpriteContents.FrameInfo> frames = ((AnimatedTextureAccessor) this.animationInfo).sodium$getFrames();
         int index = frames.get(this.frame).index();
         if (this.interpolationData != null) {
@@ -97,11 +96,6 @@ public class SpriteContentsTickerMixin {
                 ((AnimatedTextureAccessor) this.animationInfo).sodium$uploadFrame(x, y, index);
             }
         }
-    }
-
-    @Inject(method = "tickAndUpload", at = @At("TAIL"))
-    private void postTick(CallbackInfo ci) {
-        SpriteContentsExtension parent = (SpriteContentsExtension) this.parent;
-        parent.sodium$setActive(false);
+        this.skippedUpload = false;
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/textures/animations/tracking/TextureAtlasSpriteTickerImplMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/textures/animations/tracking/TextureAtlasSpriteTickerImplMixin.java
@@ -1,0 +1,33 @@
+package net.caffeinemc.mods.sodium.mixin.features.textures.animations.tracking;
+
+import net.caffeinemc.mods.sodium.client.render.texture.SpriteContentsExtension;
+import net.caffeinemc.mods.sodium.client.render.texture.SpriteContentsTickerExtension;
+import net.caffeinemc.mods.sodium.client.render.texture.TextureAtlasSpriteTickerExtension;
+import net.minecraft.client.renderer.texture.SpriteTicker;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(targets = "net/minecraft/client/renderer/texture/TextureAtlasSprite$1")
+public abstract class TextureAtlasSpriteTickerImplMixin implements TextureAtlasSpriteTickerExtension {
+    @Shadow
+    @Final
+    TextureAtlasSprite field_40555;
+    @Shadow
+    @Final
+    SpriteTicker val$ticker;
+
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void passTickerToSpriteContents(CallbackInfo ci) {
+        ((SpriteContentsExtension) this.field_40555.contents()).sodium$setTicker(this);
+    }
+
+    @Override
+    public void sodium$ensureUpload() {
+        ((SpriteContentsTickerExtension) this.val$ticker).sodium$ensureUpload(this.field_40555.atlasLocation(), this.field_40555.getX(), this.field_40555.getY());
+    }
+}

--- a/common/src/main/resources/sodium-common.mixins.json
+++ b/common/src/main/resources/sodium-common.mixins.json
@@ -77,6 +77,7 @@
     "features.textures.animations.tracking.GuiGraphicsMixin",
     "features.textures.animations.tracking.InterpolationDataAccessor",
     "features.textures.animations.tracking.TextureAtlasMixin",
+    "features.textures.animations.tracking.TextureAtlasSpriteTickerImplMixin",
     "features.textures.animations.tracking.TextureSheetParticleMixin",
     "features.textures.animations.tracking.AnimatedTextureAccessor",
     "features.textures.animations.tracking.SpriteContentsFrameInfoAccessor",

--- a/common/src/main/resources/sodium-common.mixins.json
+++ b/common/src/main/resources/sodium-common.mixins.json
@@ -75,6 +75,7 @@
     "features.textures.SpriteContentsInvoker",
     "features.textures.animations.tracking.ModelBlockRendererMixin",
     "features.textures.animations.tracking.GuiGraphicsMixin",
+    "features.textures.animations.tracking.InterpolationDataAccessor",
     "features.textures.animations.tracking.TextureAtlasMixin",
     "features.textures.animations.tracking.TextureSheetParticleMixin",
     "features.textures.animations.tracking.AnimatedTextureAccessor",


### PR DESCRIPTION
When a sprite becomes active again after skipping uploads, it won't immediately update to its correct state, instead it will only do so the next time the frame index changes.
I initially fixed this by just ensuring it will always upload the first tick after becoming active again, however that still leaves the time between being marked as active and being ticked where the texture would be wrong.
The fix for that is to ensure the upload right when the sprite is marked as active, which means we have to look up and bind the atlas texture everytime that happens. I'm unsure about the performance cost of that, if it's a problem I can revert the second commit, the first one alone is still significantly better than the current behaviour.

Closes https://github.com/CaffeineMC/sodium/issues/2514