### PR TITLE
Update breaks clauses in fabric.mod.json

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -104,7 +104,8 @@
     "sspb" : "<6.0.0",
     "moreculling": "<1.6.0-beta.2",
     "simply-no-shading": "<7.6.2",
-    "betterend": "<=21.0.11"
+    "betterend" : "<=21.0.11",
+    "enchanteds_sodium_options" : "<1.0.1"
   },
   "provides" : [
     "indium"


### PR DESCRIPTION
add enchanteds_sodium_options breaks for which there's already an update because the old version is broken with 0.8.3