### PR TITLE
Fix NPE in GFNI trigger integration when geometry planes are discarded

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicData.java
@@ -3,6 +3,7 @@ package net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.SortType;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.trigger.GeometryPlanes;
 import net.minecraft.core.SectionPos;
+import org.jetbrains.annotations.Nullable;
 import org.joml.Vector3dc;
 
 public abstract class DynamicData extends PresentTranslucentData {
@@ -22,7 +23,7 @@ public abstract class DynamicData extends PresentTranslucentData {
 
     public abstract DynamicSorter getSorter();
 
-    public GeometryPlanes getGeometryPlanes() {
+    public @Nullable GeometryPlanes getGeometryPlanes() {
         return this.geometryPlanes;
     }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/trigger/GFNITriggers.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/trigger/GFNITriggers.java
@@ -63,6 +63,9 @@ class GFNITriggers implements SectionTriggers<DynamicData> {
     public void integrateSection(SortTriggering ts, SectionPos pos, DynamicData data, CameraMovement movement) {
         long sectionPos = pos.asLong();
         var geometryPlanes = data.getGeometryPlanes();
+        if (geometryPlanes == null) {
+            return;
+        }
 
         // go through all normal lists and check against the normals that the group
         // builder has. if the normal list has data for the section, but the group


### PR DESCRIPTION
## Summary
Fixes a null-pointer crash reported in #3506 during translucent sorting trigger integration.

## Cause
`DynamicData` can discard its `geometryPlanes` after integration (`discardGeometryPlanes()` sets it to `null`), but `GFNITriggers.integrateSection(...)` always dereferenced `data.getGeometryPlanes()` without a null check.

## Fix
- Added a null guard in `GFNITriggers.integrateSection(...)` and return early when `geometryPlanes` is `null`.
- Marked `DynamicData#getGeometryPlanes()` as `@Nullable` to make the lifecycle contract explicit to callers.

## Validation
- Full project build completed successfully:
  - Command: `./gradlew build`
  - Result: `BUILD SUCCESSFUL`