### PR TITLE
Fix performance regressions with buffer uploads in 1.21.5

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -50,8 +50,8 @@ dependencies {
         }
     })
 
-    compileOnly("io.github.llamalad7:mixinextras-common:0.3.5")
-    annotationProcessor("io.github.llamalad7:mixinextras-common:0.3.5")
+    compileOnly("io.github.llamalad7:mixinextras-common:0.4.1")
+    annotationProcessor("io.github.llamalad7:mixinextras-common:0.4.1")
 
     compileOnly("net.fabricmc:sponge-mixin:0.13.2+mixin.0.8.5")
     compileOnly("net.fabricmc:fabric-loader:${BuildConfig.FABRIC_LOADER_VERSION}")

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/data/config/MixinConfig.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/data/config/MixinConfig.java
@@ -63,6 +63,7 @@ public class MixinConfig {
 
         this.addMixinRule("features.render.immediate", true);
         this.addMixinRule("features.render.immediate.buffer_builder", true);
+        this.addMixinRule("features.render.immediate.buffer_upload", true);
         this.addMixinRule("features.render.immediate.matrix_stack", true);
 
         this.addMixinRule("features.render.model", true);

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/immediate/buffer_upload/GlBufferAccessor.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/immediate/buffer_upload/GlBufferAccessor.java
@@ -1,0 +1,12 @@
+package net.caffeinemc.mods.sodium.mixin.features.render.immediate.buffer_upload;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import com.mojang.blaze3d.opengl.GlBuffer;
+
+@Mixin(GlBuffer.class)
+public interface GlBufferAccessor {
+
+    @Accessor
+    void setInitialized(boolean value);
+}

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/immediate/buffer_upload/VertexFormatMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/immediate/buffer_upload/VertexFormatMixin.java
@@ -1,0 +1,34 @@
+package net.caffeinemc.mods.sodium.mixin.features.render.immediate.buffer_upload;
+
+import java.nio.ByteBuffer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import com.llamalad7.mixinextras.injector.ModifyReceiver;
+import com.llamalad7.mixinextras.sugar.Cancellable;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.mojang.blaze3d.buffers.GpuBuffer;
+import com.mojang.blaze3d.systems.CommandEncoder;
+import com.mojang.blaze3d.vertex.VertexFormat;
+
+/**
+ * Fixes an issue where buffer uploads can be slow on some systems due to Vanilla using {@code glBufferSubData} in 1.21.5 (MC-295893).
+ */
+@Mixin(VertexFormat.class)
+public class VertexFormatMixin {
+
+    @ModifyReceiver(method = { "uploadImmediateVertexBuffer", "uploadImmediateIndexBuffer" }, at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/buffers/GpuBuffer;size()I"), require = 2)
+    private GpuBuffer replaceBufferData(GpuBuffer gpuBuffer, ByteBuffer data, @Local CommandEncoder commandEncoder, @Cancellable CallbackInfoReturnable<GpuBuffer> cir) {
+        //Setting the initialized field to false forces the glBufferSubData path to be skipped in GlCommandEncoder
+        ((GlBufferAccessor) gpuBuffer).setInitialized(false);
+        //Update the size of the GpuBuffer
+        gpuBuffer.size = data.remaining();
+
+        //Write the data and cancel the method
+        commandEncoder.writeToBuffer(gpuBuffer, data, 0);
+        cir.setReturnValue(gpuBuffer);
+
+        return gpuBuffer;
+    }
+}

--- a/common/src/main/resources/sodium-common.mixins.json
+++ b/common/src/main/resources/sodium-common.mixins.json
@@ -63,6 +63,8 @@
     "features.render.immediate.buffer_builder.intrinsics.BufferBuilderMixin",
     "features.render.immediate.buffer_builder.sorting.MeshDataMixin",
     "features.render.immediate.buffer_builder.sorting.VertexSortingMixin",
+    "features.render.immediate.buffer_upload.GlBufferAccessor",
+    "features.render.immediate.buffer_upload.VertexFormatMixin",
     "features.render.immediate.matrix_stack.VertexConsumerMixin",
     "features.render.model.ItemBlockRenderTypesMixin",
     "features.render.model.item.ItemRendererMixin",


### PR DESCRIPTION
This PR essentially reverts Mojang's changes to buffer uploading in 1.21.5 where the new method of uploading buffer data via `glBufferSubData` is inefficient and causes significant performance losses across some systems (see MC-295893 for further details).

This patch on my system (macOS) pretty much fixes the significant performance loss I've experienced from this update. I'm not sure if the patch should only be applied to certain systems or not given the many users reporting performance losses (which may or may not be related to this) so that might be something worth considering.

I believe I have added the mixins and whatnot correctly, if anything needs changing please let me know. I also had to update MixinExtras for the `@Cancellable` annotation (Fabric and Neo ship this version so it should be fine).