### PR TITLE
Reload video mode when preferred video mode changes

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumConfigBuilder.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumConfigBuilder.java
@@ -245,6 +245,7 @@ public class SodiumConfigBuilder implements ConfigEntryPoint {
                                                     state.readBooleanOption(Identifier.parse("sodium:general.fullscreen"));
                                         },
                                         Identifier.parse("sodium:general.fullscreen"))
+                                .setFlags(OptionFlag.REQUIRES_VIDEOMODE_RELOAD)
                 )
                 .addOption(
                         builder.createBooleanOption(Identifier.parse("sodium:general.vsync"))


### PR DESCRIPTION
it was just missing the flag that tells it to update the video mode based on the preferred video mode. I didn't know this was a thing.

Fixes #3427
