### PR TITLE
Swap face indexes to achieve parity with vanilla

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/model/ModelCuboid.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/model/ModelCuboid.java
@@ -27,9 +27,9 @@ public class ModelCuboid {
     public static final int
             FACE_NEG_Y = 0, // DOWN
             FACE_POS_Y = 1, // UP
-            FACE_NEG_X = 2, // WEST
+            FACE_NEG_X = 2, // EAST
             FACE_NEG_Z = 3, // NORTH
-            FACE_POS_X = 4, // EAST
+            FACE_POS_X = 4, // WEST
             FACE_POS_Z = 5; // SOUTH
 
     public final float originX, originY, originZ;
@@ -183,8 +183,8 @@ public class ModelCuboid {
             case UP     -> FACE_POS_Y;
             case NORTH  -> FACE_NEG_Z;
             case SOUTH  -> FACE_POS_Z;
-            case WEST   -> FACE_NEG_X;
-            case EAST   -> FACE_POS_X;
+            case WEST   -> FACE_POS_X;
+            case EAST   -> FACE_NEG_X;
         };
     }
 }


### PR DESCRIPTION
Current face rendering behavior of sodium is different from vanilla due to swapped indexes. There is a demo mod that uses manual face culling at [2190303755/Cube](https://github.com/2190303755/Cube) for testing purpose.

Vanilla:
<img width="2560" height="1494" alt="Vanilla" src="https://github.com/user-attachments/assets/7b6f7273-9974-4402-ab6a-e3ca9cb47286" />

Sodium:
<img width="2560" height="1494" alt="Sodium" src="https://github.com/user-attachments/assets/8ef42ae4-de88-4fbb-ac53-9b9c600ff2ba" />
