### PR TITLE
Change Primitive Iteration in TS System Away From Enhanced For Loops

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/bsp_tree/InnerPartitionBSPNode.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/bsp_tree/InnerPartitionBSPNode.java
@@ -245,7 +245,8 @@ abstract class InnerPartitionBSPNode extends BSPNode {
 
             // collect all the geometry's start and end points in this direction
             points.clear();
-            for (int quadIndex : indexes) {
+            for (int i = 0, size = indexes.size(); i < size; i++) {
+                int quadIndex = indexes.getInt(i);
                 var quad = workspace.quads[quadIndex];
                 var extents = quad.getExtents();
                 var posExtent = extents[axis];
@@ -288,7 +289,8 @@ abstract class InnerPartitionBSPNode extends BSPNode {
             IntArrayList quadsBefore = null;
             IntArrayList quadsOn = null;
             int thickness = 0;
-            for (long point : points) {
+            for (int i = 0, size = points.size(); i < size; i++) {
+                long point = points.getLong(i);
                 switch (decodeType(point)) {
                     case INTERVAL_START -> {
                         // unless at the start, flush if there's a gap

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/trigger/NormalPlanes.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/trigger/NormalPlanes.java
@@ -57,7 +57,8 @@ public class NormalPlanes {
         var size = this.relativeDistancesSet.size();
         this.relativeDistances = new float[this.relativeDistancesSet.size()];
         int i = 0;
-        for (float relDistance : this.relativeDistancesSet) {
+        for (var it = this.relativeDistancesSet.iterator(); it.hasNext(); ) {
+            float relDistance = it.nextFloat();
             this.relativeDistances[i++] = relDistance;
 
             long distanceBits = Double.doubleToLongBits(relDistance);


### PR DESCRIPTION
Change enhanced for loops over primitive lists in the translucency sorting system to use regular for loops or primitive iterators instead, potentially improving performance by avoiding (un)boxing (I have not measured).

Based on @MCRcortex's [suggestion](https://discord.com/channels/602796788608401408/651120262129123330/1367856874577330316).