### PR TITLE
Show Sodium's Debug Info on F3 Debug Screen by Default

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/SodiumClientMod.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/SodiumClientMod.java
@@ -5,8 +5,11 @@ import net.caffeinemc.mods.sodium.client.console.Console;
 import net.caffeinemc.mods.sodium.client.console.message.MessageLevel;
 import net.caffeinemc.mods.sodium.client.data.fingerprint.FingerprintMeasure;
 import net.caffeinemc.mods.sodium.client.data.fingerprint.HashedFingerprint;
+import net.caffeinemc.mods.sodium.client.gui.SodiumDebugEntry;
 import net.caffeinemc.mods.sodium.client.gui.SodiumOptions;
 import net.caffeinemc.mods.sodium.client.services.PlatformRuntimeInformation;
+import net.caffeinemc.mods.sodium.mixin.features.gui.hooks.debug.DebugScreenEntriesAccessor;
+import net.minecraft.resources.ResourceLocation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,10 +18,16 @@ import java.io.IOException;
 public class SodiumClientMod {
     private static SodiumOptions OPTIONS;
     private static final Logger LOGGER = LoggerFactory.getLogger("Sodium");
+    public static final ResourceLocation SODIUM_DEBUG_ENTRY_FULL = ResourceLocation.fromNamespaceAndPath("sodium", "debug_full");
+    public static final ResourceLocation SODIUM_DEBUG_ENTRY_REDUCED = ResourceLocation.fromNamespaceAndPath("sodium", "debug_reduced");
 
     private static String MOD_VERSION;
 
     public static void onInitialization(String version) {
+        var entries = DebugScreenEntriesAccessor.getEntries();
+        entries.put(SODIUM_DEBUG_ENTRY_FULL, new SodiumDebugEntry(true));
+        entries.put(SODIUM_DEBUG_ENTRY_REDUCED, new SodiumDebugEntry(false));
+
         MOD_VERSION = version;
 
         OPTIONS = loadConfig();

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumDebugEntry.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumDebugEntry.java
@@ -1,10 +1,7 @@
 package net.caffeinemc.mods.sodium.client.gui;
 
-import com.google.common.collect.Lists;
 import net.caffeinemc.mods.sodium.client.SodiumClientMod;
 import net.caffeinemc.mods.sodium.client.render.SodiumWorldRenderer;
-import net.caffeinemc.mods.sodium.client.util.MathUtil;
-import net.caffeinemc.mods.sodium.client.util.NativeBuffer;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.components.debug.DebugScreenDisplayer;
 import net.minecraft.client.gui.components.debug.DebugScreenEntry;
@@ -13,11 +10,13 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.chunk.LevelChunk;
 import org.jetbrains.annotations.Nullable;
 
-import java.lang.management.ManagementFactory;
-import java.util.ArrayList;
-
 public class SodiumDebugEntry implements DebugScreenEntry {
     private static final ResourceLocation DEBUG_GROUP = ResourceLocation.fromNamespaceAndPath("sodium", "debug_group");
+    private final boolean verbose;
+
+    public SodiumDebugEntry(boolean verbose) {
+        this.verbose = verbose;
+    }
 
     private static ChatFormatting getVersionColor() {
         String version = SodiumClientMod.getVersion();
@@ -41,7 +40,7 @@ public class SodiumDebugEntry implements DebugScreenEntry {
         var renderer = SodiumWorldRenderer.instanceNullable();
 
         if (renderer != null) {
-            debugScreenDisplayer.addToGroup(DEBUG_GROUP, renderer.getDebugStrings());
+            debugScreenDisplayer.addToGroup(DEBUG_GROUP, renderer.getDebugStrings(this.verbose));
         }
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumDebugEntry.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumDebugEntry.java
@@ -35,7 +35,7 @@ public class SodiumDebugEntry implements DebugScreenEntry {
 
     @Override
     public void display(DebugScreenDisplayer debugScreenDisplayer, @Nullable Level level, @Nullable LevelChunk levelChunk, @Nullable LevelChunk levelChunk2) {
-        debugScreenDisplayer.addLine("%sSodium Renderer (%s)".formatted(getVersionColor(), SodiumClientMod.getVersion()));
+        debugScreenDisplayer.addToGroup(DEBUG_GROUP, "%sSodium Renderer (%s)".formatted(getVersionColor(), SodiumClientMod.getVersion()));
 
         var renderer = SodiumWorldRenderer.instanceNullable();
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -517,8 +517,8 @@ public class SodiumWorldRenderer {
         this.renderSectionManager.scheduleRebuild(x, y, z, important);
     }
 
-    public Collection<String> getDebugStrings() {
-        return this.renderSectionManager == null ? Collections.emptyList() : this.renderSectionManager.getDebugStrings();
+    public Collection<String> getDebugStrings(boolean verbose) {
+        return this.renderSectionManager == null ? Collections.emptyList() : this.renderSectionManager.getDebugStrings(verbose);
     }
 
     public boolean isSectionReady(int x, int y, int z) {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -854,7 +854,7 @@ public class RenderSectionManager {
         return this.sectionByPosition.get(SectionPos.asLong(x, y, z));
     }
 
-    public Collection<String> getDebugStrings() {
+    public Collection<String> getDebugStrings(boolean verbose) {
         List<String> list = new ArrayList<>();
 
         int count = 0;
@@ -882,18 +882,26 @@ public class RenderSectionManager {
             count++;
         }
 
-        list.add(String.format("Pools: Geometry %d/%d MiB, Index %d/%d MiB (%d buffers)",
-                MathUtil.toMib(geometryDeviceUsed), MathUtil.toMib(geometryDeviceAllocated),
-                MathUtil.toMib(indexDeviceUsed), MathUtil.toMib(indexDeviceAllocated), count));
-        list.add(String.format("Transfer Queue: %s", this.regions.getStagingBuffer().toString()));
+        if (verbose) {
+            list.add(String.format("Pools: Geometry %d/%d MiB, Index %d/%d MiB (%d buffers)",
+                    MathUtil.toMib(geometryDeviceUsed), MathUtil.toMib(geometryDeviceAllocated),
+                    MathUtil.toMib(indexDeviceUsed), MathUtil.toMib(indexDeviceAllocated), count));
+            list.add(String.format("Transfer Queue: %s", this.regions.getStagingBuffer().toString()));
+        } else {
+            list.add(String.format("Geometry %d/%d MiB, Index %d/%d MiB (#%d), TQ: %s",
+                    MathUtil.toMib(geometryDeviceUsed), MathUtil.toMib(geometryDeviceAllocated),
+                    MathUtil.toMib(indexDeviceUsed), MathUtil.toMib(indexDeviceAllocated), count, this.regions.getStagingBuffer().toString()));
+        }
 
         list.add(String.format("Chunk Builder: Schd=%02d | Busy=%02d (%04d%%) | Total=%02d",
                 this.builder.getScheduledJobCount(), this.builder.getBusyThreadCount(), (int) (this.builder.getBusyFraction(this.lastFrameDuration) * 100), this.builder.getTotalThreadCount())
         );
 
-        list.add(String.format("Tasks: N0=%03d | N1=%03d | Def=%03d, Recv=%03d",
-                this.thisFrameBlockingTasks, this.nextFrameBlockingTasks, this.deferredTasks, this.buildResults.size())
-        );
+        if (verbose) {
+            list.add(String.format("Tasks: N0=%03d | N1=%03d | Def=%03d, Recv=%03d",
+                    this.thisFrameBlockingTasks, this.nextFrameBlockingTasks, this.deferredTasks, this.buildResults.size())
+            );
+        }
 
         if (PlatformRuntimeInformation.getInstance().isDevelopmentEnvironment()) {
             var meshTaskParameters = this.jobDurationEstimator.toString(ChunkBuilderMeshingTask.class);
@@ -909,7 +917,7 @@ public class RenderSectionManager {
         }
 
         if (this.sortBehavior != SortBehavior.OFF) {
-            this.sortTriggering.addDebugStrings(list, this.sortBehavior);
+            this.sortTriggering.addDebugStrings(list, this.sortBehavior, verbose);
         } else {
             list.add("TS OFF");
         }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -888,22 +888,28 @@ public class RenderSectionManager {
                     MathUtil.toMib(indexDeviceUsed), MathUtil.toMib(indexDeviceAllocated), count));
             list.add(String.format("Transfer Queue: %s", this.regions.getStagingBuffer().toString()));
         } else {
-            list.add(String.format("Geometry %d/%d MiB, Index %d/%d MiB (#%d), TQ: %s",
+            list.add(String.format("(#%d) G:%d/%d I:%d/%d MiB TQ: %s",
                     MathUtil.toMib(geometryDeviceUsed), MathUtil.toMib(geometryDeviceAllocated),
                     MathUtil.toMib(indexDeviceUsed), MathUtil.toMib(indexDeviceAllocated), count, this.regions.getStagingBuffer().toString()));
         }
 
-        list.add(String.format("Chunk Builder: Schd=%02d | Busy=%02d (%04d%%) | Total=%02d",
-                this.builder.getScheduledJobCount(), this.builder.getBusyThreadCount(), (int) (this.builder.getBusyFraction(this.lastFrameDuration) * 100), this.builder.getTotalThreadCount())
-        );
-
+        if (verbose) {
+            list.add(String.format("Chunk Builder: Schd=%02d | Busy=%02d (%04d%%) | Total=%02d",
+                    this.builder.getScheduledJobCount(), this.builder.getBusyThreadCount(), (int) (this.builder.getBusyFraction(this.lastFrameDuration) * 100), this.builder.getTotalThreadCount())
+            );
+        } else {
+            list.add(String.format("B: S%02d/B%02d/T%02d",
+                    this.builder.getScheduledJobCount(), this.builder.getBusyThreadCount(), this.builder.getTotalThreadCount())
+            );
+        }
+        
         if (verbose) {
             list.add(String.format("Tasks: N0=%03d | N1=%03d | Def=%03d, Recv=%03d",
                     this.thisFrameBlockingTasks, this.nextFrameBlockingTasks, this.deferredTasks, this.buildResults.size())
             );
         }
 
-        if (PlatformRuntimeInformation.getInstance().isDevelopmentEnvironment()) {
+        if (verbose && PlatformRuntimeInformation.getInstance().isDevelopmentEnvironment()) {
             var meshTaskParameters = this.jobDurationEstimator.toString(ChunkBuilderMeshingTask.class);
             var sortTaskParameters = this.jobDurationEstimator.toString(ChunkBuilderSortingTask.class);
             var uploadDurationParameters = this.jobUploadDurationEstimator.toString(null);

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/trigger/SortTriggering.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/trigger/SortTriggering.java
@@ -240,14 +240,11 @@ public class SortTriggering {
                     this.sortTypeCounters[SortType.DYNAMIC.ordinal()],
                     this.direct.getDirectTriggerCount()));
         } else {
-            list.add("TS (%s,%s) NL=%02d - N=%05d St=%05d DYN=%05d (DIR=%02d)".formatted(
+            list.add("TS (%s,%s) St=%d Dy=%d".formatted(
                     sortBehavior.getShortName(),
-                    this.gfni.getUniqueNormalCount(),
-                    this.triggeredNormalCount,
-                    this.sortTypeCounters[SortType.NONE.ordinal()],
+                    splittingMode.getShortName(),
                     this.sortTypeCounters[SortType.STATIC_NORMAL_RELATIVE.ordinal()] + this.sortTypeCounters[SortType.STATIC_TOPO.ordinal()],
-                    this.sortTypeCounters[SortType.DYNAMIC.ordinal()],
-                    this.direct.getDirectTriggerCount()
+                    this.sortTypeCounters[SortType.DYNAMIC.ordinal()]
             ));
         }
     }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/trigger/SortTriggering.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/trigger/SortTriggering.java
@@ -222,20 +222,33 @@ public class SortTriggering {
         }
     }
 
-    public void addDebugStrings(List<String> list, SortBehavior sortBehavior) {
+    public void addDebugStrings(List<String> list, SortBehavior sortBehavior, boolean verbose) {
         var splittingMode = SodiumClientMod.options().performance.quadSplittingMode;
-        list.add("TS (%s,%s) NL=%02d TrN=%02d TrS=G%03d/D%03d".formatted(
-                sortBehavior.getShortName(),
-                splittingMode.getShortName(),
-                this.gfni.getUniqueNormalCount(),
-                this.triggeredNormalCount,
-                this.gfniTriggerCount,
-                this.directTriggerCount));
-        list.add("N=%05d SNR=%05d STA=%05d DYN=%05d (DIR=%02d)".formatted(
-                this.sortTypeCounters[SortType.NONE.ordinal()],
-                this.sortTypeCounters[SortType.STATIC_NORMAL_RELATIVE.ordinal()],
-                this.sortTypeCounters[SortType.STATIC_TOPO.ordinal()],
-                this.sortTypeCounters[SortType.DYNAMIC.ordinal()],
-                this.direct.getDirectTriggerCount()));
+
+        if (verbose) {
+            list.add("TS (%s,%s) NL=%02d TrN=%02d TrS=G%03d/D%03d".formatted(
+                    sortBehavior.getShortName(),
+                    splittingMode.getShortName(),
+                    this.gfni.getUniqueNormalCount(),
+                    this.triggeredNormalCount,
+                    this.gfniTriggerCount,
+                    this.directTriggerCount));
+            list.add("N=%05d SNR=%05d STA=%05d DYN=%05d (DIR=%02d)".formatted(
+                    this.sortTypeCounters[SortType.NONE.ordinal()],
+                    this.sortTypeCounters[SortType.STATIC_NORMAL_RELATIVE.ordinal()],
+                    this.sortTypeCounters[SortType.STATIC_TOPO.ordinal()],
+                    this.sortTypeCounters[SortType.DYNAMIC.ordinal()],
+                    this.direct.getDirectTriggerCount()));
+        } else {
+            list.add("TS (%s,%s) NL=%02d - N=%05d St=%05d DYN=%05d (DIR=%02d)".formatted(
+                    sortBehavior.getShortName(),
+                    this.gfni.getUniqueNormalCount(),
+                    this.triggeredNormalCount,
+                    this.sortTypeCounters[SortType.NONE.ordinal()],
+                    this.sortTypeCounters[SortType.STATIC_NORMAL_RELATIVE.ordinal()] + this.sortTypeCounters[SortType.STATIC_TOPO.ordinal()],
+                    this.sortTypeCounters[SortType.DYNAMIC.ordinal()],
+                    this.direct.getDirectTriggerCount()
+            ));
+        }
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/gui/hooks/debug/DebugScreenEntryListMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/gui/hooks/debug/DebugScreenEntryListMixin.java
@@ -1,0 +1,56 @@
+package net.caffeinemc.mods.sodium.mixin.features.gui.hooks.debug;
+
+import net.caffeinemc.mods.sodium.client.SodiumClientMod;
+import net.caffeinemc.mods.sodium.client.services.PlatformRuntimeInformation;
+import net.minecraft.client.gui.components.debug.DebugScreenEntries;
+import net.minecraft.client.gui.components.debug.DebugScreenEntryList;
+import net.minecraft.client.gui.components.debug.DebugScreenEntryStatus;
+import net.minecraft.client.gui.components.debug.DebugScreenProfile;
+import net.minecraft.resources.ResourceLocation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Map;
+
+@Mixin(DebugScreenEntryList.class)
+public class DebugScreenEntryListMixin {
+    @Shadow
+    private Map<ResourceLocation, DebugScreenEntryStatus> allStatuses;
+    
+    @Unique
+    private void setFullDebugStatuses() {
+        if (PlatformRuntimeInformation.getInstance().isDevelopmentEnvironment()) {
+            this.allStatuses.put(SodiumClientMod.SODIUM_DEBUG_ENTRY_FULL, DebugScreenEntryStatus.IN_F3);
+        } else {
+            this.allStatuses.put(SodiumClientMod.SODIUM_DEBUG_ENTRY_REDUCED, DebugScreenEntryStatus.IN_F3);
+        }
+        this.allStatuses.put(DebugScreenEntries.CHUNK_RENDER_STATS, DebugScreenEntryStatus.IN_F3);
+        this.allStatuses.put(DebugScreenEntries.MEMORY, DebugScreenEntryStatus.IN_F3);
+        this.allStatuses.put(DebugScreenEntries.SYSTEM_SPECS, DebugScreenEntryStatus.IN_F3);
+    }
+
+    @Unique
+    private void setReducedDebugStatuses() {
+        this.allStatuses.put(SodiumClientMod.SODIUM_DEBUG_ENTRY_REDUCED, DebugScreenEntryStatus.IN_F3);
+        this.allStatuses.put(DebugScreenEntries.CHUNK_RENDER_STATS, DebugScreenEntryStatus.IN_F3);
+    }
+
+    @Inject(method = "loadDefaultProfile", at = @At(value = "FIELD", shift = At.Shift.AFTER, target = "Lnet/minecraft/client/gui/components/debug/DebugScreenEntryList;allStatuses:Ljava/util/Map;"))
+    private void injectLoadDefaultProfile(CallbackInfo ci) {
+        this.setFullDebugStatuses();
+    }
+
+    @Inject(method = "loadProfile", at = @At(value = "FIELD", shift = At.Shift.AFTER, target = "Lnet/minecraft/client/gui/components/debug/DebugScreenEntryList;allStatuses:Ljava/util/Map;"))
+    private void injectLoadProfile(DebugScreenProfile debugScreenProfile, CallbackInfo ci) {
+        if (debugScreenProfile == DebugScreenProfile.PERFORMANCE && !PlatformRuntimeInformation.getInstance().isDevelopmentEnvironment()) {
+            this.setReducedDebugStatuses();
+        } else {
+            this.setFullDebugStatuses();
+        }
+    }
+}
+

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/gui/hooks/debug/DebugScreenEntryListMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/gui/hooks/debug/DebugScreenEntryListMixin.java
@@ -23,11 +23,6 @@ public class DebugScreenEntryListMixin {
     
     @Unique
     private void setFullDebugStatuses() {
-        if (PlatformRuntimeInformation.getInstance().isDevelopmentEnvironment()) {
-            this.allStatuses.put(SodiumClientMod.SODIUM_DEBUG_ENTRY_FULL, DebugScreenEntryStatus.IN_F3);
-        } else {
-            this.allStatuses.put(SodiumClientMod.SODIUM_DEBUG_ENTRY_REDUCED, DebugScreenEntryStatus.IN_F3);
-        }
         this.allStatuses.put(DebugScreenEntries.CHUNK_RENDER_STATS, DebugScreenEntryStatus.IN_F3);
         this.allStatuses.put(DebugScreenEntries.MEMORY, DebugScreenEntryStatus.IN_F3);
         this.allStatuses.put(DebugScreenEntries.SYSTEM_SPECS, DebugScreenEntryStatus.IN_F3);
@@ -35,7 +30,6 @@ public class DebugScreenEntryListMixin {
 
     @Unique
     private void setReducedDebugStatuses() {
-        this.allStatuses.put(SodiumClientMod.SODIUM_DEBUG_ENTRY_REDUCED, DebugScreenEntryStatus.IN_F3);
         this.allStatuses.put(DebugScreenEntries.CHUNK_RENDER_STATS, DebugScreenEntryStatus.IN_F3);
     }
 
@@ -50,6 +44,14 @@ public class DebugScreenEntryListMixin {
             this.setReducedDebugStatuses();
         } else {
             this.setFullDebugStatuses();
+        }
+    }
+
+    @Inject(method = "rebuildCurrentList", at = @At("HEAD"))
+    private void injectSodiumSettings(CallbackInfo ci) {
+        ResourceLocation setting = PlatformRuntimeInformation.getInstance().isDevelopmentEnvironment() ? SodiumClientMod.SODIUM_DEBUG_ENTRY_FULL : SodiumClientMod.SODIUM_DEBUG_ENTRY_REDUCED;
+        if (!this.allStatuses.containsKey(setting)) {
+            this.allStatuses.put(setting, DebugScreenEntryStatus.IN_F3);
         }
     }
 }

--- a/common/src/main/resources/sodium-common.mixins.json
+++ b/common/src/main/resources/sodium-common.mixins.json
@@ -52,6 +52,7 @@
     "features.render.entity.cull.EntityRendererMixin",
     "features.render.entity.shadows.ShadowFeatureRendererMixin",
     "features.gui.hooks.debug.DebugScreenEntriesAccessor",
+    "features.gui.hooks.debug.DebugScreenEntryListMixin",
     "features.render.gui.font.BakedGlyphMixin",
     "features.render.gui.outlines.LevelRendererMixin",
     "features.render.immediate.DirectionMixin",


### PR DESCRIPTION
Also splits debug info into verbose and non-verbose modes, which are applied differently depending on the selected profile to reduce clutter. This reduces clutter while still allowing us to debug user issues without as big of a hassle.
Fixes https://github.com/CaffeineMC/sodium/issues/3267