### PR TITLE
Show Information About Offending Option on Exceptions During Option Overlay Processing

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/config/structure/Config.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/config/structure/Config.java
@@ -128,8 +128,12 @@ public class Config implements ConfigState {
                         // apply overlay to option if it exists
                         if (overlay != null) {
                             var change = overlay.change();
-                            var overlaidOption = change.buildWithBaseOption(option);
-                            exchangeOption(options, i, overlaidOption, option);
+                            try {
+                                var overlaidOption = change.buildWithBaseOption(option);
+                                exchangeOption(options, i, overlaidOption, option);
+                            } catch (Exception e) {
+                                throw new IllegalArgumentException("Failed to apply overlay from '" + overlay.source() + "' to option '" + option.id + "'", e);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Rethrows the exception that may occur while building an option overlay to show which mod added it.