### PR TITLE
Fix "render list is full" crash casued by immediate presentation

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionFlags.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionFlags.java
@@ -15,9 +15,8 @@ public class RenderSectionFlags {
     public static boolean needsRender(int flags) {
         return (flags & MASK_NEEDS_RENDER) != 0;
     }
-    
-    public static boolean renderingMoreTypesNow(int prevFlags, int newFlags) {
-        // true if there is some bit that is set now and was not set previously
-        return ((newFlags & MASK_NEEDS_RENDER) & ~(prevFlags & MASK_NEEDS_RENDER)) != 0;
+
+    public static int getNewRenderFlags(int prevFlags, int newFlags) {
+        return ((newFlags & MASK_NEEDS_RENDER) & ~(prevFlags & MASK_NEEDS_RENDER));
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -54,9 +54,9 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.LevelChunkSection;
 import org.apache.commons.lang3.ArrayUtils;
+import org.joml.Vector3dc;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
-import org.joml.Vector3dc;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -435,14 +435,17 @@ public class RenderSectionManager {
                 // if result was blocking (or is approximately visible) and section is now newly renderable, force render it since it's probably a newly uncovered chunk.
                 // This also fixes flickering issues with pistons moving blocks and switching between being a mesh and a BE.
                 if (job != null
-                        && (job.isBlocking() || this.isSectionImmediatePresentationCandidate(result.render))
-                        && RenderSectionFlags.renderingMoreTypesNow(prevFlags, chunkBuildOutput.info.flags)) {
-                    // if there is currently no section collector since there was no graph traversal,
-                    // reuse the previous section collector and use it to generate new extended render lists
-                    if (this.sectionCollector == null) {
-                        this.sectionCollector = this.lastSectionCollector;
+                        && (job.isBlocking() || this.isSectionImmediatePresentationCandidate(result.render))) {
+                    // make sure only to add the section's new render flags to avoid duplicate entries in the render list
+                    var newFlags = RenderSectionFlags.getNewRenderFlags(prevFlags, chunkBuildOutput.info.flags);
+                    if (newFlags != 0) {
+                        // if there is currently no section collector since there was no graph traversal,
+                        // reuse the previous section collector and use it to generate new extended render lists
+                        if (this.sectionCollector == null) {
+                            this.sectionCollector = this.lastSectionCollector;
+                        }
+                        this.sectionCollector.visitWithFlags(result.render, newFlags);
                     }
-                    this.sectionCollector.visit(result.render);
                 }
 
                 result.render.setLastMeshResultSize(resultSize);

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/ChunkRenderList.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/ChunkRenderList.java
@@ -1,7 +1,6 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.lists;
 
 import net.caffeinemc.mods.sodium.client.render.chunk.LocalSectionIndex;
-import net.caffeinemc.mods.sodium.client.render.chunk.RenderSection;
 import net.caffeinemc.mods.sodium.client.render.chunk.RenderSectionFlags;
 import net.caffeinemc.mods.sodium.client.render.chunk.region.RenderRegion;
 import net.caffeinemc.mods.sodium.client.util.iterator.ByteArrayIterator;
@@ -126,15 +125,11 @@ public class ChunkRenderList {
         }
     }
 
-    public void add(RenderSection render) {
-        if (this.size >= RenderRegion.REGION_SIZE) {
-            throw new ArrayIndexOutOfBoundsException("Render list is full");
-        }
-
+    /*
+    In immediate presentation mode this method is called during the processing of results for immediate-mode built sections. Sometimes this means that their render flags change as a result of the build. However, when the section was already entered into the render list and the render list was full, this resulted in an exception since previously this method threw when the render list was full. It's also not good to have the section be in the render list twice. The method now accepts a flags parameter, which is set to only the new flags when updating the render lists with immediate built results, to prevent this issue.
+     */
+    public void add(int index, int flags) {
         this.size++;
-
-        int index = render.getSectionIndex();
-        int flags = render.getFlags();
 
         if (((flags >>> RenderSectionFlags.HAS_BLOCK_GEOMETRY) & 1) == 1) {
             this.sectionsWithGeometryMap[index >> 6] |= 1L << (index & 0b111111);

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/SectionCollector.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/SectionCollector.java
@@ -34,10 +34,9 @@ public abstract class SectionCollector implements RenderListProvider, RenderSect
         }
     }
 
-    @Override
-    public void visit(RenderSection section) {
+    private void visit(RenderSection section, int flags) {
         // only process section (and associated render list) if it has content that needs rendering
-        if (section.getFlags() != 0) {
+        if (flags != 0) {
             RenderRegion region = section.getRegion();
             ChunkRenderList renderList = region.getRenderList();
 
@@ -47,7 +46,7 @@ public abstract class SectionCollector implements RenderListProvider, RenderSect
                 this.renderLists.add(renderList);
             }
 
-            renderList.add(section);
+            renderList.add(section.getSectionIndex(), flags);
         }
 
         // always add to rebuild lists though, because it might just not be built yet
@@ -69,6 +68,15 @@ public abstract class SectionCollector implements RenderListProvider, RenderSect
                 queue.add(section);
             }
         }
+    }
+
+    @Override
+    public void visit(RenderSection section) {
+        this.visit(section, section.getFlags());
+    }
+
+    public void visitWithFlags(RenderSection section, int flags) {
+        this.visit(section, flags);
     }
 
     @Override


### PR DESCRIPTION
fix crash when sections are immediate-presented but are already in the render list by only adding the new render flags to the render list.

Fixes #3511 