### PR TITLE
Add cursors to clickable widgets in the config screen

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/CyclingControl.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/CyclingControl.java
@@ -1,5 +1,6 @@
 package net.caffeinemc.mods.sodium.client.gui.options.control;
 
+import com.mojang.blaze3d.platform.cursor.CursorTypes;
 import net.caffeinemc.mods.sodium.client.config.structure.EnumOption;
 import net.caffeinemc.mods.sodium.client.config.structure.Option;
 import net.caffeinemc.mods.sodium.client.gui.ColorTheme;
@@ -69,6 +70,10 @@ public class CyclingControl<T extends Enum<T>> implements Control {
 
             int strWidth = this.getStringWidth(name);
             this.drawString(graphics, name, this.getLimitX() - strWidth - 6, this.getCenterY() + Layout.REGULAR_TEXT_BASELINE_OFFSET, Colors.FOREGROUND);
+
+            if(this.isHovered()) {
+                graphics.requestCursor(CursorTypes.POINTING_HAND);
+            }
         }
 
         @Override

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/CyclingControl.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/CyclingControl.java
@@ -71,7 +71,7 @@ public class CyclingControl<T extends Enum<T>> implements Control {
             int strWidth = this.getStringWidth(name);
             this.drawString(graphics, name, this.getLimitX() - strWidth - 6, this.getCenterY() + Layout.REGULAR_TEXT_BASELINE_OFFSET, Colors.FOREGROUND);
 
-            if(this.isHovered()) {
+            if (this.isHovered()) {
                 graphics.requestCursor(CursorTypes.POINTING_HAND);
             }
         }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/ExternalButtonControl.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/ExternalButtonControl.java
@@ -83,7 +83,7 @@ public class ExternalButtonControl implements Control {
                     this.getCenterY() + Layout.REGULAR_TEXT_BASELINE_OFFSET,
                     Colors.FOREGROUND);
 
-            if(this.isHovered()) {
+            if (this.isHovered()) {
                 graphics.requestCursor(CursorTypes.POINTING_HAND);
             }
         }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/ExternalButtonControl.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/ExternalButtonControl.java
@@ -1,5 +1,6 @@
 package net.caffeinemc.mods.sodium.client.gui.options.control;
 
+import com.mojang.blaze3d.platform.cursor.CursorTypes;
 import net.caffeinemc.mods.sodium.client.config.structure.ExternalButtonOption;
 import net.caffeinemc.mods.sodium.client.config.structure.Option;
 import net.caffeinemc.mods.sodium.client.gui.ColorTheme;
@@ -81,6 +82,10 @@ public class ExternalButtonControl implements Control {
                     this.getLimitX() - Layout.OPTION_TEXT_SIDE_PADDING - this.font.width(buttonText),
                     this.getCenterY() + Layout.REGULAR_TEXT_BASELINE_OFFSET,
                     Colors.FOREGROUND);
+
+            if(this.isHovered()) {
+                graphics.requestCursor(CursorTypes.POINTING_HAND);
+            }
         }
 
         private void openScreen(Screen screen) {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/SliderControl.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/SliderControl.java
@@ -1,5 +1,6 @@
 package net.caffeinemc.mods.sodium.client.gui.options.control;
 
+import com.mojang.blaze3d.platform.cursor.CursorTypes;
 import net.caffeinemc.mods.sodium.client.config.structure.IntegerOption;
 import net.caffeinemc.mods.sodium.client.config.structure.Option;
 import net.caffeinemc.mods.sodium.client.config.structure.StatefulOption;
@@ -102,6 +103,10 @@ public class SliderControl implements Control {
                 this.drawString(graphics, label, sliderX - labelWidth - 6, sliderY + (sliderHeight / 2) + Layout.REGULAR_TEXT_BASELINE_OFFSET, Colors.FOREGROUND);
             } else {
                 this.drawString(graphics, label, sliderX + sliderWidth - labelWidth, sliderY + (sliderHeight / 2) + Layout.REGULAR_TEXT_BASELINE_OFFSET, Colors.FOREGROUND);
+            }
+
+            if(this.isHovered() && this.sliderHeld) {
+                graphics.requestCursor(CursorTypes.RESIZE_EW);
             }
         }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/SliderControl.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/SliderControl.java
@@ -105,7 +105,7 @@ public class SliderControl implements Control {
                 this.drawString(graphics, label, sliderX + sliderWidth - labelWidth, sliderY + (sliderHeight / 2) + Layout.REGULAR_TEXT_BASELINE_OFFSET, Colors.FOREGROUND);
             }
 
-            if(this.isMouseOverSlider(mouseX, mouseY)) {
+            if (this.isMouseOverSlider(mouseX, mouseY)) {
                 graphics.requestCursor(this.sliderHeld ? CursorTypes.RESIZE_EW : CursorTypes.POINTING_HAND);
             }
         }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/SliderControl.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/SliderControl.java
@@ -105,8 +105,8 @@ public class SliderControl implements Control {
                 this.drawString(graphics, label, sliderX + sliderWidth - labelWidth, sliderY + (sliderHeight / 2) + Layout.REGULAR_TEXT_BASELINE_OFFSET, Colors.FOREGROUND);
             }
 
-            if(this.isHovered() && this.sliderHeld) {
-                graphics.requestCursor(CursorTypes.RESIZE_EW);
+            if(this.isMouseOverSlider(mouseX, mouseY)) {
+                graphics.requestCursor(this.sliderHeld ? CursorTypes.RESIZE_EW : CursorTypes.POINTING_HAND);
             }
         }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/TickBoxControl.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/TickBoxControl.java
@@ -93,7 +93,7 @@ public class TickBoxControl implements Control {
                 graphics.fill(xEnd - 1, yEnd - size, xEnd, yEnd, color);
             }
 
-            if(this.isHovered()) {
+            if (this.isHovered()) {
                 graphics.requestCursor(CursorTypes.POINTING_HAND);
             }
         }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/TickBoxControl.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/TickBoxControl.java
@@ -1,5 +1,6 @@
 package net.caffeinemc.mods.sodium.client.gui.options.control;
 
+import com.mojang.blaze3d.platform.cursor.CursorTypes;
 import net.caffeinemc.mods.sodium.client.config.structure.BooleanOption;
 import net.caffeinemc.mods.sodium.client.config.structure.Option;
 import net.caffeinemc.mods.sodium.client.config.structure.StatefulOption;
@@ -90,6 +91,10 @@ public class TickBoxControl implements Control {
 
                 graphics.fill(xEnd - size, yEnd - 1, xEnd, yEnd, color);
                 graphics.fill(xEnd - 1, yEnd - size, xEnd, yEnd, color);
+            }
+
+            if(this.isHovered()) {
+                graphics.requestCursor(CursorTypes.POINTING_HAND);
             }
         }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/widgets/OptionListWidget.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/widgets/OptionListWidget.java
@@ -1,5 +1,6 @@
 package net.caffeinemc.mods.sodium.client.gui.widgets;
 
+import com.mojang.blaze3d.platform.cursor.CursorTypes;
 import it.unimi.dsi.fastutil.objects.Reference2ReferenceMap;
 import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
 import net.caffeinemc.mods.sodium.client.config.ConfigManager;
@@ -335,6 +336,10 @@ public class OptionListWidget extends AbstractOptionList {
                     this.getLimitX() - Layout.OPTION_TEXT_SIDE_PADDING - this.font.width(buttonText),
                     this.getCenterY() + Layout.REGULAR_TEXT_BASELINE_OFFSET,
                     Colors.FOREGROUND);
+
+            if(this.isHovered()) {
+                graphics.requestCursor(CursorTypes.POINTING_HAND);
+            }
         }
 
         @Override

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/widgets/OptionListWidget.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/widgets/OptionListWidget.java
@@ -337,7 +337,7 @@ public class OptionListWidget extends AbstractOptionList {
                     this.getCenterY() + Layout.REGULAR_TEXT_BASELINE_OFFSET,
                     Colors.FOREGROUND);
 
-            if(this.isHovered()) {
+            if (this.isHovered()) {
                 graphics.requestCursor(CursorTypes.POINTING_HAND);
             }
         }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/widgets/PageListWidget.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/widgets/PageListWidget.java
@@ -181,7 +181,7 @@ public class PageListWidget extends AbstractScrollable {
         public void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
             super.render(graphics, mouseX, mouseY, delta);
 
-            if(this.isHovered()) {
+            if (this.isHovered()) {
                 graphics.requestCursor(CursorTypes.POINTING_HAND);
             }
         }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/widgets/PageListWidget.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/widgets/PageListWidget.java
@@ -1,5 +1,6 @@
 package net.caffeinemc.mods.sodium.client.gui.widgets;
 
+import com.mojang.blaze3d.platform.cursor.CursorTypes;
 import it.unimi.dsi.fastutil.objects.Reference2ReferenceMap;
 import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
 import net.caffeinemc.mods.sodium.client.config.ConfigManager;
@@ -174,6 +175,15 @@ public class PageListWidget extends AbstractScrollable {
             super(dim, page.name(), true, theme);
             this.page = page;
             this.scrollTargetStart = scrollTargetStart;
+        }
+
+        @Override
+        public void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+            super.render(graphics, mouseX, mouseY, delta);
+
+            if(this.isHovered()) {
+                graphics.requestCursor(CursorTypes.POINTING_HAND);
+            }
         }
     }
 


### PR DESCRIPTION
Clickable widgets now show the pointer cursor like vanilla Minecraft's widgets do, sliders the resize cursor when dragging.

https://github.com/user-attachments/assets/f4eef570-6591-47ca-9b03-7d34603f5222

