### PR TITLE
add caching to `GlStateManager#glViewport`

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/data/config/MixinConfig.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/data/config/MixinConfig.java
@@ -62,6 +62,8 @@ public class MixinConfig {
 
         this.addMixinRule("features.render.particle", true);
 
+        this.addMixinRule("features.render.viewport", true);
+
         this.addMixinRule("features.render.world", true);
         this.addMixinRule("features.render.world.clouds", true);
         this.addMixinRule("features.render.world.sky", true);

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/viewport/GlStateManagerMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/viewport/GlStateManagerMixin.java
@@ -1,30 +1,34 @@
 package net.caffeinemc.mods.sodium.mixin.features.render.viewport;
 
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.mojang.blaze3d.opengl.GlStateManager;
-import org.lwjgl.opengl.GL11;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(GlStateManager.class)
 public class GlStateManagerMixin {
-    @Unique private static int viewportX;
-    @Unique private static int viewportY;
-    @Unique private static int viewportWidth;
-    @Unique private static int viewportHeight;
+    @Unique
+    private static int lastViewportX;
+    @Unique
+    private static int lastViewportY;
+    @Unique
+    private static int lastViewportWidth;
+    @Unique
+    private static int lastViewportHeight;
 
-    /**
-     * @author Crosby
-     * @reason Viewport only changes a few times per frame
-     */
-    @Overwrite
-    public static void _viewport(int x, int y, int width, int height) {
-        if (x != viewportX || y != viewportY || width != viewportWidth || height != viewportHeight) {
-            viewportX = x;
-            viewportY = y;
-            viewportWidth = width;
-            viewportHeight = height;
-            GL11.glViewport(x, y, width, height);
+    @WrapWithCondition(
+            method = "_viewport",
+            at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/GL11;glViewport(IIII)V")
+    )
+    private static boolean skipRedundantViewport(int x, int y, int w, int h) {
+        if (x == lastViewportX && y == lastViewportY && w == lastViewportWidth && h == lastViewportHeight) {
+            return false;
         }
+        lastViewportX = x;
+        lastViewportY = y;
+        lastViewportWidth = w;
+        lastViewportHeight = h;
+        return true;
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/viewport/GlStateManagerMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/viewport/GlStateManagerMixin.java
@@ -1,0 +1,30 @@
+package net.caffeinemc.mods.sodium.mixin.features.render.viewport;
+
+import com.mojang.blaze3d.opengl.GlStateManager;
+import org.lwjgl.opengl.GL11;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(GlStateManager.class)
+public class GlStateManagerMixin {
+    @Unique private static int viewportX;
+    @Unique private static int viewportY;
+    @Unique private static int viewportWidth;
+    @Unique private static int viewportHeight;
+
+    /**
+     * @author Crosby
+     * @reason Viewport only changes a few times per frame
+     */
+    @Overwrite
+    public static void _viewport(int x, int y, int width, int height) {
+        if (x != viewportX || y != viewportY || width != viewportWidth || height != viewportHeight) {
+            viewportX = x;
+            viewportY = y;
+            viewportWidth = width;
+            viewportHeight = height;
+            GL11.glViewport(x, y, width, height);
+        }
+    }
+}

--- a/common/src/main/resources/sodium-common.mixins.json
+++ b/common/src/main/resources/sodium-common.mixins.json
@@ -63,6 +63,7 @@
     "features.render.immediate.buffer_builder.sorting.VertexSortingMixin",
     "features.render.immediate.matrix_stack.VertexConsumerMixin",
     "features.render.particle.QuadParticleRenderStateMixin",
+    "features.render.viewport.GlStateManagerMixin",
     "features.render.world.clouds.CloudRendererMixin",
     "features.render.world.sky.LevelRendererMixin",
     "features.textures.NativeImageAccessor",


### PR DESCRIPTION
Every `RenderPass` object created caused a non-memoized call to `GL11#glViewport`, usually with the same arguments

Summing up all instances of `GlStateManager#glViewport` in a spark profile from a simple world with an uncapped framerate:
Before: 214.6ms in 60s, or .35% of render thread [[spark profile]](https://spark.lucko.me/VqB3HSIHoP?hl=3759,3276,3434,4165,4387,3995,2596,2298,2064,4449,4709,2818,5351,5492,5594,5023,4872,5170,1299,1436,486,855,347)
After: 3.2ms in 60s [[spark profile]](https://spark.lucko.me/NwwG3UuC1i?hl=6354,6762)