### PR TITLE
Play click sound from SliderControl

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/SliderControl.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/SliderControl.java
@@ -153,6 +153,17 @@ public class SliderControl implements Control<Integer> {
             return false;
         }
 
+        @Override
+        public boolean mouseReleased(double mouseX, double mouseY, int button) {
+            if (this.option.isAvailable() && button == 0 && sliderHeld) {
+                sliderHeld = false;
+                playClickSound();
+                return true;
+            }
+
+            return false;
+        }
+
         private void setValueFromMouse(double d) {
             this.setValue((d - (double) this.sliderBounds.getX()) / (double) this.sliderBounds.getWidth());
         }


### PR DESCRIPTION
The slider control in vanilla Minecraft plays the click sound when it is released.
This modifies the custom slider control in Sodium to do the same.