### PR TITLE
Update texture light coords math to match Vanilla

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/vertex/format/impl/CompactChunkVertex.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/vertex/format/impl/CompactChunkVertex.java
@@ -107,8 +107,8 @@ public class CompactChunkVertex implements ChunkVertexType {
     }
 
     private static int encodeLight(int light) {
-        int sky = Mth.clamp((light >>> 16) & 0xFF, 8, 248);
-        int block = Mth.clamp((light >>>  0) & 0xFF, 8, 248);
+        int sky = Mth.clamp(((light >>> 16) & 0xFF) + 8, 8, 248);
+        int block = Mth.clamp(((light >>>  0) & 0xFF) + 8, 8, 248);
 
         return (block << 0) | (sky << 8);
     }


### PR DESCRIPTION
Fixes https://github.com/CaffeineMC/sodium/issues/3308
With 25w36a, Mojang changed `terrain.vsh/minecraft_sample_lightmap(sampler2D, ivec2)` from
`return texture(lightMap, clamp(uv / 256.0, vec2(0.5 / 16.0), vec2(15.5 / 16.0)));`
to
`return texture(lightMap, clamp((uv / 256.0) + 0.5 / 16.0, vec2(0.5 / 16.0), vec2(15.5 / 16.0)));`

Comparison screenshots:
Vanilla 1.21.10
<img width="2560" height="1369" alt="image" src="https://github.com/user-attachments/assets/b4ac8650-b00e-4388-b1e1-49476c538c1a" />

1.21.9/stable branch of Sodium (forgot F3)
<img width="2560" height="1369" alt="image" src="https://github.com/user-attachments/assets/4dc29cb8-62cd-4dd2-8f37-f2dde8104832" />

PR
<img width="2560" height="1369" alt="image" src="https://github.com/user-attachments/assets/5342d777-5336-4b80-80a2-5ab33b18ff8c" />