### PR TITLE
Disable color smoothing when biome blending is off

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/model/color/ColorProvider.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/model/color/ColorProvider.java
@@ -15,6 +15,7 @@ public interface ColorProvider<T> {
      * @param state  The state of the object being colorized
      * @param quad   The quad geometry which should be colorized
      * @param output The output array of vertex colors (in ABGR format)
+     * @param smooth Whether the colors should be blended across vertices
      */
-    void getColors(LevelSlice slice, BlockPos pos, BlockPos.MutableBlockPos scratchPos, T state, ModelQuadView quad, int[] output);
+    void getColors(LevelSlice slice, BlockPos pos, BlockPos.MutableBlockPos scratchPos, T state, ModelQuadView quad, int[] output, boolean smooth);
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/model/color/DefaultColorProviders.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/model/color/DefaultColorProviders.java
@@ -49,7 +49,7 @@ public class DefaultColorProviders {
         }
 
         @Override
-        public void getColors(LevelSlice slice, BlockPos pos, BlockPos.MutableBlockPos scratchPos, BlockState state, ModelQuadView quad, int[] output) {
+        public void getColors(LevelSlice slice, BlockPos pos, BlockPos.MutableBlockPos scratchPos, BlockState state, ModelQuadView quad, int[] output, boolean smooth) {
             Arrays.fill(output, 0xFF000000 | this.color.getColor(state, slice, pos, quad.getTintIndex()));
         }
     }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/model/quad/blender/BlendedColorProvider.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/model/quad/blender/BlendedColorProvider.java
@@ -9,9 +9,16 @@ import net.minecraft.util.Mth;
 
 public abstract class BlendedColorProvider<T> implements ColorProvider<T> {
     @Override
-    public void getColors(LevelSlice slice, BlockPos pos, BlockPos.MutableBlockPos scratchPos, T state, ModelQuadView quad, int[] output) {
-        for (int vertexIndex = 0; vertexIndex < 4; vertexIndex++) {
-            output[vertexIndex] = this.getVertexColor(slice, pos, scratchPos, quad, state, vertexIndex);
+    public void getColors(LevelSlice slice, BlockPos pos, BlockPos.MutableBlockPos scratchPos, T state, ModelQuadView quad, int[] output, boolean smooth) {
+        if (smooth) {
+            for (int vertexIndex = 0; vertexIndex < 4; vertexIndex++) {
+                output[vertexIndex] = this.getVertexColor(slice, pos, scratchPos, quad, state, vertexIndex);
+            }
+        } else {
+            int color = this.getColor(slice, state, pos);
+            for (int vertexIndex = 0; vertexIndex < 4; vertexIndex++) {
+                output[vertexIndex] = color;
+            }
         }
     }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/BlockRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/BlockRenderer.java
@@ -136,7 +136,7 @@ public class BlockRenderer extends AbstractBlockRenderContext {
 
             if (colorProvider != null) {
                 int[] vertexColors = this.vertexColors;
-                colorProvider.getColors(this.slice, this.pos, this.scratchPos, this.state, quad, vertexColors);
+                colorProvider.getColors(this.slice, this.pos, this.scratchPos, this.state, quad, vertexColors, slice.hasBiomeBlend());
 
                 for (int i = 0; i < 4; i++) {
                     quad.color(i, ColorMixer.mulComponentWise(vertexColors[i], quad.color(i)));

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/DefaultFluidRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/DefaultFluidRenderer.java
@@ -377,7 +377,7 @@ public class DefaultFluidRenderer {
 
         lighter.calculate(quad, pos, light, null, dir, false, false);
 
-        colorProvider.getColors(level, pos, scratchPos, fluidState, quad, this.quadColors);
+        colorProvider.getColors(level, pos, scratchPos, fluidState, quad, this.quadColors, level.hasBiomeBlend());
 
         // multiply the per-vertex color against the combined brightness
         // the combined brightness is the per-vertex brightness multiplied by the block's brightness

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/world/LevelSlice.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/world/LevelSlice.java
@@ -353,6 +353,10 @@ public final class LevelSlice implements BlockAndTintGetter {
         return this.biomeColors.getColor(resolver, pos.getX(), pos.getY(), pos.getZ());
     }
 
+    public boolean hasBiomeBlend() {
+        return this.biomeColors.getBlendRadius() > 0;
+    }
+
     @Override
     public int getHeight() {
         return this.level.getHeight();

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/world/biome/LevelColorCache.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/world/biome/LevelColorCache.java
@@ -109,6 +109,10 @@ public class LevelColorCache {
         slice.lastPopulateStamp = this.populateStamp;
     }
 
+    public int getBlendRadius() {
+        return blendRadius;
+    }
+
     private static class Slice {
         private final ColorBuffer buffer;
         private long lastPopulateStamp;

--- a/fabric/src/main/java/net/caffeinemc/mods/sodium/fabric/render/FabricColorProviders.java
+++ b/fabric/src/main/java/net/caffeinemc/mods/sodium/fabric/render/FabricColorProviders.java
@@ -22,7 +22,7 @@ public class FabricColorProviders {
         }
 
         @Override
-        public void getColors(LevelSlice slice, BlockPos pos, BlockPos.MutableBlockPos scratchPos, FluidState state, ModelQuadView quad, int[] output) {
+        public void getColors(LevelSlice slice, BlockPos pos, BlockPos.MutableBlockPos scratchPos, FluidState state, ModelQuadView quad, int[] output, boolean smooth) {
             Arrays.fill(output, 0xFF000000 | this.handler.getFluidColor(slice, pos, state));
         }
     }

--- a/neoforge/src/main/java/net/caffeinemc/mods/sodium/neoforge/render/ForgeColorProviders.java
+++ b/neoforge/src/main/java/net/caffeinemc/mods/sodium/neoforge/render/ForgeColorProviders.java
@@ -23,7 +23,7 @@ public class ForgeColorProviders {
         }
 
         @Override
-        public void getColors(LevelSlice slice, BlockPos pos, BlockPos.MutableBlockPos scratchPos, FluidState state, ModelQuadView quad, int[] output) {
+        public void getColors(LevelSlice slice, BlockPos pos, BlockPos.MutableBlockPos scratchPos, FluidState state, ModelQuadView quad, int[] output, boolean smooth) {
             Arrays.fill(output,this.handler.getTintColor(state, slice, pos));
         }
     }


### PR DESCRIPTION
This makes biome transitions harsh when biome blending is off, which is what the user most likely expects.

Current (biome blend 0):
<img width="2560" height="1440" alt="2025-09-07_21 10 40" src="https://github.com/user-attachments/assets/3348f755-2bdd-44f9-af28-abcca97f3b69" />

Patch:
<img width="2560" height="1440" alt="2025-09-07_21 10 10" src="https://github.com/user-attachments/assets/d1baaaa4-f1b7-4b10-afd1-29397cc0d46b" />
