### PR TITLE
Track sprites in object components

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/textures/animations/tracking/AtlasGlyphProviderMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/textures/animations/tracking/AtlasGlyphProviderMixin.java
@@ -1,0 +1,23 @@
+package net.caffeinemc.mods.sodium.mixin.features.textures.animations.tracking;
+
+import net.caffeinemc.mods.sodium.api.texture.SpriteUtil;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(targets = "net.minecraft.client.gui.font.AtlasGlyphProvider$Instance")
+public class AtlasGlyphProviderMixin {
+
+    @Shadow
+    @Final
+    private TextureAtlasSprite sprite;
+
+    @Inject(method = "renderSprite", at = @At("HEAD"))
+    private void preRenderSprite(CallbackInfo ci) {
+        SpriteUtil.INSTANCE.markSpriteActive(this.sprite);
+    }
+}

--- a/common/src/main/resources/sodium-common.mixins.json
+++ b/common/src/main/resources/sodium-common.mixins.json
@@ -91,6 +91,7 @@
     "features.textures.animations.tracking.SpriteContentsFrameInfoAccessor",
     "features.textures.animations.tracking.SpriteContentsTickerMixin",
     "features.textures.animations.tracking.SpriteContentsMixin",
+    "features.textures.animations.tracking.AtlasGlyphProviderMixin",
     "features.textures.animations.upload.SpriteContentsAccessor",
     "features.textures.animations.upload.SpriteContentsAnimatedTextureAccessor",
     "features.textures.animations.upload.SpriteContentsFrameInfoAccessor",


### PR DESCRIPTION
fixes #3327 by marking sprites as active when rendered in glyphs