### PR TITLE
Separate Workflows for Commit Building and Publishing

### DIFF
--- a/.github/workflows/build-commit-publish.yml
+++ b/.github/workflows/build-commit-publish.yml
@@ -1,12 +1,16 @@
-# Used when building external pull requests
-# We don't want to publish build artifacts or expose our other caches to possibly untrusted code
-name: build-pull-request
+# Used when a commit is pushed to the repository
+# This makes use of caching for faster builds and uploads the resulting artifacts
+name: build-commit
 
-on: [ pull_request ]
+on:
+  push:
+    branches:
+      - dev
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: staging
 
     steps:
       - name: Extract current branch name
@@ -27,7 +31,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          cache-read-only: true
+          cache-read-only: false
 
       - name: Execute Gradle build
         run: ./gradlew build
@@ -37,3 +41,10 @@ jobs:
         with:
           name: sodium-artifacts-${{ steps.ref.outputs.branch }}
           path: build/mods/*.jar
+
+      - name: Publish Release Snapshot to CaffeineMC Maven
+        env:
+          ORG_GRADLE_PROJECT_caffeineMCMavenUsername: ${{ secrets.CAFFEINEMC_MAVEN_USERNAME }}
+          ORG_GRADLE_PROJECT_caffeineMCMavenPassword: ${{ secrets.CAFFEINEMC_MAVEN_PASSWORD }}
+        if: ${{ env.ORG_GRADLE_PROJECT_caffeineMCMavenUsername != '' && env.ORG_GRADLE_PROJECT_caffeineMCMavenPassword != '' }}
+        run: ./gradlew publishAllPublicationsToCaffeineMCRepository

--- a/.github/workflows/build-commit.yml
+++ b/.github/workflows/build-commit.yml
@@ -2,13 +2,14 @@
 # This makes use of caching for faster builds and uploads the resulting artifacts
 name: build-commit
 
-on: [ push ]
+on:
+  push:
+    branches-ignore:
+      - dev
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment:
-      name: staging
 
     steps:
       - name: Extract current branch name
@@ -16,6 +17,7 @@ jobs:
         # bash pattern expansion to grab branch name without slashes
         run: ref="${GITHUB_REF#refs/heads/}" && echo "branch=${ref////-}" >> $GITHUB_OUTPUT
         id: ref
+
       - name: Checkout sources
         uses: actions/checkout@v4
 
@@ -38,10 +40,3 @@ jobs:
         with:
           name: sodium-artifacts-${{ steps.ref.outputs.branch }}
           path: build/mods/*.jar
-
-      - name: Publish Commit Snapshot to CaffeineMC Maven
-        env:
-          ORG_GRADLE_PROJECT_caffeineMCMavenUsername: ${{ secrets.CAFFEINEMC_MAVEN_USERNAME }}
-          ORG_GRADLE_PROJECT_caffeineMCMavenPassword: ${{ secrets.CAFFEINEMC_MAVEN_PASSWORD }}
-        if: ${{ env.ORG_GRADLE_PROJECT_caffeineMCMavenUsername != '' && env.ORG_GRADLE_PROJECT_caffeineMCMavenPassword != '' }}
-        run: ./gradlew publishAllPublicationsToCaffeineMCRepository


### PR DESCRIPTION
This lets us do things differently based on the branch and require a staging environment in the one and not in the other. I tried using separate jobs within the same workflow but it was not elegant at all.

Also updated the PR workflow, but the changes are insubstantial.

Fixes https://github.com/CaffeineMC/sodium/issues/3363