### PR TITLE
Use existing VALUES field instead of values()

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/frapi/mesh/EncodingFormat.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/frapi/mesh/EncodingFormat.java
@@ -178,7 +178,7 @@ public final class EncodingFormat {
     }
 
     static ModelQuadFacing normalFace(int bits) {
-        return ModelQuadFacing.values()[(bits & NORMAL_FACE_MASK) >>> NORMAL_FACE_BIT_OFFSET];
+        return ModelQuadFacing.VALUES[(bits & NORMAL_FACE_MASK) >>> NORMAL_FACE_BIT_OFFSET];
     }
 
     static int normalFace(int bits, ModelQuadFacing face) {


### PR DESCRIPTION
Small allocation optimization, VALUES field already existed in the enum so I figured we could use it. Saw it on a Spark report originally.

<img width="1166" height="188" alt="Screenshot From 2025-09-17 23-14-42" src="https://github.com/user-attachments/assets/35061fdb-f9ce-4021-97c6-701351a94517" />

Likely very minor gains to be noticeable. I haven't extensively tested it, but from a quick test the game runs fine with the patch.

I have not checked all the usages of the method to verify the return value is not modified, but modifying an enum's values would be terrible anyways, so returning the same VALUES constant instead of allocating a new array everytime from values() should be safe and the VALUES field already exists, suggesting that this code was just forgotten to be updated to utilize it over values().

I have not checked if any other place could be turned from values() to VALUES, but this was the only code path I saw in my Spark reports.

Testing
1. `/sparkc profiler start --thread * --alloc`
2. Wait for a while, play normally
3. `/sparkc profiler stop`
4. Open result from link, look in "Chunk Render Task Executor" thread