### PR TITLE
Fix RSM to Take Worker Thread Budget Into Account

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -549,7 +549,8 @@ public class RenderSectionManager {
     private void submitSectionTasks(ChunkJobCollector collector, UploadResourceBudget uploadBudget, TaskQueueType queueType) {
         var taskList = this.taskLists.get(queueType);
 
-        while (!taskList.isEmpty() && (uploadBudget.isAvailable() || queueType.allowsUnlimitedUploadDuration())) {
+        // submit tasks as long as there's tasks available, the collector has worker thread budget, and there's enough upload budget left 
+        while (!taskList.isEmpty() && collector.hasBudgetRemaining() && (uploadBudget.isAvailable() || queueType.allowsUnlimitedUploadDuration())) {
             RenderSection section = taskList.poll();
 
             if (section == null) {


### PR DESCRIPTION
This PR should be merged before releasing Sodium 0.7, it's a followup to [this change](https://github.com/CaffeineMC/sodium/pull/3202/commits/b2374bd9f00def5ae4ea1de100c986b929320068#diff-1d09641bb5e2c4b4686c92aaa9cd1e0c153b778b1be908498b0bd31c6eb8026cR489), which is missing the `collector.hasBudgetRemaining()` check.

Fixes an oversight in RSM that wasn't taking the available worker budget into account when scheduling tasks.

This caused too many tasks to be submitted, causing weird chunk loading patterns and unresponsive loading of chunks when moving rapidly.

dev:

https://github.com/user-attachments/assets/44c3f058-10df-46b8-b6d1-94586b52eebc

patch:

https://github.com/user-attachments/assets/676affcf-af6e-449e-89c2-6ed293576e03

I did not measure an overall slowdown in how fast chunks are loaded, this just makes their loading pattern more reasonable and more responsible than it was in 0.6.