### PR TITLE
Fix Non-Latin Locales Crashing in Config System

### DIFF
--- a/common/src/api/java/net/caffeinemc/mods/sodium/api/config/option/OptionFlag.java
+++ b/common/src/api/java/net/caffeinemc/mods/sodium/api/config/option/OptionFlag.java
@@ -2,6 +2,8 @@ package net.caffeinemc.mods.sodium.api.config.option;
 
 import net.minecraft.resources.Identifier;
 
+import java.util.Locale;
+
 /**
  * Flags that indicate specific actions required when an option is changed.
  */
@@ -31,7 +33,7 @@ public enum OptionFlag {
      */
     REQUIRES_GAME_RESTART;
 
-    private final Identifier id = Identifier.fromNamespaceAndPath("sodium", "builtin_option_flag." + this.name().toLowerCase());
+    private final Identifier id = Identifier.fromNamespaceAndPath("sodium", "builtin_option_flag." + this.name().toLowerCase(Locale.ROOT));
 
     /**
      * Gets the {@link Identifier} for this option flag.

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/config/search/BigramSearchIndex.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/config/search/BigramSearchIndex.java
@@ -5,6 +5,7 @@ import org.jspecify.annotations.NonNull;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 public class BigramSearchIndex extends SourceStoringIndex {
@@ -54,7 +55,7 @@ public class BigramSearchIndex extends SourceStoringIndex {
     }
 
     private static String conditionText(String text) {
-        text = text.toLowerCase();
+        text = text.toLowerCase(Locale.ROOT);
         text = NON_WORD.matcher(text).replaceAll(" ");
         return text;
     }
@@ -134,9 +135,9 @@ public class BigramSearchIndex extends SourceStoringIndex {
                     var score = queryBigramDensity * ((float) Math.log(sourceCount) + 1) * prevalenceInv;
 
                     // if the query matches exactly the start or part of the source, it is probably significantly more important.
-                    if (source.getText().toLowerCase().startsWith(query.trim())) {
+                    if (source.getText().toLowerCase(Locale.ROOT).startsWith(query.trim())) {
                         score *= 3.0f;
-                    } else if (source.getText().toLowerCase().contains(query.trim())) {
+                    } else if (source.getText().toLowerCase(Locale.ROOT).contains(query.trim())) {
                         score *= 2.0f;
                     }
 


### PR DESCRIPTION
Fix crashes on non-latin locales caused by missing use of Locale.ROOT in toLowerCase()
Fixes #3413