### PR TITLE
Add workaround for Intel blit crash

### DIFF
--- a/common/src/boot/java/net/caffeinemc/mods/sodium/client/compatibility/workarounds/Workarounds.java
+++ b/common/src/boot/java/net/caffeinemc/mods/sodium/client/compatibility/workarounds/Workarounds.java
@@ -86,6 +86,7 @@ public class Workarounds {
          * Intel's graphics driver for Gen8 and older seems to be faulty and causes a crash when calling
          * glFramebufferBlit after the window loses focus.
          * <a href="https://github.com/CaffeineMC/sodium/issues/2727">GitHub Issue</a>
+         * <a href="https://github.com/CaffeineMC/sodium/issues/3226">GitHub Issue</a>
          */
         INTEL_FRAMEBUFFER_BLIT_CRASH_WHEN_UNFOCUSED,
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/data/config/MixinConfig.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/data/config/MixinConfig.java
@@ -86,6 +86,7 @@ public class MixinConfig {
         this.addMixinRule("workarounds", true);
         this.addMixinRule("workarounds.context_creation", true);
         this.addMixinRule("workarounds.event_loop", true);
+        this.addMixinRule("workarounds.window_minimized_state", true);
     }
 
     /**

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/workarounds/window_minimized_state/MinecraftMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/workarounds/window_minimized_state/MinecraftMixin.java
@@ -4,11 +4,22 @@ import com.mojang.blaze3d.platform.Window;
 import net.caffeinemc.mods.sodium.client.compatibility.workarounds.Workarounds;
 import net.minecraft.client.Minecraft;
 import org.lwjgl.glfw.GLFW;
+import org.lwjgl.system.MemoryStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+/** As a workaround for the blitting crash on some Intel GPUs (see
+ * {@link Workarounds.Reference#INTEL_FRAMEBUFFER_BLIT_CRASH_WHEN_UNFOCUSED}), vanilla skips framebuffer blitting
+ * when the window is minimized. However, the vanilla implementation of {@link Window#isMinimized()} relies on
+ * {@link org.lwjgl.glfw.GLFWFramebufferSizeCallback}, which means it only has the information of when the last event
+ * polling happened. The problem is that event polling only happens once per frame. The game might think the window is
+ * not minimized, if it is minimized after the last event polling.
+ * <p>
+ * This Mixin replaces the call to {@link Window#isMinimized()} with {@link GLFW#glfwGetFramebufferSize}, which actively
+ * queries the actual framebuffer size from the operating system.
+ * */
 @Mixin(Minecraft.class)
 public class MinecraftMixin {
     @Unique
@@ -19,6 +30,11 @@ public class MinecraftMixin {
         if (!sodium$redirectWindowMinimizedState) {
             return window.isMinimized();
         }
-        return GLFW.glfwGetWindowAttrib(window.handle(), GLFW.GLFW_ICONIFIED) == GLFW.GLFW_TRUE;
+        try (var stack = MemoryStack.stackPush()) {
+            var width = stack.callocInt(1);
+            var height = stack.callocInt(1);
+            GLFW.glfwGetFramebufferSize(window.handle(), width, height);
+            return width.get(0) == 0 || height.get(0) == 0;
+        }
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/workarounds/window_minimized_state/MinecraftMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/workarounds/window_minimized_state/MinecraftMixin.java
@@ -1,0 +1,24 @@
+package net.caffeinemc.mods.sodium.mixin.workarounds.window_minimized_state;
+
+import com.mojang.blaze3d.platform.Window;
+import net.caffeinemc.mods.sodium.client.compatibility.workarounds.Workarounds;
+import net.minecraft.client.Minecraft;
+import org.lwjgl.glfw.GLFW;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(Minecraft.class)
+public class MinecraftMixin {
+    @Unique
+    private final boolean sodium$redirectWindowMinimizedState = Workarounds.isWorkaroundEnabled(Workarounds.Reference.INTEL_FRAMEBUFFER_BLIT_CRASH_WHEN_UNFOCUSED);
+
+    @Redirect(method = "runTick", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/platform/Window;isMinimized()Z"))
+    private boolean redirectWindowMinimized(Window window) {
+        if (!sodium$redirectWindowMinimizedState) {
+            return window.isMinimized();
+        }
+        return GLFW.glfwGetWindowAttrib(window.handle(), GLFW.GLFW_ICONIFIED) == GLFW.GLFW_TRUE;
+    }
+}

--- a/common/src/main/resources/sodium-common.mixins.json
+++ b/common/src/main/resources/sodium-common.mixins.json
@@ -102,6 +102,7 @@
     "features.textures.scan.TextureAtlasSpriteMixin",
     "workarounds.context_creation.WindowMixin",
     "workarounds.context_creation.RenderSystemMixin",
-    "workarounds.event_loop.RenderSystemMixin"
+    "workarounds.event_loop.RenderSystemMixin",
+    "workarounds.window_minimized_state.MinecraftMixin"
   ]
 }


### PR DESCRIPTION
This PR re-adds workaround for Intel framebuffer blitting crash.

I originally wanted to replace the call to `glBlitFramebuffer` entirely with shader-based texture drawing, but after thinking about it it seems more of an unnecessary burden that may hinder porting Sodium to future versions of Minecraft. This PR should be a simple yet effective fix for the issue.

Closes #3226 
For reference: see https://github.com/decce6/Ixeris/issues/26#issuecomment-3172341308 and https://github.com/CaffeineMC/sodium/issues/3226#issuecomment-3471375428