### PR TITLE
Faster section aabb test

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/occlusion/OcclusionCuller.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/occlusion/OcclusionCuller.java
@@ -234,16 +234,12 @@ public class OcclusionCuller {
     public static final float CHUNK_SECTION_SIZE = CHUNK_SECTION_RADIUS + CHUNK_SECTION_MARGIN;
 
     public static boolean isWithinFrustum(Viewport viewport, RenderSection section) {
-        return viewport.isBoxVisible(section.getCenterX(), section.getCenterY(), section.getCenterZ(),
-                CHUNK_SECTION_SIZE, CHUNK_SECTION_SIZE, CHUNK_SECTION_SIZE);
+        return viewport.isBoxVisible(section.getCenterX(), section.getCenterY(), section.getCenterZ());
     }
 
-    // this bigger chunk section size is only used for frustum-testing nearby sections with large models
-    private static final float CHUNK_SECTION_SIZE_NEARBY = CHUNK_SECTION_RADIUS + 2.0f /* bigger model extent */ + 0.125f /* epsilon */;
-    
+    // Only used for nearby sections with large models
     public static boolean isWithinNearbySectionFrustum(Viewport viewport, RenderSection section) {
-        return viewport.isBoxVisible(section.getCenterX(), section.getCenterY(), section.getCenterZ(),
-                CHUNK_SECTION_SIZE_NEARBY, CHUNK_SECTION_SIZE_NEARBY, CHUNK_SECTION_SIZE_NEARBY);
+        return viewport.isBoxVisibleLooser(section.getCenterX(), section.getCenterY(), section.getCenterZ());
     }
 
     // This method visits sections near the origin that are not in the path of the graph traversal

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/viewport/Viewport.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/viewport/Viewport.java
@@ -1,18 +1,18 @@
 package net.caffeinemc.mods.sodium.client.render.viewport;
 
-import net.caffeinemc.mods.sodium.client.render.viewport.frustum.Frustum;
+import net.caffeinemc.mods.sodium.client.render.viewport.frustum.SimpleFrustum;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.SectionPos;
 import org.joml.Vector3d;
 
 public final class Viewport {
-    private final Frustum frustum;
+    private final SimpleFrustum frustum;
     private final CameraTransform transform;
 
     private final SectionPos sectionCoords;
     private final BlockPos blockCoords;
 
-    public Viewport(Frustum frustum, Vector3d position) {
+    public Viewport(SimpleFrustum frustum, Vector3d position) {
         this.frustum = frustum;
         this.transform = new CameraTransform(position.x, position.y, position.z);
 
@@ -25,20 +25,20 @@ public final class Viewport {
         this.blockCoords = BlockPos.containing(position.x, position.y, position.z);
     }
 
-    public boolean isBoxVisible(int intOriginX, int intOriginY, int intOriginZ, float floatSizeX, float floatSizeY, float floatSizeZ) {
+    public boolean isBoxVisible(int intOriginX, int intOriginY, int intOriginZ) {
         float floatOriginX = (intOriginX - this.transform.intX) - this.transform.fracX;
         float floatOriginY = (intOriginY - this.transform.intY) - this.transform.fracY;
         float floatOriginZ = (intOriginZ - this.transform.intZ) - this.transform.fracZ;
 
-        return this.frustum.testAab(
-                floatOriginX - floatSizeX,
-                floatOriginY - floatSizeY,
-                floatOriginZ - floatSizeZ,
+        return this.frustum.testCubeQuick(floatOriginX, floatOriginY, floatOriginZ);
+    }
 
-                floatOriginX + floatSizeX,
-                floatOriginY + floatSizeY,
-                floatOriginZ + floatSizeZ
-        );
+    public boolean isBoxVisibleLooser(int intOriginX, int intOriginY, int intOriginZ) {
+        float floatOriginX = (intOriginX - this.transform.intX) - this.transform.fracX;
+        float floatOriginY = (intOriginY - this.transform.intY) - this.transform.fracY;
+        float floatOriginZ = (intOriginZ - this.transform.intZ) - this.transform.fracZ;
+
+        return this.frustum.testCubeWithExtend(floatOriginX, floatOriginY, floatOriginZ, 1.0625f);
     }
 
     public boolean isBoxVisibleDirect(float floatOriginX, float floatOriginY, float floatOriginZ, float floatSize) {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/viewport/frustum/SimpleFrustum.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/viewport/frustum/SimpleFrustum.java
@@ -1,12 +1,106 @@
 package net.caffeinemc.mods.sodium.client.render.viewport.frustum;
 
+import net.caffeinemc.mods.sodium.client.render.chunk.occlusion.OcclusionCuller;
 import org.joml.FrustumIntersection;
+import org.joml.Vector4f;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
 
 public final class SimpleFrustum implements Frustum {
+    private float nxX, nxY, nxZ, negNxW;
+    private float pxX, pxY, pxZ, negPxW;
+    private float nyX, nyY, nyZ, negNyW;
+    private float pyX, pyY, pyZ, negPyW;
+    private float nzX, nzY, nzZ, negNzW;
+    private float pzX, pzY, pzZ, negPzW;
+
     private final FrustumIntersection frustum;
+
+    private static final MethodHandle PLANES_GETTER;
+    static {
+        try {
+            Field field = FrustumIntersection.class.getDeclaredField("planes");
+            field.setAccessible(true);
+            PLANES_GETTER = MethodHandles.lookup().unreflectGetter(field);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException("Failed to find planes field in JOML", e);
+        }
+    }
 
     public SimpleFrustum(FrustumIntersection frustumIntersection) {
         this.frustum = frustumIntersection;
+        Vector4f[] planes;
+        try {
+            planes = (Vector4f[]) PLANES_GETTER.invokeExact(frustumIntersection);
+        } catch (Throwable e) {
+            throw new RuntimeException("Failed to access planes field in FrustumIntersection", e);
+        }
+
+        nxX = planes[0].x;
+        nxY = planes[0].y;
+        nxZ = planes[0].z;
+        pxX = planes[1].x;
+        pxY = planes[1].y;
+        pxZ = planes[1].z;
+        nyX = planes[2].x;
+        nyY = planes[2].y;
+        nyZ = planes[2].z;
+        pyX = planes[3].x;
+        pyY = planes[3].y;
+        pyZ = planes[3].z;
+        nzX = planes[4].x;
+        nzY = planes[4].y;
+        nzZ = planes[4].z;
+        pzX = planes[5].x;
+        pzY = planes[5].y;
+        pzZ = planes[5].z;
+
+        final float size = OcclusionCuller.CHUNK_SECTION_SIZE;
+        negNxW = -(planes[0].w + nxX * (nxX < 0 ? -size : size) +
+                nxY * (nxY < 0 ? -size : size) +
+                nxZ * (nxZ < 0 ? -size : size));
+        negPxW = -(planes[1].w + pxX * (pxX < 0 ? -size : size) +
+                pxY * (pxY < 0 ? -size : size) +
+                pxZ * (pxZ < 0 ? -size : size));
+        negNyW = -(planes[2].w + nyX * (nyX < 0 ? -size : size) +
+                nyY * (nyY < 0 ? -size : size) +
+                nyZ * (nyZ < 0 ? -size : size));
+        negPyW = -(planes[3].w + pyX * (pyX < 0 ? -size : size) +
+                pyY * (pyY < 0 ? -size : size) +
+                pyZ * (pyZ < 0 ? -size : size));
+        negNzW = -(planes[4].w + nzX * (nzX < 0 ? -size : size) +
+                nzY * (nzY < 0 ? -size : size) +
+                nzZ * (nzZ < 0 ? -size : size));
+        negPzW = -(planes[5].w + pzX * (pzX < 0 ? -size : size) +
+                pzY * (pzY < 0 ? -size : size) +
+                pzZ * (pzZ < 0 ? -size : size));
+    }
+
+    public boolean testCubeQuick(float x, float y, float z) {
+        // Skip far plane checks because it has been ensured by searchDistance and isWithinRenderDistance check in OcclusionCuller
+        return nxX * x + nxY * y + nxZ * z >= negNxW &&
+                pxX * x + pxY * y + pxZ * z >= negPxW &&
+                nyX * x + nyY * y + nyZ * z >= negNyW &&
+                pyX * x + pyY * y + pyZ * z >= negPyW &&
+                nzX * x + nzY * y + nzZ * z >= negNzW;
+    }
+
+    public boolean testCubeWithExtend(float floatOriginX, float floatOriginY, float floatOriginZ, float extend) {
+        float minX = floatOriginX - extend;
+        float maxX = floatOriginX + extend;
+        float minY = floatOriginY - extend;
+        float maxY = floatOriginY + extend;
+        float minZ = floatOriginZ - extend;
+        float maxZ = floatOriginZ + extend;
+
+        return nxX * (nxX < 0 ? minX : maxX) + nxY * (nxY < 0 ? minY : maxY) + nxZ * (nxZ < 0 ? minZ : maxZ) >= negNxW &&
+                pxX * (pxX < 0 ? minX : maxX) + pxY * (pxY < 0 ? minY : maxY) + pxZ * (pxZ < 0 ? minZ : maxZ) >= negPxW &&
+                nyX * (nyX < 0 ? minX : maxX) + nyY * (nyY < 0 ? minY : maxY) + nyZ * (nyZ < 0 ? minZ : maxZ) >= negNyW &&
+                pyX * (pyX < 0 ? minX : maxX) + pyY * (pyY < 0 ? minY : maxY) + pyZ * (pyZ < 0 ? minZ : maxZ) >= negPyW &&
+                nzX * (nzX < 0 ? minX : maxX) + nzY * (nzY < 0 ? minY : maxY) + nzZ * (nzZ < 0 ? minZ : maxZ) >= negNzW &&
+                pzX * (pzX < 0 ? minX : maxX) + pzY * (pzY < 0 ? minY : maxY) + pzZ * (pzZ < 0 ? minZ : maxZ) >= negPzW;
     }
 
     @Override


### PR DESCRIPTION
This PR precomputes section size into SimpleFrustum and skips far plane check to make it faster during RenderSectionManager.createTerrainRenderList
In Sparks time per tick mode createTerrainRenderList's time decreases from 10.75ms to 7.81ms and fps improves from 400 to about 500 when continuously moving mouse around with RD 40.
Reflection is used in this pr to access planes in FrustumIntersection