### PR TITLE
Add AMD Workarounds

### DIFF
--- a/common/src/boot/java/net/caffeinemc/mods/sodium/client/compatibility/workarounds/Workarounds.java
+++ b/common/src/boot/java/net/caffeinemc/mods/sodium/client/compatibility/workarounds/Workarounds.java
@@ -1,6 +1,7 @@
 package net.caffeinemc.mods.sodium.client.compatibility.workarounds;
 
 import net.caffeinemc.mods.sodium.client.compatibility.environment.OsUtils;
+import net.caffeinemc.mods.sodium.client.compatibility.workarounds.amd.AmdWorkarounds;
 import net.caffeinemc.mods.sodium.client.compatibility.workarounds.intel.IntelWorkarounds;
 import net.caffeinemc.mods.sodium.client.compatibility.workarounds.nvidia.NvidiaWorkarounds;
 import org.slf4j.Logger;
@@ -39,6 +40,10 @@ public class Workarounds {
 
         if (NvidiaWorkarounds.isNvidiaGraphicsCardPresent()) {
             workarounds.add(Reference.NVIDIA_THREADED_OPTIMIZATIONS_BROKEN);
+        }
+
+        if (AmdWorkarounds.isAmdGraphicsCardPresent()) {
+            workarounds.add(Reference.AMD_GAME_OPTIMIZATION_BROKEN);
         }
 
         if (IntelWorkarounds.isUsingIntelGen8OrOlder()) {
@@ -96,6 +101,15 @@ public class Workarounds {
          * the base model.
          * <a href="https://github.com/CaffeineMC/sodium/issues/2830">GitHub Issue</a>
          */
-        INTEL_DEPTH_BUFFER_COMPARISON_UNRELIABLE
+        INTEL_DEPTH_BUFFER_COMPARISON_UNRELIABLE,
+
+        /**
+         * AMD's graphics driver starting at 25.10.2 does not correctly handle glMapBufferRange
+         * when minecraft is detected, causing terrain rendering to go invisible if the launcher allows minecraft
+         * to be detected. Most commonly this happens with some third party PVP clients,
+         * but can happen with other launchers.
+         * <a href="https://github.com/CaffeineMC/sodium/issues/3318">GitHub Issue</a>
+         */
+        AMD_GAME_OPTIMIZATION_BROKEN
     }
 }

--- a/common/src/boot/java/net/caffeinemc/mods/sodium/client/compatibility/workarounds/amd/AmdWorkarounds.java
+++ b/common/src/boot/java/net/caffeinemc/mods/sodium/client/compatibility/workarounds/amd/AmdWorkarounds.java
@@ -1,0 +1,74 @@
+package net.caffeinemc.mods.sodium.client.compatibility.workarounds.amd;
+
+import net.caffeinemc.mods.sodium.client.compatibility.environment.OsUtils;
+import net.caffeinemc.mods.sodium.client.compatibility.environment.probe.GraphicsAdapterProbe;
+import net.caffeinemc.mods.sodium.client.compatibility.environment.probe.GraphicsAdapterVendor;
+import net.caffeinemc.mods.sodium.client.compatibility.workarounds.nvidia.NvidiaWorkarounds;
+import net.caffeinemc.mods.sodium.client.platform.windows.WindowsCommandLine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AmdWorkarounds {
+    private static final Logger LOGGER = LoggerFactory.getLogger("Sodium-AmdWorkarounds");
+
+    public static boolean isAmdGraphicsCardPresent() {
+        return GraphicsAdapterProbe.getAdapters()
+                .stream()
+                .anyMatch(adapter -> adapter.vendor() == GraphicsAdapterVendor.AMD);
+    }
+
+    public static void undoEnvironmentChanges() {
+        if (OsUtils.getOs() == OsUtils.OperatingSystem.WIN) {
+            undoEnvironmentChanges$Windows();
+        }
+    }
+
+    private static void undoEnvironmentChanges$Windows() {
+        WindowsCommandLine.resetCommandLine();
+    }
+
+    public static void applyEnvironmentChanges() {
+        // We can't know if the OpenGL context will actually be initialized using the AMD ICD, but we need to
+        // modify the process environment *now* otherwise the driver will initialize with bad settings. For non-AMD
+        // drivers, these workarounds are not likely to cause issues.
+        if (!isAmdGraphicsCardPresent()) {
+            return;
+        }
+
+        // Skip applying the AMD workaround if the user also has an Nvidia gpu, to avoid attempting to overwrite the
+        // process command line twice.
+        if (NvidiaWorkarounds.isNvidiaGraphicsCardPresent()) {
+            return;
+        }
+
+        LOGGER.info("Modifying process environment to apply workarounds for the AMD graphics driver...");
+
+        try {
+            if (OsUtils.getOs() == OsUtils.OperatingSystem.WIN) {
+                applyEnvironmentChanges$Windows();
+            }
+        } catch (Throwable t) {
+            LOGGER.error("Failed to modify the process environment", t);
+            logWarning();
+        }
+    }
+
+
+    private static void applyEnvironmentChanges$Windows() {
+        // The new AMD drivers rely on parsing the command line arguments to detect Minecraft.
+        // When they do they apply an optimization that is broken with sodium present
+        // This stops AMD drivers from detecting the game
+        WindowsCommandLine.setCommandLine("net.caffeinemc.sodium / net.minecraft.client.main.Main /");
+    }
+
+    private static void logWarning() {
+        LOGGER.error("READ ME!");
+        LOGGER.error("READ ME! The workarounds for the AMD Graphics Driver did not apply correctly!");
+        LOGGER.error("READ ME! You may run into unexplained graphical issues.");
+        LOGGER.error("READ ME! More information about what went wrong can be found above this message.");
+        LOGGER.error("READ ME!");
+        LOGGER.error("READ ME! Please help us understand why this problem occurred by opening a bug report on our issue tracker:");
+        LOGGER.error("READ ME!   https://github.com/CaffeineMC/sodium/issues");
+        LOGGER.error("READ ME!");
+    }
+}

--- a/common/src/boot/java/net/caffeinemc/mods/sodium/client/platform/windows/WindowsCommandLine.java
+++ b/common/src/boot/java/net/caffeinemc/mods/sodium/client/platform/windows/WindowsCommandLine.java
@@ -17,10 +17,14 @@ public class WindowsCommandLine {
         // Pointer into the command-line arguments stored within the Windows process structure
         // We do not own this memory, and it should not be freed.
         var pCmdline = Kernel32.getCommandLine();
+        var pCmdlineA = Kernel32.getCommandLineA();
 
         // The original command-line the process was started with.
         var cmdline = MemoryUtil.memUTF16(pCmdline);
         var cmdlineLen = MemoryUtil.memLengthUTF16(cmdline, true);
+
+        var cmdlineA = MemoryUtil.memASCII(pCmdlineA);
+        var cmdLineLenA = MemoryUtil.memLengthASCII(cmdlineA, true);
 
         if (MemoryUtil.memLengthUTF16(modifiedCmdline, true) > cmdlineLen) {
             // We can never write a string which is larger than what we were given, as there
@@ -30,12 +34,18 @@ public class WindowsCommandLine {
             throw new BufferOverflowException();
         }
 
+        if (MemoryUtil.memLengthASCII(modifiedCmdline, true) > cmdLineLenA) {
+            throw new BufferOverflowException();
+        }
+
         ByteBuffer buffer = MemoryUtil.memByteBuffer(pCmdline, cmdlineLen);
+        ByteBuffer bufferA = MemoryUtil.memByteBuffer(pCmdlineA, cmdLineLenA);
 
         // Write the new command line arguments into the process structure.
         // The Windows API documentation explicitly says this is forbidden, but it *does* give us a pointer
         // directly into the PEB structure, so...
         MemoryUtil.memUTF16(modifiedCmdline, true, buffer);
+        MemoryUtil.memASCII(modifiedCmdline, true, bufferA);
 
         // Make sure we can actually see our changes in the process structure
         // We don't know if this could ever actually happen, but since we're doing something pretty hacky
@@ -43,8 +53,11 @@ public class WindowsCommandLine {
         if (!Objects.equals(modifiedCmdline, MemoryUtil.memUTF16(pCmdline))) {
             throw new RuntimeException("Sanity check failed, the command line arguments did not appear to change");
         }
+        if (!Objects.equals(modifiedCmdline, MemoryUtil.memASCII(pCmdlineA))) {
+            throw new RuntimeException("Sanity check failed, the command line arguments did not appear to change");
+        }
 
-        ACTIVE_COMMAND_LINE_HOOK = new CommandLineHook(cmdline, buffer);
+        ACTIVE_COMMAND_LINE_HOOK = new CommandLineHook(cmdline, cmdlineA, buffer, bufferA);
     }
 
     public static void resetCommandLine() {
@@ -56,13 +69,17 @@ public class WindowsCommandLine {
 
     private static class CommandLineHook {
         private final String cmdline;
+        private final String cmdlineA;
         private final ByteBuffer cmdlineBuf;
+        private final ByteBuffer cmdlineBufA;
 
         private boolean active = true;
 
-        private CommandLineHook(String cmdline, ByteBuffer cmdlineBuf) {
+        private CommandLineHook(String cmdline, String cmdlineA, ByteBuffer cmdlineBuf, ByteBuffer cmdlineBufA) {
             this.cmdline = cmdline;
+            this.cmdlineA = cmdlineA;
             this.cmdlineBuf = cmdlineBuf;
+            this.cmdlineBufA = cmdlineBufA;
         }
 
         public void uninstall() {
@@ -73,6 +90,7 @@ public class WindowsCommandLine {
             // Restore the original value of the command line arguments
             // Must be null-terminated (as it was given to us)
             MemoryUtil.memUTF16(this.cmdline, true, this.cmdlineBuf);
+            MemoryUtil.memASCII(this.cmdlineA, true, this.cmdlineBufA);
 
             this.active = false;
         }

--- a/common/src/boot/java/net/caffeinemc/mods/sodium/client/platform/windows/api/Kernel32.java
+++ b/common/src/boot/java/net/caffeinemc/mods/sodium/client/platform/windows/api/Kernel32.java
@@ -14,6 +14,7 @@ public class Kernel32 {
     private static final int GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS = 1 << 2;
 
     private static final long PFN_GetCommandLineW;
+    private static final long PFN_GetCommandLineA;
     private static final long PFN_SetEnvironmentVariableW;
 
     private static final long PFN_GetModuleHandleExW;
@@ -24,6 +25,7 @@ public class Kernel32 {
 
     static {
         PFN_GetCommandLineW = APIUtil.apiGetFunctionAddress(LIBRARY, "GetCommandLineW");
+        PFN_GetCommandLineA = APIUtil.apiGetFunctionAddress(LIBRARY, "GetCommandLineA");
         PFN_SetEnvironmentVariableW = APIUtil.apiGetFunctionAddress(LIBRARY, "SetEnvironmentVariableW");
         PFN_GetModuleHandleExW = APIUtil.apiGetFunctionAddress(LIBRARY, "GetModuleHandleExW");
         PFN_GetLastError = APIUtil.apiGetFunctionAddress(LIBRARY, "GetLastError");
@@ -48,6 +50,10 @@ public class Kernel32 {
 
     public static long getCommandLine() {
         return JNI.callP(PFN_GetCommandLineW);
+    }
+
+    public static long getCommandLineA() {
+        return JNI.callP(PFN_GetCommandLineA);
     }
 
     public static long getModuleHandleByNames(String[] names) {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/workarounds/context_creation/WindowMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/workarounds/context_creation/WindowMixin.java
@@ -8,6 +8,7 @@ import com.mojang.blaze3d.platform.Window;
 import com.mojang.blaze3d.platform.WindowEventHandler;
 import net.caffeinemc.mods.sodium.client.compatibility.checks.ModuleScanner;
 import net.caffeinemc.mods.sodium.client.compatibility.checks.PostLaunchChecks;
+import net.caffeinemc.mods.sodium.client.compatibility.workarounds.amd.AmdWorkarounds;
 import net.caffeinemc.mods.sodium.client.compatibility.workarounds.nvidia.NvidiaWorkarounds;
 import net.caffeinemc.mods.sodium.client.compatibility.environment.GlContextInfo;
 import net.caffeinemc.mods.sodium.client.platform.NativeWindowHandle;
@@ -36,11 +37,13 @@ public class WindowMixin {
     @Redirect(method = "<init>", at = @At(value = "INVOKE", target = "Lorg/lwjgl/glfw/GLFW;glfwCreateWindow(IILjava/lang/CharSequence;JJ)J"), expect = 0, require = 0)
     private long wrapGlfwCreateWindow(int width, int height, CharSequence title, long monitor, long share) {
         NvidiaWorkarounds.applyEnvironmentChanges();
+        AmdWorkarounds.applyEnvironmentChanges();
 
         try {
             return GLFW.glfwCreateWindow(width, height, title, monitor, share);
         } finally {
             NvidiaWorkarounds.undoEnvironmentChanges();
+            AmdWorkarounds.undoEnvironmentChanges();
         }
     }
 
@@ -52,6 +55,7 @@ public class WindowMixin {
 
         if (applyWorkaroundsLate) {
             NvidiaWorkarounds.applyEnvironmentChanges();
+            AmdWorkarounds.applyEnvironmentChanges();
         }
 
         try {
@@ -59,6 +63,7 @@ public class WindowMixin {
         } finally {
             if (applyWorkaroundsLate) {
                 NvidiaWorkarounds.undoEnvironmentChanges();
+                AmdWorkarounds.undoEnvironmentChanges();
             }
         }
     }


### PR DESCRIPTION
This is more or less a direct copy of the NVIDIA workarounds in function and form.

Fixes issue #3318 by applying a workaround that prevents game detection when an AMD GPU is detected on windows.

In an ideal world this would also detect the driver version and only apply if the version is newer then the version this started, but the WDDM version scheme is not easily decodable and the NVIDIA workarounds do not seem to check for a driver version

some testing notes

the AMD drivers appear apply there patches when 3 conditions are met.
executable name is `javaw.exe`,
process arguments contain `\.minecraft`
and, process arguments contain `--version` with a valid modern game version like `--version 1.21.11`

This parsing of the version is why this issue does not effect users of fabric with the default launcher is it will specify a version string like `--version fabric-loader-0.18.2-1.21.11` which does not parse correctly, whereas other launchers with the issue use `--version 1.21.11-fabric0.18.2`

This also appears to be the first time AMD have done detection for Minecraft, and the optimization is broken with sodium. So anyone in a situation where the game is working currently is also in a situation where this change makes no difference. Meaning this should make no difference in performance for users who do not have the issue. as the AMD optimization being applied and the game working with sodium are mutually exclusive.

If you wish to force the game to be detected and apply the optimization using a launcher like prism launcher you can add a JVM argument like `-Damd=" \\.minecraft --version 1.21.11 "` this ensures the instance satisfies the `--version`  and `\.minecraft` requirements.

This may not be the ideal way of solving this, but it is similar to how NVIDIA drivers are already handled in sodium.
