### PR TITLE
More Accurate Buffer Sizing

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/data/SectionRenderDataStorage.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/data/SectionRenderDataStorage.java
@@ -145,7 +145,7 @@ public class SectionRenderDataStorage {
      * @param arena The buffer arena to allocate the new buffer from
      * @return true if the arena resized itself
      */
-    public boolean updateSharedIndexData(CommandList commandList, GlBufferArena arena) {
+    public boolean updateSharedIndexData(CommandList commandList, GlBufferArena arena, float regionFillFractionInv) {
         // assumes this.needsSharedIndexUpdate is true when this is called
         this.needsSharedIndexUpdate = false;
 
@@ -177,7 +177,7 @@ public class SectionRenderDataStorage {
         // create and upload a new shared index buffer
         var buffer = SharedQuadIndexBuffer.createIndexBuffer(SharedQuadIndexBuffer.IndexType.INTEGER, this.sharedIndexCapacity);
         var pendingUpload = new PendingUpload(buffer);
-        var bufferChanged = arena.upload(commandList, Stream.of(pendingUpload));
+        var bufferChanged = arena.upload(commandList, Stream.of(pendingUpload), regionFillFractionInv);
         this.sharedIndexAllocation = pendingUpload.getResult();
         buffer.free();
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/region/RenderRegion.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/region/RenderRegion.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 public class RenderRegion {
     public static final int SECTION_VERTEX_COUNT_ESTIMATE = 756;
-    public static final int SECTION_INDEX_COUNT_ESTIMATE = (SECTION_VERTEX_COUNT_ESTIMATE / 4) * 6;
+    public static final int SECTION_INDEX_COUNT_ESTIMATE = (SECTION_VERTEX_COUNT_ESTIMATE / DefaultTerrainRenderPasses.ALL.length / 4) * 6;
     public static final int SECTION_BUFFER_ESTIMATE = SECTION_VERTEX_COUNT_ESTIMATE * ChunkMeshFormats.COMPACT.getVertexFormat().getStride() + SECTION_INDEX_COUNT_ESTIMATE * Integer.BYTES;
 
     public static final int REGION_WIDTH = 8;
@@ -218,6 +218,10 @@ public class RenderRegion {
 
         this.sections[sectionIndex] = null;
         this.sectionCount--;
+    }
+    
+    public float getFillFractionInv() {
+        return (float) RenderRegion.REGION_SIZE / (float) this.sectionCount;
     }
 
     public RenderSection getSection(int id) {


### PR DESCRIPTION
Improved buffer size estimation leading to far fewer buffer allocations and much less resizing.

- Reuses buffers instead of freeing and reallocating them
- Uses the first 16 allocated segments in a region's buffer to estimate the total required size of the region buffer to avoid resizing it again in the future
- Resizes small buffers where size estimation would be imprecise with a growth factor instead of a small increment
- Avoids attempting to upload a queue of segments when the total remaining space is less than the total required for the segments in the upload queue. Instead it immediately performs resizing, thereby avoiding some CPU-side insertion effort and unnecessary copy commands.
- Adds a bunch of buffer-related debug counters to the F3 screen, these will likely get removed before this PR is merged.
- The buffer reuse list is a global field on `GlBufferArena` which means that any buffers allocated with it will share the same reuse pool, which currently is only the terrain. We may want to change this architecture if this class should be able to serve multiple different allocation contexts, which it currently does not.

Fixes https://github.com/CaffeineMC/sodium/issues/3300, but without implementing a "young gen" buffer because the current approach also seems to work well. My testing indicates that having a larger sample of sections to get the average size from does not improve the result much. Together with buffer reuse, this largely avoids the small initial buffers from going to waste, which is what a young gen buffer would primarily be for. It would still reduce the total number of allocations, but for now I think this is a good approach. (and less complex)

I may investigate adding a young gen buffer for reducing the number of very small index buffer allocations in the future.

Does not do https://github.com/CaffeineMC/sodium/issues/2683. There's no buffer sharing going on here and the points in that issue are still valid.

This will be a draft PR until it's been validated to actually fix the problem and not cause other problems.

If you want to test this and give feedback as a user, [please do so here](https://discord.com/channels/602796788608401408/1433967424222527519/1433967424222527519) on [our discord server](https://jellysquid.me/discord).