### PR TITLE
Fix Resource Pack Scanner For Recent Versions of Minecraft

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/checks/ResourcePackScanner.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/checks/ResourcePackScanner.java
@@ -2,13 +2,8 @@ package net.caffeinemc.mods.sodium.client.checks;
 
 import net.caffeinemc.mods.sodium.client.console.Console;
 import net.caffeinemc.mods.sodium.client.console.message.MessageLevel;
-import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.packs.FilePackResources;
-import net.minecraft.server.packs.PackResources;
-import net.minecraft.server.packs.PackType;
-import net.minecraft.server.packs.PathPackResources;
+import net.minecraft.server.packs.*;
 import net.minecraft.server.packs.resources.ResourceManager;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -41,7 +36,9 @@ public class ResourcePackScanner {
             "rendertype_tripwire.json",
             "rendertype_clouds.vsh",
             "rendertype_clouds.fsh",
-            "rendertype_clouds.json"
+            "rendertype_clouds.json",
+            "terrain.vsh",
+            "terrain.fsh"
     );
 
     private static final Set<String> SHADER_INCLUDE_BLACKLIST = Set.of(
@@ -181,7 +178,7 @@ public class ResourcePackScanner {
     }
 
     private static boolean isExternalResourcePack(PackResources pack) {
-        return pack instanceof PathPackResources || pack instanceof FilePackResources;
+        return pack instanceof PathPackResources || pack instanceof FilePackResources || pack instanceof CompositePackResources;
     }
 
     private static String getResourcePackName(PackResources pack) {


### PR DESCRIPTION
There's been two recent updates that changed resource packs:
- Since 1.20.2 it's possible to define multi-version packs that show up as `CompositePackResources`, which we were not checking for
- Since 1.21.2 the terrain shaders are defined in `terrain.vsh/.fsh` instead of the old `rendertype_*`

This fixes the pack scanner to once again detect packs such as Vanilla Tweaks.