### PR TITLE
Use Level's Sea Level for Chunk Mesh Size Estimation Heuristics

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -76,7 +76,7 @@ public class RenderSectionManager {
 
     private final ConcurrentLinkedDeque<ChunkJobResult<? extends BuilderTaskOutput>> buildResults = new ConcurrentLinkedDeque<>();
     private final JobDurationEstimator jobDurationEstimator = new JobDurationEstimator();
-    private final MeshTaskSizeEstimator meshTaskSizeEstimator = new MeshTaskSizeEstimator();
+    private final MeshTaskSizeEstimator meshTaskSizeEstimator;
     private final UploadDurationEstimator jobUploadDurationEstimator = new UploadDurationEstimator();
     private ChunkJobCollector lastBlockingCollector;
     private int thisFrameBlockingTasks;
@@ -116,6 +116,8 @@ public class RenderSectionManager {
     private final RemovableMultiForest renderableSectionTree;
 
     public RenderSectionManager(ClientLevel level, int renderDistance, SortBehavior sortBehavior, CommandList commandList) {
+        this.meshTaskSizeEstimator = new MeshTaskSizeEstimator(level);
+        
         this.chunkRenderer = new DefaultChunkRenderer(RenderDevice.INSTANCE, ChunkMeshFormats.COMPACT);
 
         this.level = level;
@@ -386,7 +388,7 @@ public class RenderSectionManager {
                 touchedSectionInfo |= this.updateSectionInfo(result.render, chunkBuildOutput.info);
 
                 result.render.setLastMeshResultSize(resultSize);
-                this.meshTaskSizeEstimator.addData(MeshResultSize.forSection(result.render, resultSize));
+                this.meshTaskSizeEstimator.addData(this.meshTaskSizeEstimator.resultForSection(result.render, resultSize));
 
                 if (chunkBuildOutput.translucentData != null) {
                     this.sortTriggering.integrateTranslucentData(oldData, chunkBuildOutput.translucentData, this.cameraPosition, this::scheduleSort);

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/estimation/MeshResultSize.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/estimation/MeshResultSize.java
@@ -12,24 +12,27 @@ public record MeshResultSize(SectionCategory category, long resultSize) implemen
         SURFACE,
         HIGH;
 
-        public static SectionCategory forSection(RenderSection section) {
+        public static SectionCategory forSection(RenderSection section, int seaLevelChunk) {
             var sectionY = section.getChunkY();
-            if (sectionY < 0) {
-                return LOW;
-            } else if (sectionY < 3) {
-                return UNDERGROUND;
-            } else if (sectionY == 3) {
+            
+            // Roughly classify type of chunk based on Y level relative to sea level:
+            // Water level chunks are likely to have different meshes from those below and those above.
+            // Very low chunks are again different because they aren't going to include the underwater terrain (just caves).
+            // Very high chunks are (at least locally) different because they are likely to be mostly air with some terrain poking through, or just buildings/jungle tree tops.
+            if (sectionY == seaLevelChunk) {
                 return WATER_LEVEL;
-            } else if (sectionY < 7) {
-                return SURFACE;
-            } else {
-                return HIGH;
             }
+            if (sectionY < seaLevelChunk - 4) {
+                return LOW;
+            }
+            if (sectionY < seaLevelChunk) {
+                return UNDERGROUND;
+            }
+            if (sectionY < seaLevelChunk + 3) {
+                return SURFACE;
+            }
+            return HIGH;
         }
-    }
-
-    public static MeshResultSize forSection(RenderSection section, long resultSize) {
-        return new MeshResultSize(SectionCategory.forSection(section), resultSize);
     }
 
     @Override

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/estimation/MeshTaskSizeEstimator.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/estimation/MeshTaskSizeEstimator.java
@@ -2,15 +2,20 @@ package net.caffeinemc.mods.sodium.client.render.chunk.compile.estimation;
 
 import net.caffeinemc.mods.sodium.client.render.chunk.RenderSection;
 import net.caffeinemc.mods.sodium.client.render.chunk.region.RenderRegion;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
 
 import java.util.EnumMap;
 import java.util.Map;
 
 public class MeshTaskSizeEstimator extends Average1DEstimator<MeshResultSize.SectionCategory> {
     public static final float NEW_DATA_RATIO = 0.02f;
+    
+    private final int seaLevelChunk;
 
-    public MeshTaskSizeEstimator() {
+    public MeshTaskSizeEstimator(ClientLevel level) {
         super(NEW_DATA_RATIO, RenderRegion.SECTION_BUFFER_ESTIMATE);
+        this.seaLevelChunk = level.getSeaLevel() / 16;
     }
 
     public long estimateSize(RenderSection section) {
@@ -18,7 +23,11 @@ public class MeshTaskSizeEstimator extends Average1DEstimator<MeshResultSize.Sec
         if (lastResultSize != MeshResultSize.NO_DATA) {
             return lastResultSize;
         }
-        return this.predict(MeshResultSize.SectionCategory.forSection(section));
+        return this.predict(MeshResultSize.SectionCategory.forSection(section, this.seaLevelChunk));
+    }
+    
+    public MeshResultSize resultForSection(RenderSection section, long resultSize) {
+        return new MeshResultSize(MeshResultSize.SectionCategory.forSection(section, this.seaLevelChunk), resultSize);
     }
 
     @Override

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/estimation/MeshTaskSizeEstimator.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/estimation/MeshTaskSizeEstimator.java
@@ -15,7 +15,7 @@ public class MeshTaskSizeEstimator extends Average1DEstimator<MeshResultSize.Sec
 
     public MeshTaskSizeEstimator(ClientLevel level) {
         super(NEW_DATA_RATIO, RenderRegion.SECTION_BUFFER_ESTIMATE);
-        this.seaLevelChunk = level.getSeaLevel() / 16;
+        this.seaLevelChunk = level.getSeaLevel() >> 4;
     }
 
     public long estimateSize(RenderSection section) {


### PR DESCRIPTION
Changes the chunk mesh size estimator's class generator to use the sea level provided by the Level for chunk mesh size estimation classes instead of just assuming it's 62. When estimating mesh sizes it's beneficial to do the estimation separately for different types of chunks, for which knowing the sea level is relevant given the unique geometry of the ocean and the terrain above/below it. Previously this was hardcoded to 62 and I've now changed it to adapt based on the `Level`'s sea level.

This could be considered a bug fix but the functionality is not broken without it, it may just perform suboptimally in non-standard world configurations otherwise.

Thanks to @IMS212 for pointing this out.