### PR TITLE
Improved Immediate Chunk Presentation

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -247,6 +247,10 @@ public class SodiumWorldRenderer {
             }
         }
 
+        profiler.popPush("chunk_render_lists");
+        
+        this.renderSectionManager.finalizeRenderLists(viewport);
+
         profiler.popPush("chunk_render_tick");
 
         this.renderSectionManager.tickVisibleRenders();

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/ChunkUpdateTypes.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/ChunkUpdateTypes.java
@@ -37,7 +37,7 @@ public class ChunkUpdateTypes {
         return (isRebuild(type) || isInitialBuild(type)) && isSort(type);
     }
 
-    public static TaskQueueType getQueueType(int type, TaskQueueType importantRebuildQueueType) {
+    public static TaskQueueType getQueueType(int type, TaskQueueType importantRebuildQueueType, TaskQueueType importantSortQueueType) {
         if (isInitialBuild(type)) {
             return TaskQueueType.INITIAL_BUILD;
         }
@@ -45,7 +45,7 @@ public class ChunkUpdateTypes {
             if (isRebuild(type)) {
                 return importantRebuildQueueType;
             } else { // implies important sort task
-                return TaskQueueType.ZERO_FRAME_DEFER;
+                return importantSortQueueType;
             }
         } else {
             return TaskQueueType.ALWAYS_DEFER;

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSection.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSection.java
@@ -8,7 +8,6 @@ import net.caffeinemc.mods.sodium.client.render.chunk.occlusion.GraphDirectionSe
 import net.caffeinemc.mods.sodium.client.render.chunk.occlusion.VisibilityEncoding;
 import net.caffeinemc.mods.sodium.client.render.chunk.region.RenderRegion;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data.TranslucentData;
-import net.caffeinemc.mods.sodium.client.util.task.CancellationToken;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.SectionPos;
@@ -55,7 +54,7 @@ public class RenderSection {
 
     // Pending Update State
     @Nullable
-    private ChunkJob taskCancellationToken = null;
+    private ChunkJob runningJob = null;
     private long lastMeshResultSize = MeshResultSize.NO_DATA;
 
     private int pendingUpdateType;
@@ -133,9 +132,9 @@ public class RenderSection {
      * be used.
      */
     public void delete() {
-        if (this.taskCancellationToken != null) {
-            this.taskCancellationToken.setCancelled();
-            this.taskCancellationToken = null;
+        if (this.runningJob != null) {
+            this.runningJob.setCancelled();
+            this.runningJob = null;
         }
 
         this.clearRenderState();
@@ -350,12 +349,12 @@ public class RenderSection {
         return this.globalBlockEntities;
     }
 
-    public @Nullable ChunkJob getTaskCancellationToken() {
-        return this.taskCancellationToken;
+    public @Nullable ChunkJob getRunningJob() {
+        return this.runningJob;
     }
 
-    public void setTaskCancellationToken(@Nullable ChunkJob token) {
-        this.taskCancellationToken = token;
+    public void setRunningJob(@Nullable ChunkJob token) {
+        this.runningJob = token;
     }
 
     public int getPendingUpdate() {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSection.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSection.java
@@ -1,6 +1,7 @@
 package net.caffeinemc.mods.sodium.client.render.chunk;
 
 import net.caffeinemc.mods.sodium.client.render.chunk.compile.estimation.MeshResultSize;
+import net.caffeinemc.mods.sodium.client.render.chunk.compile.executor.ChunkJob;
 import net.caffeinemc.mods.sodium.client.render.chunk.data.BuiltSectionInfo;
 import net.caffeinemc.mods.sodium.client.render.chunk.occlusion.GraphDirection;
 import net.caffeinemc.mods.sodium.client.render.chunk.occlusion.GraphDirectionSet;
@@ -54,7 +55,7 @@ public class RenderSection {
 
     // Pending Update State
     @Nullable
-    private CancellationToken taskCancellationToken = null;
+    private ChunkJob taskCancellationToken = null;
     private long lastMeshResultSize = MeshResultSize.NO_DATA;
 
     private int pendingUpdateType;
@@ -349,11 +350,11 @@ public class RenderSection {
         return this.globalBlockEntities;
     }
 
-    public @Nullable CancellationToken getTaskCancellationToken() {
+    public @Nullable ChunkJob getTaskCancellationToken() {
         return this.taskCancellationToken;
     }
 
-    public void setTaskCancellationToken(@Nullable CancellationToken token) {
+    public void setTaskCancellationToken(@Nullable ChunkJob token) {
         this.taskCancellationToken = token;
     }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionFlags.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionFlags.java
@@ -15,4 +15,9 @@ public class RenderSectionFlags {
     public static boolean needsRender(int flags) {
         return (flags & MASK_NEEDS_RENDER) != 0;
     }
+    
+    public static boolean renderingMoreTypesNow(int prevFlags, int newFlags) {
+        // true if there is some bit that is set now and was not set previously
+        return ((newFlags & MASK_NEEDS_RENDER) & ~(prevFlags & MASK_NEEDS_RENDER)) != 0;
+    }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -98,6 +98,7 @@ public class RenderSectionManager {
 
     @NotNull
     private SortedRenderLists renderLists;
+    private SectionCollector sectionCollector;
 
     @NotNull
     private Map<TaskQueueType, ArrayDeque<RenderSection>> taskLists;
@@ -175,7 +176,6 @@ public class RenderSectionManager {
         final var searchDistance = this.getSearchDistance(fogParameters);
         final var useOcclusionCulling = this.shouldUseOcclusionCulling(camera, spectator);
 
-        RenderListProvider renderListProvider;
         var importantRebuildQueueType = SodiumClientMod.options().performance.chunkBuildDeferMode.getImportantRebuildQueueType();
         var importantSortQueueType = this.sortBehavior.getDeferMode().getImportantRebuildQueueType();
         if (this.isOutOfGraph(viewport.getChunkCoord())) {
@@ -183,22 +183,28 @@ public class RenderSectionManager {
             this.renderableSectionTree.prepareForTraversal();
             this.renderableSectionTree.traverse(visitor, viewport, searchDistance);
 
-            renderListProvider = visitor;
+            this.sectionCollector = visitor;
         } else {
             var visitor = new OcclusionSectionCollector(frame, importantRebuildQueueType, importantSortQueueType);
             this.occlusionCuller.findVisible(visitor, viewport, searchDistance, useOcclusionCulling, frame);
 
-            renderListProvider = visitor;
+            this.sectionCollector = visitor;
         }
 
-        this.renderLists = renderListProvider.createRenderLists(viewport);
-        this.taskLists = renderListProvider.getTaskLists();
+        this.taskLists = this.sectionCollector.getTaskLists();
 
         // when there were sections with pending updates that were skipped because they already had a task running,
         // it needs to revisit them to schedule the remaining pending updates.
         // since not all tasks necessarily change the section info to trigger a graph update,
         // without this pending updates might be missed when the camera is stationary
-        return renderListProvider.needsRevisitForPendingUpdates();
+        return this.sectionCollector.needsRevisitForPendingUpdates();
+    }
+
+    public void finalizeRenderLists(Viewport viewport) {
+        if (this.sectionCollector != null) {
+            this.renderLists = this.sectionCollector.createRenderLists(viewport);
+            this.sectionCollector = null;
+        }
     }
 
     private boolean isOutOfGraph(SectionPos pos) {
@@ -383,10 +389,18 @@ public class RenderSectionManager {
         long totalUploadSize = 0;
         for (var result : filtered) {
             var resultSize = result.getResultSize();
+            var job = result.render.getTaskCancellationToken();
 
             TranslucentData oldData = result.render.getTranslucentData();
             if (result instanceof ChunkBuildOutput chunkBuildOutput) {
+                var prevFlags = result.render.getFlags();
+
                 touchedSectionInfo |= this.updateSectionInfo(result.render, chunkBuildOutput.info);
+                
+                // if result was blocking and section is now newly renderable, force render it since it's probably a newly uncovered chunk
+                if (job != null && job.isBlocking() && !RenderSectionFlags.needsRender(prevFlags) && RenderSectionFlags.needsRender(chunkBuildOutput.info.flags)) {
+                    this.sectionCollector.visit(result.render);
+                }
 
                 result.render.setLastMeshResultSize(resultSize);
                 this.meshTaskSizeEstimator.addData(this.meshTaskSizeEstimator.resultForSection(result.render, resultSize));
@@ -402,8 +416,6 @@ public class RenderSectionManager {
                     && result.render.getTranslucentData() instanceof DynamicTopoData data) {
                 this.sortTriggering.applyTriggerChanges(data, sortOutput.getDynamicSorter(), result.render.getPosition(), this.cameraPosition);
             }
-
-            var job = result.render.getTaskCancellationToken();
 
             // clear the cancellation token (thereby marking the section as not having an
             // active task) if this job is the most recent submitted job for this section
@@ -557,12 +569,12 @@ public class RenderSectionManager {
             // sections for which there's a currently running task.
             var pendingUpdate = section.getPendingUpdate();
             if (pendingUpdate != 0) {
-                submitSectionTask(collector, section, pendingUpdate, uploadBudget);
+                submitSectionTask(collector, section, pendingUpdate, uploadBudget, queueType == TaskQueueType.ZERO_FRAME_DEFER);
             }
         }
     }
 
-    private void submitSectionTask(ChunkJobCollector collector, @NotNull RenderSection section, int type, UploadResourceBudget uploadBudget) {
+    private void submitSectionTask(ChunkJobCollector collector, @NotNull RenderSection section, int type, UploadResourceBudget uploadBudget, boolean blocking) {
         if (section.isDisposed()) {
             return;
         }
@@ -604,7 +616,7 @@ public class RenderSectionManager {
         }
 
         if (task != null) {
-            var job = this.builder.scheduleTask(task, ChunkUpdateTypes.isImportant(type), collector::onJobFinished);
+            var job = this.builder.scheduleTask(task, ChunkUpdateTypes.isImportant(type), collector::onJobFinished, blocking);
             collector.addSubmittedJob(job);
 
             // consume upload budget in size and duration using estimates

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -63,7 +63,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 public class RenderSectionManager {
     private static final float NEARBY_REBUILD_DISTANCE = Mth.square(16.0f);
     private static final float NEARBY_SORT_DISTANCE = Mth.square(25.0f);
-    
+
     private static final float FRAME_DURATION_UPLOAD_FRACTION = 0.1f;
     private static final long MIN_UPLOAD_DURATION_BUDGET = 2_000_000L; // 2ms
 
@@ -117,7 +117,7 @@ public class RenderSectionManager {
 
     public RenderSectionManager(ClientLevel level, int renderDistance, SortBehavior sortBehavior, CommandList commandList) {
         this.meshTaskSizeEstimator = new MeshTaskSizeEstimator(level);
-        
+
         this.chunkRenderer = new DefaultChunkRenderer(RenderDevice.INSTANCE, ChunkMeshFormats.COMPACT);
 
         this.level = level;
@@ -177,14 +177,15 @@ public class RenderSectionManager {
 
         RenderListProvider renderListProvider;
         var importantRebuildQueueType = SodiumClientMod.options().performance.chunkBuildDeferMode.getImportantRebuildQueueType();
+        var importantSortQueueType = this.sortBehavior.getDeferMode().getImportantRebuildQueueType();
         if (this.isOutOfGraph(viewport.getChunkCoord())) {
-            var visitor = new TreeSectionCollector(frame, importantRebuildQueueType, this.sectionByPosition);
+            var visitor = new TreeSectionCollector(frame, importantRebuildQueueType, importantSortQueueType, this.sectionByPosition);
             this.renderableSectionTree.prepareForTraversal();
             this.renderableSectionTree.traverse(visitor, viewport, searchDistance);
 
             renderListProvider = visitor;
         } else {
-            var visitor = new OcclusionSectionCollector(frame, importantRebuildQueueType);
+            var visitor = new OcclusionSectionCollector(frame, importantRebuildQueueType, importantSortQueueType);
             this.occlusionCuller.findVisible(visitor, viewport, searchDistance, useOcclusionCulling, frame);
 
             renderListProvider = visitor;
@@ -511,19 +512,13 @@ public class RenderSectionManager {
             // an estimator is used estimate task duration and limit the execution time to the available worker capacity.
             // separately, tasks are limited by their estimated upload size and duration.
             var uploadBudget = new LimitedResourceBudget(
-                    Math.max((long)(this.averageFrameDuration * FRAME_DURATION_UPLOAD_FRACTION), MIN_UPLOAD_DURATION_BUDGET),
+                    Math.max((long) (this.averageFrameDuration * FRAME_DURATION_UPLOAD_FRACTION), MIN_UPLOAD_DURATION_BUDGET),
                     this.regions.getStagingBuffer().getUploadSizeLimit(this.averageFrameDuration));
 
             var nextFrameBlockingCollector = new ChunkJobCollector(this.buildResults::add);
             var deferredCollector = new ChunkJobCollector(remainingDuration, this.buildResults::add);
 
-            // if zero frame delay is allowed, submit important sorts with the current frame blocking collector.
-            // otherwise submit with the collector that the next frame is blocking on.
-            if (this.sortBehavior.getDeferMode() == DeferMode.ZERO_FRAMES) {
-                this.submitSectionTasks(thisFrameBlockingCollector, nextFrameBlockingCollector, deferredCollector, uploadBudget);
-            } else {
-                this.submitSectionTasks(nextFrameBlockingCollector, nextFrameBlockingCollector, deferredCollector, uploadBudget);
-            }
+            this.submitSectionTasks(thisFrameBlockingCollector, nextFrameBlockingCollector, deferredCollector, uploadBudget);
 
             this.thisFrameBlockingTasks = thisFrameBlockingCollector.getSubmittedTaskCount();
             this.nextFrameBlockingTasks = nextFrameBlockingCollector.getSubmittedTaskCount();

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -99,6 +99,7 @@ public class RenderSectionManager {
     @NotNull
     private SortedRenderLists renderLists;
     private SectionCollector sectionCollector;
+    private SectionCollector lastSectionCollector;
 
     @NotNull
     private Map<TaskQueueType, ArrayDeque<RenderSection>> taskLists;
@@ -190,6 +191,7 @@ public class RenderSectionManager {
 
             this.sectionCollector = visitor;
         }
+        this.lastSectionCollector = null;
 
         this.taskLists = this.sectionCollector.getTaskLists();
 
@@ -203,6 +205,7 @@ public class RenderSectionManager {
     public void finalizeRenderLists(Viewport viewport) {
         if (this.sectionCollector != null) {
             this.renderLists = this.sectionCollector.createRenderLists(viewport);
+            this.lastSectionCollector = this.sectionCollector;
             this.sectionCollector = null;
         }
     }
@@ -397,8 +400,15 @@ public class RenderSectionManager {
 
                 touchedSectionInfo |= this.updateSectionInfo(result.render, chunkBuildOutput.info);
                 
-                // if result was blocking and section is now newly renderable, force render it since it's probably a newly uncovered chunk
-                if (job != null && job.isBlocking() && !RenderSectionFlags.needsRender(prevFlags) && RenderSectionFlags.needsRender(chunkBuildOutput.info.flags)) {
+                // if result was blocking (or has proximity priority) and section is now newly renderable, force render it since it's probably a newly uncovered chunk
+                if (job != null
+                        && (job.isBlocking() || this.shouldPrioritizeTask(result.render, NEARBY_REBUILD_DISTANCE))
+                        && RenderSectionFlags.renderingMoreTypesNow(prevFlags, chunkBuildOutput.info.flags)) {
+                    // if there is currently no section collector since there was no graph traversal,
+                    // reuse the previous section collector and use it to generate new extended render lists
+                    if (this.sectionCollector == null) {
+                        this.sectionCollector = this.lastSectionCollector;
+                    }
                     this.sectionCollector.visit(result.render);
                 }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -422,7 +422,7 @@ public class RenderSectionManager {
         long totalUploadSize = 0;
         for (var result : filtered) {
             var resultSize = result.getResultSize();
-            var job = result.render.getTaskCancellationToken();
+            var job = result.render.getRunningJob();
 
             TranslucentData oldData = result.render.getTranslucentData();
             if (result instanceof ChunkBuildOutput chunkBuildOutput) {
@@ -458,10 +458,9 @@ public class RenderSectionManager {
                 this.sortTriggering.applyTriggerChanges(data, sortOutput.getDynamicSorter(), result.render.getPosition(), this.cameraPosition);
             }
 
-            // clear the cancellation token (thereby marking the section as not having an
-            // active task) if this job is the most recent submitted job for this section
+            // clear the running job if this job is the most recent submitted job for this section
             if (job != null && result.submitTime >= result.render.getLastSubmittedFrame()) {
-                result.render.setTaskCancellationToken(null);
+                result.render.setRunningJob(null);
             }
 
             result.render.setLastUploadFrame(result.submitTime);
@@ -643,7 +642,7 @@ public class RenderSectionManager {
                         BuiltSectionInfo.EMPTY, Collections.emptyMap()));
                 this.buildResults.add(result);
 
-                section.setTaskCancellationToken(null);
+                section.setRunningJob(null);
             }
         } else { // implies it's a type of sort task
             task = this.createSortTask(section, this.frame);
@@ -663,7 +662,7 @@ public class RenderSectionManager {
             // consume upload budget in size and duration using estimates
             uploadBudget.consume(job.getEstimatedUploadDuration(), job.getEstimatedSize());
 
-            section.setTaskCancellationToken(job);
+            section.setRunningJob(job);
         }
 
         section.setLastSubmittedFrame(this.frame);

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -62,6 +62,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 
 public class RenderSectionManager {
     private static final float NEARBY_REBUILD_DISTANCE = Mth.square(16.0f);
+    private static final float IMMEDIATE_PRESENT_DISTANCE = Mth.square(64.0f);
     private static final float NEARBY_SORT_DISTANCE = Mth.square(25.0f);
 
     private static final float FRAME_DURATION_UPLOAD_FRACTION = 0.1f;
@@ -381,6 +382,35 @@ public class RenderSectionManager {
         }
     }
 
+    private boolean sectionVisible(RenderSection section) {
+        return section.getLastVisibleFrame() == this.lastUpdatedFrame;
+    }
+
+    private boolean isSectionImmediatePresentationCandidate(RenderSection section) {
+        if (this.cameraPosition == null) {
+            return false;
+        }
+        var distanceSquared = section.getSquaredDistance(
+                (float) this.cameraPosition.x(),
+                (float) this.cameraPosition.y(),
+                (float) this.cameraPosition.z()
+        );
+        
+        if (distanceSquared < NEARBY_REBUILD_DISTANCE) {
+            return true;
+        }
+        
+        return distanceSquared < IMMEDIATE_PRESENT_DISTANCE &&
+                // check that visible or adjacent to a visible section
+                (this.sectionVisible(section)
+                        || this.sectionVisible(section.adjacentDown)
+                        || this.sectionVisible(section.adjacentUp)
+                        || this.sectionVisible(section.adjacentNorth)
+                        || this.sectionVisible(section.adjacentSouth)
+                        || this.sectionVisible(section.adjacentWest)
+                        || this.sectionVisible(section.adjacentEast));
+    }
+
     private boolean processChunkBuildResults(ArrayList<BuilderTaskOutput> results) {
         var filtered = filterChunkBuildResults(results);
 
@@ -399,10 +429,11 @@ public class RenderSectionManager {
                 var prevFlags = result.render.getFlags();
 
                 touchedSectionInfo |= this.updateSectionInfo(result.render, chunkBuildOutput.info);
-                
-                // if result was blocking (or has proximity priority) and section is now newly renderable, force render it since it's probably a newly uncovered chunk
+
+                // if result was blocking (or is approximately visible) and section is now newly renderable, force render it since it's probably a newly uncovered chunk.
+                // This also fixes flickering issues with pistons moving blocks and switching between being a mesh and a BE.
                 if (job != null
-                        && (job.isBlocking() || this.shouldPrioritizeTask(result.render, NEARBY_REBUILD_DISTANCE))
+                        && (job.isBlocking() || this.isSectionImmediatePresentationCandidate(result.render))
                         && RenderSectionFlags.renderingMoreTypesNow(prevFlags, chunkBuildOutput.info.flags)) {
                     // if there is currently no section collector since there was no graph traversal,
                     // reuse the previous section collector and use it to generate new extended render lists

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/executor/ChunkBuilder.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/executor/ChunkBuilder.java
@@ -90,8 +90,7 @@ public class ChunkBuilder {
         this.threads.clear();
     }
 
-    public <TASK extends ChunkBuilderTask<OUTPUT>, OUTPUT extends BuilderTaskOutput> ChunkJobTyped<TASK, OUTPUT> scheduleTask(TASK task, boolean important,
-                                                                                                    Consumer<ChunkJobResult<OUTPUT>> consumer)
+    public <TASK extends ChunkBuilderTask<OUTPUT>, OUTPUT extends BuilderTaskOutput> ChunkJobTyped<TASK, OUTPUT> scheduleTask(TASK task, boolean important, Consumer<ChunkJobResult<OUTPUT>> consumer, boolean blocking)
     {
         Validate.notNull(task, "Task must be non-null");
 
@@ -99,7 +98,7 @@ public class ChunkBuilder {
             throw new IllegalStateException("Executor is stopped");
         }
 
-        var job = new ChunkJobTyped<>(task, consumer);
+        var job = new ChunkJobTyped<>(task, consumer, blocking);
 
         this.queue.add(job, important);
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/executor/ChunkJob.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/executor/ChunkJob.java
@@ -7,6 +7,8 @@ public interface ChunkJob extends CancellationToken {
     void execute(ChunkBuildContext context);
 
     boolean isStarted();
+    
+    boolean isBlocking();
 
     long getEstimatedSize();
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/executor/ChunkJobTyped.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/executor/ChunkJobTyped.java
@@ -12,13 +12,15 @@ public class ChunkJobTyped<TASK extends ChunkBuilderTask<OUTPUT>, OUTPUT extends
 {
     private final TASK task;
     private final Consumer<ChunkJobResult<OUTPUT>> consumer;
+    private final boolean blocking;
 
     private volatile boolean cancelled;
     private volatile boolean started;
 
-    ChunkJobTyped(TASK task, Consumer<ChunkJobResult<OUTPUT>> consumer) {
+    ChunkJobTyped(TASK task, Consumer<ChunkJobResult<OUTPUT>> consumer, boolean blocking) {
         this.task = task;
         this.consumer = consumer;
+        this.blocking = blocking;
     }
 
     @Override
@@ -67,6 +69,11 @@ public class ChunkJobTyped<TASK extends ChunkBuilderTask<OUTPUT>, OUTPUT extends
     @Override
     public boolean isStarted() {
         return this.started;
+    }
+
+    @Override
+    public boolean isBlocking() {
+        return this.blocking;
     }
 
     @Override

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/OcclusionSectionCollector.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/OcclusionSectionCollector.java
@@ -7,8 +7,8 @@ import net.caffeinemc.mods.sodium.client.render.chunk.TaskQueueType;
  * collect the visible chunks.
  */
 public class OcclusionSectionCollector extends SectionCollector {
-    public OcclusionSectionCollector(int frame, TaskQueueType importantRebuildQueueType) {
-        super(frame, importantRebuildQueueType);
+    public OcclusionSectionCollector(int frame, TaskQueueType importantRebuildQueueType, TaskQueueType importantSortQueueType) {
+        super(frame, importantRebuildQueueType, importantSortQueueType);
     }
 
     @Override

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/SectionCollector.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/SectionCollector.java
@@ -14,15 +14,17 @@ import java.util.Queue;
 public abstract class SectionCollector implements RenderListProvider, RenderSectionVisitor {
     private final int frame;
     private final TaskQueueType importantRebuildQueueType;
+    private final TaskQueueType importantSortQueueType;
     private final ObjectArrayList<ChunkRenderList> renderLists;
     private final EnumMap<TaskQueueType, ArrayDeque<RenderSection>> sortedTaskLists;
     private boolean needsRevisitForPendingUpdates = false;
 
     private static int[] sortItems = new int[RenderRegion.REGION_SIZE];
 
-    public SectionCollector(int frame, TaskQueueType importantRebuildQueueType) {
+    public SectionCollector(int frame, TaskQueueType importantRebuildQueueType, TaskQueueType importantSortQueueType) {
         this.frame = frame;
         this.importantRebuildQueueType = importantRebuildQueueType;
+        this.importantSortQueueType = importantSortQueueType;
 
         this.renderLists = new ObjectArrayList<>();
         this.sortedTaskLists = new EnumMap<>(TaskQueueType.class);
@@ -60,7 +62,7 @@ public abstract class SectionCollector implements RenderListProvider, RenderSect
                 return;
             }
             
-            var queueType = ChunkUpdateTypes.getQueueType(pendingUpdate, this.importantRebuildQueueType);
+            var queueType = ChunkUpdateTypes.getQueueType(pendingUpdate, this.importantRebuildQueueType, this.importantSortQueueType);
             Queue<RenderSection> queue = this.sortedTaskLists.get(queueType);
 
             if (queue.size() < queueType.queueSizeLimit()) {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/SectionCollector.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/SectionCollector.java
@@ -61,7 +61,7 @@ public abstract class SectionCollector implements RenderListProvider, RenderSect
                 this.needsRevisitForPendingUpdates = true;
                 return;
             }
-            
+
             var queueType = ChunkUpdateTypes.getQueueType(pendingUpdate, this.importantRebuildQueueType, this.importantSortQueueType);
             Queue<RenderSection> queue = this.sortedTaskLists.get(queueType);
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/SectionCollector.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/SectionCollector.java
@@ -57,7 +57,7 @@ public abstract class SectionCollector implements RenderListProvider, RenderSect
             // if the section has a pending update but a task is already running for it,
             // don't add it to the task list again because starting a new task when there's already one running is invalid.
             // (for example, it would become impossible to cancel the earlier task)
-            if (section.getTaskCancellationToken() != null) {
+            if (section.getRunningJob() != null) {
                 this.needsRevisitForPendingUpdates = true;
                 return;
             }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/TreeSectionCollector.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/TreeSectionCollector.java
@@ -11,8 +11,8 @@ import net.minecraft.core.SectionPos;
 public class TreeSectionCollector extends SectionCollector implements CoordinateSectionVisitor {
     private final Long2ReferenceMap<RenderSection> sections;
 
-    public TreeSectionCollector(int frame, TaskQueueType importantRebuildQueueType, Long2ReferenceMap<RenderSection> sections) {
-        super(frame, importantRebuildQueueType);
+    public TreeSectionCollector(int frame, TaskQueueType importantRebuildQueueType, TaskQueueType importantSortQueueType, Long2ReferenceMap<RenderSection> sections) {
+        super(frame, importantRebuildQueueType, importantSortQueueType);
         this.sections = sections;
     }
 


### PR DESCRIPTION
### [Remove redundant code for implementation of the sort task defer mode.](https://github.com/CaffeineMC/sodium/commit/19d591e2883996270976ae7fe829d6e52258c2d1)

There was previously an implementation for controlling sort task deferring as part of the sorting code. A different implementation of essentially the same concept but for rebuild tasks was added later. Now they both use the newer approach, which simplifies the task submit code.

### [Improve immediate presentation of meshes generated in blocking mode.](https://github.com/CaffeineMC/sodium/commit/8b10c2dde539135de8178ad92a1992e8ef1d1cbf)

Previously even when meshes were generated in the blocking defer mode "Immediate" (zero frame) they would not become visible if they were part of a previously invisible section and thus not in a render list already. This change makes it so that sections that receive results from blocking rebuilds are added to the render list.

When the "Immediate" chunk update defer mode is selected this fixes the issue of holes in the world when breaking a block that reveals a previously invisible section without needing to perform a second graph search pass. This is especially an issue on slower hardware and lower fps limits.

Also fixes #2768 by removing the delay between uploading chunk meshes and the render lists getting updated to include the presence of block entities in the chunk section.