### PR TITLE
Fix Environment Variable Names and Only Run Jobs with Available Secrets

### DIFF
--- a/.github/workflows/build-commit.yml
+++ b/.github/workflows/build-commit.yml
@@ -40,9 +40,8 @@ jobs:
           path: build/mods/*.jar
 
       - name: Publish Commit Snapshot to CaffeineMC Maven
-        # uses the general "publish" task which is allowed to silently skip publishing if publish secrets are not given
-        # this lets forks of this repo run CI without it failing because of missing credentials
-        run: ./gradlew publish
         env:
           ORG_GRADLE_PROJECT_caffeineMCMavenUsername: ${{ secrets.CAFFEINEMC_MAVEN_USERNAME }}
           ORG_GRADLE_PROJECT_caffeineMCMavenPassword: ${{ secrets.CAFFEINEMC_MAVEN_PASSWORD }}
+        if: ${{ env.ORG_GRADLE_PROJECT_caffeineMCMavenUsername != '' && env.ORG_GRADLE_PROJECT_caffeineMCMavenPassword != '' }}
+        run: ./gradlew publishAllPublicationsToCaffeineMCRepository

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -39,9 +39,10 @@ jobs:
         with:
           name: sodium-artifacts-${{ steps.ref.outputs.branch }}
           path: build/mods/*.jar
-      
+
       - name: Publish Tag Release to CaffeineMC Maven
-        run: ./gradlew publishMavenPublicationToCaffeineMCRepository -Pbuild.release=true
         env:
-          ORG_GRADLE_caffeineMCMavenUsername: ${{ secrets.CAFFEINEMC_MAVEN_USERNAME }}
-          ORG_GRADLE_caffeineMCMavenPassword: ${{ secrets.CAFFEINEMC_MAVEN_PASSWORD }}
+          ORG_GRADLE_PROJECT_caffeineMCMavenUsername: ${{ secrets.CAFFEINEMC_MAVEN_USERNAME }}
+          ORG_GRADLE_PROJECT_caffeineMCMavenPassword: ${{ secrets.CAFFEINEMC_MAVEN_PASSWORD }}
+        if: ${{ env.ORG_GRADLE_PROJECT_caffeineMCMavenUsername != '' && env.ORG_GRADLE_PROJECT_caffeineMCMavenPassword != '' }}
+        run: ./gradlew publishAllPublicationsToCaffeineMCRepository -Pbuild.release=true

--- a/buildSrc/src/main/kotlin/multiloader-platform.gradle.kts
+++ b/buildSrc/src/main/kotlin/multiloader-platform.gradle.kts
@@ -35,20 +35,18 @@ publishing {
 
     repositories {
         val isReleaseBuild = project.hasProperty("build.release")
-        val caffeineMCMavenUsername: String? by project // reads from ORG_GRADLE_caffeineMCMavenUsername
-        val caffeineMCMavenPassword: String? by project // reads from ORG_GRADLE_caffeineMCMavenPassword
+        val caffeineMCMavenUsername: String? by project // reads from ORG_GRADLE_PROJECT_caffeineMCMavenUsername
+        val caffeineMCMavenPassword: String? by project // reads from ORG_GRADLE_PROJECT_caffeineMCMavenPassword
 
-        if (caffeineMCMavenUsername != null && caffeineMCMavenPassword != null) {
-            maven {
-                name = "CaffeineMC"
-                url = uri("https://maven.caffeinemc.net".let {
-                    if (isReleaseBuild) "$it/releases" else "$it/snapshots"
-                })
+        maven {
+            name = "CaffeineMC"
+            url = uri("https://maven.caffeinemc.net".let {
+                if (isReleaseBuild) "$it/releases" else "$it/snapshots"
+            })
 
-                credentials {
-                    username = caffeineMCMavenUsername
-                    password = caffeineMCMavenPassword
-                }
+            credentials {
+                username = caffeineMCMavenUsername
+                password = caffeineMCMavenPassword
             }
         }
     }


### PR DESCRIPTION
Fix env var naming and use conditional job to only run publish if secrets are available.