### PR TITLE
Remove Cloud Shaders From ResourcePackScanner

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/checks/ResourcePackScanner.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/checks/ResourcePackScanner.java
@@ -34,9 +34,6 @@ public class ResourcePackScanner {
             "rendertype_tripwire.vsh",
             "rendertype_tripwire.fsh",
             "rendertype_tripwire.json",
-            "rendertype_clouds.vsh",
-            "rendertype_clouds.fsh",
-            "rendertype_clouds.json",
             "terrain.vsh",
             "terrain.fsh"
     );


### PR DESCRIPTION
Remove the cloud shader files from ResourcePackScanner since we don't have a clouds renderer anymore, and thus don't replace the cloud shaders anymore.

This fixes unnecessary warnings about resource packs that replace cloud shaders with custom ones.

If/when we implement a new clouds shader these lines can be added back.

User report of unnecessary shader warning can be found [here](https://discord.com/channels/602796788608401408/1422729999655374952).