### PR TITLE
Fix Resolution Slider Value Exception

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumConfigBuilder.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumConfigBuilder.java
@@ -227,7 +227,7 @@ public class SodiumConfigBuilder implements ConfigEntryPoint {
                                 })
                                 .setEnabledProvider(
                                         (state) -> {
-                                            if (this.monitor == null) {
+                                            if (this.monitor == null || this.monitor.getModeCount() <= 0) {
                                                 return false;
                                             }
                                             var os = OsUtils.getOs();

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/ControlValueFormatterImpls.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/ControlValueFormatterImpls.java
@@ -20,7 +20,7 @@ public class ControlValueFormatterImpls {
         return (v) -> {
             Monitor monitor = Minecraft.getInstance().getWindow().findBestMonitor();
 
-            if (OsUtils.getOs() != OsUtils.OperatingSystem.WIN || monitor == null) {
+            if (monitor == null || OsUtils.getOs() != OsUtils.OperatingSystem.WIN) {
                 return Component.empty();
             } else if (0 == v) {
                 return Component.translatable("options.fullscreen.current");


### PR DESCRIPTION
Fix exception being thrown when there's no monitor available to select screen resolutions for because of a Windows bug.

> This happens sometimes on laptops with hybrid graphics, due to a bug in Windows that makes it so no available resolutions are returned from the API

https://discord.com/channels/602796788608401408/1391474440277327985/1391522199994765312

Fixes #3137