### PR TITLE
Avoid Too Early Minecraft Class Loading Through Service Loader

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/services/Services.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/services/Services.java
@@ -1,11 +1,14 @@
 package net.caffeinemc.mods.sodium.client.services;
 
-import net.caffeinemc.mods.sodium.client.SodiumClientMod;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ServiceLoader;
 import java.util.function.Supplier;
 
 public class Services {
+    private static final Logger LOGGER = LoggerFactory.getLogger("Sodium (Service)");
+
     // This code is used to load a service for the current environment. Your implementation of the service must be defined
     // manually by including a text file in META-INF/services named with the fully qualified class name of the service.
     // Inside the file you should write the fully qualified class name of the implementation to load for the platform.
@@ -13,7 +16,7 @@ public class Services {
         final T loadedService = ServiceLoader.load(clazz)
                 .findFirst()
                 .orElseThrow(() -> new NullPointerException("Failed to load service for " + clazz.getName()));
-        SodiumClientMod.logger().debug("Loaded {} for service {}", loadedService, clazz);
+        LOGGER.debug("Loaded {} for service {}", loadedService, clazz);
         return loadedService;
     }
 
@@ -21,7 +24,7 @@ public class Services {
         final T loadedService = ServiceLoader.load(clazz)
                 .findFirst()
                 .orElse(supplier.get());
-        SodiumClientMod.logger().debug("Loaded {} for service {}", loadedService, clazz);
+        LOGGER.debug("Loaded {} for service {}", loadedService, clazz);
         return loadedService;
     }
 }


### PR DESCRIPTION
Use local Logger instance in Service Loader to avoid indirectly loading Minecraft classes too early.
Thanks to @ishland for pointing this out this problem. They have confirmed this patch works.