### PR TITLE
fix: recalculate gui scale max everytime widget is rebuilt

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -68,7 +68,7 @@ public class SodiumGameOptionPages {
                 .add(OptionImpl.createBuilder(int.class, vanillaOpts)
                         .setName(Component.translatable("options.guiScale"))
                         .setTooltip(Component.translatable("sodium.options.gui_scale.tooltip"))
-                        .setControl(option -> new SliderControl(option, 0, Minecraft.getInstance().getWindow().calculateScale(0, Minecraft.getInstance().isEnforceUnicode()), 1, ControlValueFormatter.guiScale()))
+                        .setControl(option -> new DynamicMaxSliderControl(option, 0, () -> Minecraft.getInstance().getWindow().calculateScale(0, Minecraft.getInstance().isEnforceUnicode()), 1, ControlValueFormatter.guiScale()))
                         .setBinding((opts, value) -> {
                             opts.guiScale().set(value);
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/DynamicMaxSliderControl.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/DynamicMaxSliderControl.java
@@ -1,0 +1,49 @@
+package net.caffeinemc.mods.sodium.client.gui.options.control;
+
+import net.caffeinemc.mods.sodium.client.gui.options.Option;
+import net.caffeinemc.mods.sodium.client.util.Dim2i;
+import org.apache.commons.lang3.Validate;
+
+import java.util.function.IntSupplier;
+
+public class DynamicMaxSliderControl implements Control<Integer> {
+    private final Option<Integer> option;
+
+    private final IntSupplier max;
+    private final int min, interval;
+
+    private final ControlValueFormatter mode;
+
+    public DynamicMaxSliderControl(Option<Integer> option, int min, IntSupplier max, int interval, ControlValueFormatter mode) {
+        Validate.isTrue(interval > 0, "The slider interval must be greater than zero");
+        Validate.notNull(mode, "The slider mode must not be null");
+
+        this.option = option;
+        this.min = min;
+        this.max = max;
+        this.interval = interval;
+        this.mode = mode;
+    }
+
+    @Override
+    public ControlElement<Integer> createElement(Dim2i dim) {
+        int min = this.min;
+        int max = this.max.getAsInt();
+        int interval = this.interval;
+
+        Validate.isTrue(max > min, "The maximum value must be greater than the minimum value");
+        Validate.isTrue(((max - min) % interval) == 0, "The maximum value must be divisable by the interval");
+
+        return new SliderControl.Button(this.option, dim, min, max, interval, this.mode);
+    }
+
+    @Override
+    public Option<Integer> getOption() {
+        return this.option;
+    }
+
+    @Override
+    public int getMaxWidth() {
+        return 170;
+    }
+}

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/SliderControl.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/SliderControl.java
@@ -45,7 +45,7 @@ public class SliderControl implements Control<Integer> {
         return 170;
     }
 
-    private static class Button extends ControlElement<Integer> {
+    static class Button extends ControlElement<Integer> {
         private static final int THUMB_WIDTH = 2, TRACK_HEIGHT = 1;
 
         private final Rect2i sliderBounds;


### PR DESCRIPTION
Pass an `IntSupplier` instead of `int max` that is called everytime a new widget is created. This will update to the new max gui scale after resizing.

Closes https://github.com/CaffeineMC/sodium/issues/2951