### PR TITLE
Remove broken wrapper validation task

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -10,7 +10,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/actions/wrapper-validation@v3
       - uses: actions/setup-java@v4
         with:
           distribution: temurin


### PR DESCRIPTION
The task causes actions to fail and is not longer needed.