### PR TITLE
fix: Handle upscaled cloud textures from resource packs

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/world/clouds/CloudRendererMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/world/clouds/CloudRendererMixin.java
@@ -53,8 +53,14 @@ public abstract class CloudRendererMixin {
     private void buildMesh(CloudRenderer.RelativeCameraPos relativeCameraPos, ByteBuffer byteBuffer, int cellX, int cellZ, boolean fancy, int radius) {
         if (this.texture != null) {
             long[] cells = this.texture.cells();
-            int width = this.texture.width();
-            int height = this.texture.height();
+            int texWidth = this.texture.width();
+            int texHeight = this.texture.height();
+
+            int scaleX = texWidth / 256;
+            int scaleZ = texHeight / 256;
+
+            scaleX = Math.max(scaleX, 1);
+            scaleZ = Math.max(scaleZ, 1);
 
             long ptr = MemoryUtil.memAddress(byteBuffer);
             int cellIndex = byteBuffer.position() / 3;
@@ -64,10 +70,10 @@ public abstract class CloudRendererMixin {
                     int dz = ring - Math.abs(dx);
                     if (dz >= 0 && dz <= radius && dx * dx + dz * dz <= radius * radius) {
                         if (dz != 0) {
-                            cellIndex = sodium$addCellGeometryToBuffer(ptr, cellIndex, dx, -dz, relativeCameraPos, fancy, cellX, cellZ, cells, width, height);
+                            cellIndex = sodium$addCellGeometryToBuffer(ptr, cellIndex, dx, -dz, relativeCameraPos, fancy, cellX, cellZ, cells, texWidth, texHeight, scaleX, scaleZ);
                         }
 
-                        cellIndex = sodium$addCellGeometryToBuffer(ptr, cellIndex, dx, dz, relativeCameraPos, fancy, cellX, cellZ, cells, width, height);
+                        cellIndex = sodium$addCellGeometryToBuffer(ptr, cellIndex, dx, dz, relativeCameraPos, fancy, cellX, cellZ, cells, texWidth, texHeight, scaleX, scaleZ);
                     }
                 }
             }
@@ -84,9 +90,13 @@ public abstract class CloudRendererMixin {
                                                       int x,
                                                       int z,
                                                       CloudRenderer.@Nullable RelativeCameraPos orientation,
-                                                      boolean fancy, int camX, int camZ, long[] cells, int texWidth, int texHeight) {
-        int o = Math.floorMod(camX + x, texWidth);
-        int p = Math.floorMod(camZ + z, texHeight);
+                                                      boolean fancy, int camX, int camZ, long[] cells, int texWidth, int texHeight, int scaleX, int scaleZ) {
+        int o = Math.floorMod(camX + x, 256) * scaleX;
+        int p = Math.floorMod(camZ + z, 256) * scaleZ;
+
+        o = Math.min(o, texWidth - 1);
+        p = Math.min(p, texHeight - 1);
+
         long faces = cells[o + p * texWidth];
 
         if (faces == 0) {


### PR DESCRIPTION
Fixes #3483 

This PR fixes the cloud rendering to properly handle upscaled clouds.png textures from resource packs. Previously, when a resource pack provided a cloud texture larger than the vanilla 256x256 resolution, the clouds would be unnaturally enlarged in the world instead of maintaining their vanilla size.

The vanilla cloud renderer uses a 256x256 cell grid for cloud geometry, regardless of texture resolution. When Sodium's optimized cloud renderer was using the raw texture dimensions directly, it caused the cloud grid to expand proportionally with the texture size.

The fix calculates scale factors between the texture dimensions and the vanilla 256x256 grid, then scales the texture lookups accordingly. 

This ensures:
The cloud geometry grid remains at 256x256 cells
Upscaled textures are correctly sampled at the appropriate positions
Clouds render at the same world-space size as vanilla