### PR TITLE
Fix incorrect UV mapping for flowing fluid side textures

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/DefaultFluidRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/DefaultFluidRenderer.java
@@ -316,11 +316,11 @@ public class DefaultFluidRenderer {
                     }
                 }
 
-                float u1 = sprite.getU(0.0F);
-                float u2 = sprite.getU(0.5F);
-                float v1 = sprite.getV((1.0F - c1) * 0.5F);
-                float v2 = sprite.getV((1.0F - c2) * 0.5F);
-                float v3 = sprite.getV(0.5F);
+                float u1 = sprite.getU(0.75F);
+                float u2 = sprite.getU(0.25F);
+                float v1 = sprite.getV(0.25F + (1.0F - c1) * 0.5F);
+                float v2 = sprite.getV(0.25F + (1.0F - c2) * 0.5F);
+                float v3 = sprite.getV(0.75F);
 
                 quad.setSprite(sprite);
 
@@ -377,6 +377,19 @@ public class DefaultFluidRenderer {
     private void writeQuad(ChunkModelBuilder builder, TranslucentGeometryCollector collector, Material material, BlockPos offset, ModelQuadView quad,
                            ModelQuadFacing facing, boolean flip) {
         var vertices = this.vertices;
+        float minU = 0.0f;
+        float maxU = 0.0f;
+
+        if (flip) {
+            minU = quad.getTexU(0);
+            maxU = minU;
+
+            for (int i = 1; i < 4; i++) {
+                float u = quad.getTexU(i);
+                minU = Math.min(minU, u);
+                maxU = Math.max(maxU, u);
+            }
+        }
 
         for (int i = 0; i < 4; i++) {
             var out = vertices[flip ? (3 - i + 1) & 0b11 : i];
@@ -386,7 +399,8 @@ public class DefaultFluidRenderer {
 
             out.color = this.quadColors[i];
             out.ao = this.brightness[i];
-            out.u = quad.getTexU(i);
+            float u = quad.getTexU(i);
+            out.u = flip ? (minU + maxU - u) : u;
             out.v = quad.getTexV(i);
             out.light = this.quadLightData.lm[i];
         }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/DefaultFluidRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/DefaultFluidRenderer.java
@@ -377,19 +377,6 @@ public class DefaultFluidRenderer {
     private void writeQuad(ChunkModelBuilder builder, TranslucentGeometryCollector collector, Material material, BlockPos offset, ModelQuadView quad,
                            ModelQuadFacing facing, boolean flip) {
         var vertices = this.vertices;
-        float minU = 0.0f;
-        float maxU = 0.0f;
-
-        if (flip) {
-            minU = quad.getTexU(0);
-            maxU = minU;
-
-            for (int i = 1; i < 4; i++) {
-                float u = quad.getTexU(i);
-                minU = Math.min(minU, u);
-                maxU = Math.max(maxU, u);
-            }
-        }
 
         for (int i = 0; i < 4; i++) {
             var out = vertices[flip ? (3 - i + 1) & 0b11 : i];
@@ -399,8 +386,7 @@ public class DefaultFluidRenderer {
 
             out.color = this.quadColors[i];
             out.ao = this.brightness[i];
-            float u = quad.getTexU(i);
-            out.u = flip ? (minU + maxU - u) : u;
+            out.u = quad.getTexU(i);
             out.v = quad.getTexV(i);
             out.light = this.quadLightData.lm[i];
         }


### PR DESCRIPTION
## Description
This PR fixes visual artifacts on the side faces of flowing fluids (water/lava) where the texture mapping appeared incorrect.

## Changes
Modified `DefaultFluidRenderer.java` to adjust the UV coordinates for horizontal fluid faces.
* Updated `u1` and `u3` sampling offsets to center the texture correctly.
* Adjusted `v` coordinate calculations to match the correct texture quadrant.

<img width="966" height="620" alt="Screenshot 2026-01-27 at 11 52 01 PM" src="https://github.com/user-attachments/assets/2dc8d03e-1089-432d-809e-6952b1900da5" />

<img width="966" height="620" alt="Screenshot 2026-01-27 at 11 51 15 PM" src="https://github.com/user-attachments/assets/f326a338-3ee1-434e-bf4e-6b4733be6054" />


## Related Issues
Fixes #2471

## Testing
- [x] Verified that flowing fluid sides map to the center of the texture file.
- [x] Verified that flowing fluid sides are no longer mapped mirrored.
- [x] Ensured every pixel on the outside of fluid corresponds to the same pixel on the inside.