### PR TITLE
Re-add support for non-tinted icons and add basic theme validation

### DIFF
--- a/common/src/api/java/net/caffeinemc/mods/sodium/api/config/USAGE.md
+++ b/common/src/api/java/net/caffeinemc/mods/sodium/api/config/USAGE.md
@@ -203,9 +203,9 @@ Sodium constructs one instance of the entrypoint class, and then calls the early
 
 ### Icon Design
 
-The UI is designed with monochrome binary-alpha icons in mind, which are tinted in the color of each mod's theme. We recommend users of the api either don't supply an icon, or show an appropriately styled icon. Users can also choose to break this convention and present a regular full-color icon through means provided in the API.
+The UI is designed with monochrome, binary-alpha icons in mind. These icons are tinted the color of each mod's theme. We recommend that API users avoid displaying an icon that isn't appropriately styled. However, users can choose to deviate from this convention by presenting a regular, full-color icon using the means provided in the API.
 
-Explicitly setting a theme color is not required, as the system will automatically pick one from a predefined set. If a custom theme color is set, note that it should have a minimum level of saturation to remain true to its purpose: an accent color. The theme color's saturation is automatically adjusted to fulfill this purpose. It is also not reasonable to set the brightness/value of the theme color to be too dark, for aesthetic and accessibility. The theme base color should also not be chosen too bright or the highlight color, which is brighter, has no contrast against it.
+It is not necessary to explicitly set a theme color, as the system will automatically select one from a predefined set. However, if you set a custom theme color, it should have a minimum level of saturation to remain true to its purpose as an accent color. For aesthetic and accessibility reasons, it is also not reasonable to set the brightness/value of the theme color to be too dark. The theme base color should also not be too bright, otherwise the highlight color, which is brighter, will have no contrast against it.
 
 ## API Notes
 

--- a/common/src/api/java/net/caffeinemc/mods/sodium/api/config/USAGE.md
+++ b/common/src/api/java/net/caffeinemc/mods/sodium/api/config/USAGE.md
@@ -199,7 +199,13 @@ Each mod adds a page for its options, within each page there are groups of optio
 
 Some attributes of an option can be provided dynamically, meaning the returned value can depend on the state of another option. The default value, option enablement, and the allowed values can be computed dynamically. The methods for setting a dynamic value provider also require you to specify a list of dependencies, which are the resource locations of the options that the dynamic value provider reads from. Since dynamically evaluated attributes may change the state of an option, cyclic dependencies will lead to option registration failing and the game crashing.
 
-Sodium constructs one instance of the entrypoint class, and then calls the early and late registration methods at the right time. 
+Sodium constructs one instance of the entrypoint class, and then calls the early and late registration methods at the right time.
+
+### Icon Design
+
+The UI is designed with monochrome binary-alpha icons in mind, which are tinted in the color of each mod's theme. We recommend users of the api either don't supply an icon, or show an appropriately styled icon. Users can also choose to break this convention and present a regular full-color icon through means provided in the API.
+
+Explicitly setting a theme color is not required, as the system will automatically pick one from a predefined set. If a custom theme color is set, note that it should have a minimum level of saturation to remain true to its purpose: an accent color. The theme color's saturation is automatically adjusted to fulfill this purpose. It is also not reasonable to set the brightness/value of the theme color to be too dark, for aesthetic and accessibility. The theme base color should also not be chosen too bright or the highlight color, which is brighter, has no contrast against it.
 
 ## API Notes
 
@@ -209,7 +215,7 @@ The API is largely self-explanatory and an example is provided above. Also see S
 
 The `ConfigBuilder` instance passed to the registration method allows quick and easy registration of a mod's own options using `ConfigBuilder.registerOwnModOptions`. The mod's id, name, version or a formatter for the existing version, and the color theme can be configured on the returned `ModOptionsBuilder`. It's also possible to register options for additional mods using `ConfigBuilder.registerModOptions`. Which mod is the "own" mod for `registerOwnModOptions` is determined by the mod that owns the metadata-based entrypoint or the mod id passed to the `@ConfigEntryPointForge("examplemod")` annotation.
 
-Each registered mod gets its own header in the page list. The color of the header and the corresponding entries is randomly selected from a predefined list by default, but can be customized using `ModOptionsBuilder.setColorTheme`. A color theme is created either by specifying three (A)RGB colors or a single base color with the lighter and darker colors getting derived automatically. A mod can also specify an icon with `ModOptionsBuilder.setIcon`, which takes a `Identifier` pointing to a texture, which will be tinted in the theme color and rendered in its entirety as a square.
+Each registered mod gets its own header in the page list. The color of the header and the corresponding entries is randomly selected from a predefined list by default, but can be customized using `ModOptionsBuilder.setColorTheme`. A color theme is created either by specifying three (A)RGB colors or a single base color with the lighter and darker colors getting derived automatically. A mod can also specify an icon with `ModOptionsBuilder.setIcon`, which takes a `Identifier` pointing to a texture, which will be tinted in the theme color and rendered in its entirety as a square. Icons set with `ModOptionsBuilder.setNonTintedIcon` are not tinted.
 
 To simply switch to a new `Screen` when an entry in the video settings screen's page list is clicked, use `ConfigBuilder.createExternalPage` and add the returned page normally after configuring it with a name and a `Consumer<Screen>` that receives the current screen and switches to your custom screen.
 

--- a/common/src/api/java/net/caffeinemc/mods/sodium/api/config/structure/ModOptionsBuilder.java
+++ b/common/src/api/java/net/caffeinemc/mods/sodium/api/config/structure/ModOptionsBuilder.java
@@ -39,6 +39,8 @@ public interface ModOptionsBuilder {
 
     /**
      * Sets the color theme for the mod options UI. A color theme is optional and a theme will be chosen at random (deterministically) from a predetermined set of reasonable colors if none is provided.
+     * <p>
+     * Basic validation is applied to the color theme to ensure it's not grayscale and not too dark.
      *
      * @param colorTheme The color theme builder.
      * @return The current builder instance.
@@ -46,12 +48,31 @@ public interface ModOptionsBuilder {
     ModOptionsBuilder setColorTheme(ColorThemeBuilder colorTheme);
 
     /**
-     * Sets the icon texture for the mod. The icon should be centered within the square texture and the background should be transparent. The icon will be rendered monochrome tinted in the mod's theme color. No icon will be shown if none is provided and the layout adjusted accordingly.
+     * Sets the icon texture for the mod. See the documentation for more information about appropriate icon design. The summary is as follows. An icon should:
      *
-     * @param texture The resource location of the icon texture.
+     * <ul>
+     * <li> Be a square texture (e.g. 64x64, 128x128, etc).</li>
+     * <li> Have a transparent background unless the main content of the icon fills the entire square.</li>
+     * <li> Have binary alpha (fully opaque or fully transparent).</li>
+     * <li> Have limited detail since it will be rendered at a small size.</li>
+     * </ul>
+     * <p>
+     * Icons set with this method are tinted monochrome in the mod's theme color. This means the texture itself should be fully white to result in the theme when tinted.
+     * <p>
+     * No icon will be shown if none is provided and the layout adjusted accordingly.
+     *
+     * @param texture The ID of the icon texture.
      * @return The current builder instance.
      */
     ModOptionsBuilder setIcon(Identifier texture);
+
+    /**
+     * Sets the icon texture for the mod. Same as {@link #setIcon(Identifier)}, but the texture will be rendered in its original color instead of being tinted.
+     *
+     * @param texture The ID of the icon texture.
+     * @return The current builder instance.
+     */
+    ModOptionsBuilder setNonTintedIcon(Identifier texture);
 
     /**
      * Adds a configuration page to the mod options.
@@ -86,7 +107,7 @@ public interface ModOptionsBuilder {
     /**
      * Registers a hook that will be called after an option which has any of the specified flags changed. This can be used to implement custom behavior in response to option changes. To hook on built-in flags, use the identifiers given by {@link OptionFlag#getId()}. The hook is given an array of all flags that triggered the hook. Note that the hook may be called with a set of flags larger than the set of flags it is interested in for performance reasons, since this lets us avoid generating a different flag set for every hook.
      *
-     * @param hook    The hook to run, with the set of all triggered flags.
+     * @param hook     The hook to run, with the set of all triggered flags.
      * @param triggers The flags to listen for.
      * @return The current builder instance.
      */

--- a/common/src/api/java/net/caffeinemc/mods/sodium/api/util/ColorARGB.java
+++ b/common/src/api/java/net/caffeinemc/mods/sodium/api/util/ColorARGB.java
@@ -227,4 +227,8 @@ public class ColorARGB implements ColorU8 {
             default -> 0;
         };
     }
+
+    public static int fromHSV(float[] hsv) {
+        return fromHSV(hsv[0], hsv[1], hsv[2]);
+    }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/config/builder/ColorThemeBuilderImpl.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/config/builder/ColorThemeBuilderImpl.java
@@ -2,8 +2,12 @@ package net.caffeinemc.mods.sodium.client.config.builder;
 
 import net.caffeinemc.mods.sodium.api.config.structure.ColorThemeBuilder;
 import net.caffeinemc.mods.sodium.client.gui.ColorTheme;
+import net.caffeinemc.mods.sodium.client.gui.Colors;
 
 public class ColorThemeBuilderImpl implements ColorThemeBuilder {
+    private static final float MIN_THEME_SATURATION = 0.2f;
+    private static final float MIN_THEME_BRIGHTNESS = 0.55f;
+
     private int baseTheme;
     private int themeHighlight;
     private int themeDisabled;
@@ -13,9 +17,13 @@ public class ColorThemeBuilderImpl implements ColorThemeBuilder {
             throw new IllegalStateException("Base theme must be set");
         }
 
+        this.baseTheme = Colors.constrainColorHSV(this.baseTheme, MIN_THEME_SATURATION, MIN_THEME_BRIGHTNESS);
+
         if (this.themeHighlight == 0 || this.themeDisabled == 0) {
             return new ColorTheme(this.baseTheme);
         } else {
+            this.themeHighlight = Colors.constrainColorHSV(this.themeHighlight, MIN_THEME_SATURATION, MIN_THEME_BRIGHTNESS);
+            this.themeDisabled = Colors.constrainColorHSV(this.themeDisabled, MIN_THEME_SATURATION, 0);
             return new ColorTheme(this.baseTheme, this.themeHighlight, this.themeDisabled);
         }
     }
@@ -28,8 +36,8 @@ public class ColorThemeBuilderImpl implements ColorThemeBuilder {
 
     @Override
     public ColorThemeBuilder setFullThemeRGB(int theme, int themeHighlight, int themeDisabled) {
-        this.baseTheme = theme  | 0xFF000000;
-        this.themeHighlight = themeHighlight  | 0xFF000000;
+        this.baseTheme = theme | 0xFF000000;
+        this.themeHighlight = themeHighlight | 0xFF000000;
         this.themeDisabled = themeDisabled | 0xFF000000;
         return this;
     }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/config/builder/ModOptionsBuilderImpl.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/config/builder/ModOptionsBuilderImpl.java
@@ -25,6 +25,7 @@ class ModOptionsBuilderImpl implements ModOptionsBuilder {
     private String version;
     private ColorTheme theme;
     private Identifier icon;
+    private boolean iconMonochrome = true;
     private final List<Page> pages = new ArrayList<>();
     private List<OptionOverride> optionOverrides;
     private List<OptionOverlay> optionOverlays;
@@ -52,7 +53,7 @@ class ModOptionsBuilderImpl implements ModOptionsBuilder {
             this.theme = ColorTheme.PRESETS[Math.abs(this.configId.hashCode()) % ColorTheme.PRESETS.length];
         }
 
-        return new ModOptions(this.configId, this.name, this.version, this.theme, this.icon, ImmutableList.copyOf(this.pages), overrides, overlays, this.flagHooks);
+        return new ModOptions(this.configId, this.name, this.version, this.theme, this.icon, this.iconMonochrome, ImmutableList.copyOf(this.pages), overrides, overlays, this.flagHooks);
     }
 
     @Override
@@ -82,6 +83,13 @@ class ModOptionsBuilderImpl implements ModOptionsBuilder {
     @Override
     public ModOptionsBuilder setIcon(Identifier texture) {
         this.icon = texture;
+        return this;
+    }
+
+    @Override
+    public ModOptionsBuilder setNonTintedIcon(Identifier texture) {
+        this.icon = texture;
+        this.iconMonochrome = false;
         return this;
     }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/config/structure/ModOptions.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/config/structure/ModOptions.java
@@ -10,7 +10,7 @@ import net.minecraft.resources.Identifier;
 import java.util.Collection;
 import java.util.List;
 
-public record ModOptions(String configId, String name, String version, ColorTheme theme, Identifier icon, ImmutableList<Page> pages, List<OptionOverride> overrides, List<OptionOverlay> overlays, Collection<FlagHook> flagHooks) implements Searchable {
+public record ModOptions(String configId, String name, String version, ColorTheme theme, Identifier icon, boolean iconMonochrome, ImmutableList<Page> pages, List<OptionOverride> overrides, List<OptionOverlay> overlays, Collection<FlagHook> flagHooks) implements Searchable {
     @Override
     public void registerTextSources(SearchIndex index) {
         for (Page page : this.pages) {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/Colors.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/Colors.java
@@ -10,7 +10,6 @@ public class Colors {
     public static final int THEME_DARKER = 0xFF7A9E9E;
     public static final int FOREGROUND = 0xFFFFFFFF;
     public static final int FOREGROUND_DISABLED = 0xFFAAAAAA;
-    public static final int FOREGROUND_INVERTED = 0xFF000000;
 
     public static final int BACKGROUND_LIGHT = 0x40000000;
     public static final int BACKGROUND_MEDIUM = 0x60000000;
@@ -38,5 +37,12 @@ public class Colors {
         var s = Mth.clamp(hsv[1] * (1 - Math.abs(factor)), 0, 1);
         var b = Mth.clamp(hsv[2] * (1 + factor), 0, 1);
         return ColorARGB.transferAlpha(ColorARGB.fromHSV(hsv[0], s, b), color);
+    }
+
+    public static int constrainColorHSV(int color, float minSaturation, float minBrightness) {
+        float[] hsv = ColorARGB.toHSV(color);
+        hsv[1] = Math.max(hsv[1], minSaturation);
+        hsv[2] = Math.max(hsv[2], minBrightness);
+        return ColorARGB.fromHSV(hsv);
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/VideoSettingsScreen.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/VideoSettingsScreen.java
@@ -491,7 +491,7 @@ public class VideoSettingsScreen extends Screen implements ScreenPromptable, Scr
         return this.dim;
     }
 
-    public static int renderIconWithSpacing(GuiGraphics graphics, Identifier icon, int color, int x, int y, int height, int margin) {
+    public static int renderIconWithSpacing(GuiGraphics graphics, Identifier icon, int color, boolean iconMonochrome, int x, int y, int height, int margin) {
         int iconSize = height - margin * 2;
 
         var texture = Minecraft.getInstance().getTextureManager().getTexture(icon);
@@ -500,7 +500,11 @@ public class VideoSettingsScreen extends Screen implements ScreenPromptable, Scr
 
         x = x + margin;
         y = y + height / 2 - iconSize / 2;
-        graphics.blit(RenderPipelines.GUI_TEXTURED, icon, x, y, 0, 0, iconSize, iconSize, w, h, w, h, color);
+        if (iconMonochrome) {
+            graphics.blit(RenderPipelines.GUI_TEXTURED, icon, x, y, 0, 0, iconSize, iconSize, w, h, w, h, color);
+        } else {
+            graphics.blit(RenderPipelines.GUI_TEXTURED, icon, x, y, 0, 0, iconSize, iconSize, w, h, w, h);
+        }
 
         return margin * 2 + iconSize;
     }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/widgets/OptionListWidget.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/widgets/OptionListWidget.java
@@ -88,7 +88,7 @@ public class OptionListWidget extends AbstractOptionList {
             // Add mod header if mod has changed
             if (lastSource == null || lastSource.getModOptions() != modOptions) {
                 listHeight += Layout.OPTION_MOD_MARGIN;
-                var modHeader = new ModHeaderWidget(this, new Dim2i(x, y + listHeight, width, this.entryHeight), modOptions.name(), theme, modOptions.icon());
+                var modHeader = new ModHeaderWidget(this, new Dim2i(x, y + listHeight, width, this.entryHeight), modOptions.name(), theme, modOptions.icon(), modOptions.iconMonochrome());
                 this.addRenderableChild(modHeader);
                 listHeight += this.entryHeight;
             }
@@ -131,7 +131,7 @@ public class OptionListWidget extends AbstractOptionList {
             // Add mod header
             listHeight += Layout.OPTION_MOD_MARGIN;
             var modHeaderStart = listHeight;
-            var modHeader = new ModHeaderWidget(this, new Dim2i(x, y + listHeight, width, this.entryHeight), modOptions.name(), theme, modOptions.icon());
+            var modHeader = new ModHeaderWidget(this, new Dim2i(x, y + listHeight, width, this.entryHeight), modOptions.name(), theme, modOptions.icon(), modOptions.iconMonochrome());
             this.addRenderableChild(modHeader);
             listHeight += this.entryHeight;
 
@@ -272,10 +272,12 @@ public class OptionListWidget extends AbstractOptionList {
 
     private static class ModHeaderWidget extends HeaderWidget {
         final Identifier icon;
+        final boolean iconMonochrome;
 
-        public ModHeaderWidget(AbstractOptionList list, Dim2i dim, String title, ColorTheme theme, Identifier icon) {
+        public ModHeaderWidget(AbstractOptionList list, Dim2i dim, String title, ColorTheme theme, Identifier icon, boolean iconMonochrome) {
             super(list, dim, ChatFormatting.BOLD + title, theme.themeLighter, Colors.BACKGROUND_DARKER);
             this.icon = icon;
+            this.iconMonochrome = iconMonochrome;
         }
 
         @Override
@@ -287,7 +289,7 @@ public class OptionListWidget extends AbstractOptionList {
             int textOffset = Layout.OPTION_TEXT_SIDE_PADDING;
             int textY = this.getCenterY() + Layout.REGULAR_TEXT_BASELINE_OFFSET;
             if (this.icon != null) {
-                textOffset = VideoSettingsScreen.renderIconWithSpacing(graphics, this.icon, this.textColor, this.getX(), this.getY(), this.getHeight(), Layout.ICON_MARGIN);
+                textOffset = VideoSettingsScreen.renderIconWithSpacing(graphics, this.icon,  this.textColor, this.iconMonochrome, this.getX(), this.getY(), this.getHeight(), Layout.ICON_MARGIN);
                 textY = this.getCenterY() + Layout.ICON_TEXT_BASELINE_OFFSET;
             }
             this.drawString(graphics, truncateTextToFit(this.title, this.getWidth() - textOffset), this.getX() + textOffset, textY, this.textColor);

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/widgets/PageListWidget.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/widgets/PageListWidget.java
@@ -147,10 +147,12 @@ public class PageListWidget extends AbstractScrollable {
 
     private class HeaderEntryWidget extends EntryWidget {
         private final Identifier icon;
+        private final boolean iconMonochrome;
 
         HeaderEntryWidget(Dim2i dim, ModOptions modOptions, ColorTheme theme) {
             super(dim, Component.literal(modOptions.name()), Component.literal(modOptions.version()), false, theme);
             this.icon = modOptions.icon();
+            this.iconMonochrome = modOptions.iconMonochrome();
         }
 
         @Override
@@ -159,7 +161,7 @@ public class PageListWidget extends AbstractScrollable {
                 return super.renderIcon(graphics, textColor);
             }
 
-            return VideoSettingsScreen.renderIconWithSpacing(graphics, this.icon, textColor,
+            return VideoSettingsScreen.renderIconWithSpacing(graphics, this.icon, textColor, this.iconMonochrome,
                     this.getX(), this.getY(), this.getHeight(), Layout.ICON_MARGIN);
         }
     }


### PR DESCRIPTION
In response to feedback from @PepperCode1 and others, I'm re-adding the ability to present icons without tint, since some icons are inherently multi-colored and I can't require users to come up with a new monochrome icon and they don't want to show no icon. Additionally, I've added basic theme validation to make sure the theme color is neither grayscale nor too dark.