### PR TITLE
fix: always merge lighting when writing entity vertices

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/model/BakedModelEncoder.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/model/BakedModelEncoder.java
@@ -116,7 +116,9 @@ public class BakedModelEncoder {
 
                 int color = ColorABGR.pack(fR, fG, fB, fA);
 
-                EntityVertex.write(ptr, xt, yt, zt, color, quad.getTexU(i), quad.getTexV(i), overlay, light[i], normal);
+                int newLight = mergeLighting(quad.getMaxLightQuad(i), light[i]);
+
+                EntityVertex.write(ptr, xt, yt, zt, color, quad.getTexU(i), quad.getTexV(i), overlay, newLight, normal);
                 ptr += EntityVertex.STRIDE;
             }
 


### PR DESCRIPTION
Copies the same `mergeLighting` used in the other `BakedModelEncoder#writeQuadVertices`.

Closes https://github.com/CaffeineMC/sodium/issues/3039