### PR TITLE
Replace estimator floats with doubles

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/estimation/Abstract2DLinearEstimator.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/estimation/Abstract2DLinearEstimator.java
@@ -36,8 +36,8 @@ public abstract class Abstract2DLinearEstimator<
 
     protected abstract static class LinearFunction<C, TBatch extends DataBatch<DataPair<C>>> implements Model<Long, Long, TBatch> {
         protected final long initialOutput;
-        protected float yIntercept;
-        protected float slope;
+        protected double yIntercept;
+        protected double slope;
         protected int gatheredSamples = 0;
 
         public LinearFunction(long initialOutput) {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/estimation/Average1DEstimator.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/estimation/Average1DEstimator.java
@@ -48,7 +48,7 @@ public abstract class Average1DEstimator<C> extends Estimator<C, Average1DEstima
         private boolean hasRealData = false;
         private double average;
 
-        public Average(double newDataRatio, float initialValue) {
+        public Average(double newDataRatio, double initialValue) {
             this.average = initialValue;
             this.newDataRatio = newDataRatio;
         }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/estimation/Average1DEstimator.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/estimation/Average1DEstimator.java
@@ -5,10 +5,10 @@ import net.caffeinemc.mods.sodium.client.util.MathUtil;
 import java.util.Locale;
 
 public abstract class Average1DEstimator<C> extends Estimator<C, Average1DEstimator.Value<C>, Average1DEstimator.ValueBatch<C>, Void, Long, Average1DEstimator.Average<C>> {
-    private final float newDataRatio;
+    private final double newDataRatio;
     private final long initialEstimate;
 
-    public Average1DEstimator(float newDataRatio, long initialEstimate) {
+    public Average1DEstimator(double newDataRatio, long initialEstimate) {
         this.newDataRatio = newDataRatio;
         this.initialEstimate = initialEstimate;
     }
@@ -33,8 +33,8 @@ public abstract class Average1DEstimator<C> extends Estimator<C, Average1DEstima
             this.count = 0;
         }
 
-        public float getAverage() {
-            return ((float) this.valueSum) / this.count;
+        public double getAverage() {
+            return ((double) this.valueSum) / this.count;
         }
     }
 
@@ -44,11 +44,11 @@ public abstract class Average1DEstimator<C> extends Estimator<C, Average1DEstima
     }
 
     protected static class Average<C> implements Estimator.Model<Void, Long, ValueBatch<C>> {
-        private final float newDataRatio;
+        private final double newDataRatio;
         private boolean hasRealData = false;
-        private float average;
+        private double average;
 
-        public Average(float newDataRatio, float initialValue) {
+        public Average(double newDataRatio, float initialValue) {
             this.average = initialValue;
             this.newDataRatio = newDataRatio;
         }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/estimation/ExpDecayLinear2DEstimator.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/estimation/ExpDecayLinear2DEstimator.java
@@ -4,11 +4,11 @@ public abstract class ExpDecayLinear2DEstimator<C> extends Abstract2DLinearEstim
         C,
         ExpDecayLinear2DEstimator.ClearingLinearRegressionBatch<C>,
         ExpDecayLinear2DEstimator.ExpDecayLinearFunction<C>> {
-    private final float newDataRatio;
+    private final double newDataRatio;
     private final int initialSampleTarget;
     private final int minBatchSize;
 
-    public ExpDecayLinear2DEstimator(float newDataRatio, int initialSampleTarget, int minBatchSize, long initialOutput) {
+    public ExpDecayLinear2DEstimator(double newDataRatio, int initialSampleTarget, int minBatchSize, long initialOutput) {
         super(initialOutput);
         this.newDataRatio = newDataRatio;
         this.initialSampleTarget = initialSampleTarget;
@@ -44,19 +44,19 @@ public abstract class ExpDecayLinear2DEstimator<C> extends Abstract2DLinearEstim
             C,
             ExpDecayLinear2DEstimator.ClearingLinearRegressionBatch<C>> {
         // the maximum fraction of the total weight that new data can have
-        private final float newDataRatioInv;
+        private final double newDataRatioInv;
         // how many samples we want to have at least before we start diminishing the new data's weight
         private final int initialSampleTarget;
         private final int minBatchSize;
 
-        private float xMeanOld = 0;
-        private float yMeanOld = 0;
-        private float covarianceOld = 0;
-        private float varianceOld = 0;
+        private double xMeanOld = 0;
+        private double yMeanOld = 0;
+        private double covarianceOld = 0;
+        private double varianceOld = 0;
 
-        public ExpDecayLinearFunction(float newDataRatio, int initialSampleTarget, int minBatchSize, long initialOutput) {
+        public ExpDecayLinearFunction(double newDataRatio, int initialSampleTarget, int minBatchSize, long initialOutput) {
             super(initialOutput);
-            this.newDataRatioInv = 1.0f / newDataRatio;
+            this.newDataRatioInv = 1.0 / newDataRatio;
             this.initialSampleTarget = initialSampleTarget;
             this.minBatchSize = minBatchSize;
         }
@@ -70,8 +70,8 @@ public abstract class ExpDecayLinear2DEstimator<C> extends Abstract2DLinearEstim
             // condition the weight to gather at least the initial sample target, and then weight the new data with a ratio
             var newDataSize = batch.size();
             var totalSamples = this.gatheredSamples + newDataSize;
-            float oldDataWeight;
-            float totalWeight;
+            double oldDataWeight;
+            double totalWeight;
             if (totalSamples <= this.initialSampleTarget) {
                 totalWeight = totalSamples;
                 oldDataWeight = this.gatheredSamples;
@@ -81,7 +81,7 @@ public abstract class ExpDecayLinear2DEstimator<C> extends Abstract2DLinearEstim
                 totalWeight = oldDataWeight + newDataSize;
             }
 
-            var totalWeightInv = 1.0f / totalWeight;
+            double totalWeightInv = 1.0 / totalWeight;
 
             // calculate the weighted mean along both axes
             long xSum = 0;
@@ -90,20 +90,20 @@ public abstract class ExpDecayLinear2DEstimator<C> extends Abstract2DLinearEstim
                 xSum += data.x();
                 ySum += data.y();
             }
-            var xMean = (this.xMeanOld * oldDataWeight + xSum) * totalWeightInv;
-            var yMean = (this.yMeanOld * oldDataWeight + ySum) * totalWeightInv;
+            double xMean = (this.xMeanOld * oldDataWeight + xSum) * totalWeightInv;
+            double yMean = (this.yMeanOld * oldDataWeight + ySum) * totalWeightInv;
 
             // the covariance and variance are calculated from the differences to the mean
-            var covarianceSum = 0.0f;
-            var varianceSum = 0.0f;
+            double covarianceSum = 0.0;
+            double varianceSum = 0.0;
             for (var data : batch) {
-                var xDelta = data.x() - xMean;
-                var yDelta = data.y() - yMean;
+                double xDelta = data.x() - xMean;
+                double yDelta = data.y() - yMean;
                 covarianceSum += xDelta * yDelta;
                 varianceSum += xDelta * xDelta;
             }
 
-            if (varianceSum == 0) {
+            if (Math.abs(varianceSum)<=Double.MIN_NORMAL) {
                 return;
             }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/estimation/ExpDecayLinear2DEstimator.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/estimation/ExpDecayLinear2DEstimator.java
@@ -103,7 +103,7 @@ public abstract class ExpDecayLinear2DEstimator<C> extends Abstract2DLinearEstim
                 varianceSum += xDelta * xDelta;
             }
 
-            if (Math.abs(varianceSum)<=Double.MIN_NORMAL) {
+            if (Math.abs(varianceSum) <= Double.MIN_NORMAL) {
                 return;
             }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/estimation/JobDurationEstimator.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/estimation/JobDurationEstimator.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 public class JobDurationEstimator extends ExpDecayLinear2DEstimator<Class<?>> {
     public static final int INITIAL_SAMPLE_TARGET = 100;
-    public static final float NEW_DATA_RATIO = 0.05f;
+    public static final double NEW_DATA_RATIO = 0.05;
     private static final int MIN_BATCH_SIZE = 40;
     private static final long INITIAL_JOB_DURATION_ESTIMATE = 5_000_000L; // 5ms
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/estimation/UploadDurationEstimator.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/estimation/UploadDurationEstimator.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 
 public class UploadDurationEstimator extends ExpDecayLinear2DEstimator<Void> {
-    public static final float NEW_DATA_RATIO = 0.05f;
+    public static final double NEW_DATA_RATIO = 0.05;
     public static final int INITIAL_SAMPLE_TARGET = 100;
     public static final int MIN_BATCH_SIZE = 100;
     private static final long INITIAL_UPLOAD_TIME_ESTIMATE = 100_000L; // 100µs

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/util/MathUtil.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/util/MathUtil.java
@@ -50,10 +50,6 @@ public class MathUtil {
         return Float.intBitsToFloat(i ^ ((i >> 31) & 0x7FFFFFFF));
     }
 
-    public static float exponentialMovingAverage(float oldValue, float newValue, float newValueContribution) {
-        return newValueContribution * newValue + (1 - newValueContribution) * oldValue;
-    }
-
     public static double exponentialMovingAverage(double oldValue, double newValue, double newValueContribution) {
         return newValueContribution * newValue + (1 - newValueContribution) * oldValue;
     }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/util/MathUtil.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/util/MathUtil.java
@@ -54,6 +54,10 @@ public class MathUtil {
         return newValueContribution * newValue + (1 - newValueContribution) * oldValue;
     }
 
+    public static double exponentialMovingAverage(double oldValue, double newValue, double newValueContribution) {
+        return newValueContribution * newValue + (1 - newValueContribution) * oldValue;
+    }
+
     public static long exponentialMovingAverage(long oldValue, long newValue, float newValueContribution) {
         return (long) (newValueContribution * newValue) + (long) ((1 - newValueContribution) * oldValue);
     }


### PR DESCRIPTION
Given the size of the numbers that are being handled (nanoseconds and megabytes, both of which are in the millions) it makes sense to use doubles instead of floats for computation as floating point precision may become an issue otherwise