### PR TITLE
Improve 26.1 Fullscreen Options by Combining Into One

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/config/structure/Config.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/config/structure/Config.java
@@ -342,28 +342,22 @@ public class Config implements ConfigState {
     }
 
     private void processFlags(Set<Identifier> flags) {
-        Minecraft client = Minecraft.getInstance();
-
-        if (client.level != null) {
-            if (flags.contains(OptionFlag.REQUIRES_RENDERER_RELOAD.getId())) {
-                client.levelRenderer.allChanged();
-            } else if (flags.contains(OptionFlag.REQUIRES_RENDERER_UPDATE.getId())) {
-                client.levelRenderer.needsUpdate();
-            }
+        if (flags.contains(OptionFlag.REQUIRES_RENDERER_RELOAD.getId())) {
+            onRendererReload();
+        } else if (flags.contains(OptionFlag.REQUIRES_RENDERER_UPDATE.getId())) {
+            onRendererUpdate();
         }
 
         if (flags.contains(OptionFlag.REQUIRES_ASSET_RELOAD.getId())) {
-            client.updateMaxMipLevel(client.options.mipmapLevels().get());
-            client.delayTextureReload();
+            onAssetReload();
         }
 
         if (flags.contains(OptionFlag.REQUIRES_VIDEOMODE_RELOAD.getId())) {
-            client.getWindow().changeFullscreenVideoMode();
+            onVideoModeReload();
         }
 
         if (flags.contains(OptionFlag.REQUIRES_GAME_RESTART.getId())) {
-            Console.instance().logMessage(MessageLevel.WARN,
-                    "sodium.console.game_restart", true, 10.0);
+            onGameNeedsRestart();
         }
 
         // process the registered flag hooks
@@ -379,6 +373,36 @@ public class Config implements ConfigState {
                 }
             }
         }
+    }
+
+    public static void onRendererUpdate() {
+        var client = Minecraft.getInstance();
+        if (client.level != null) {
+            client.levelRenderer.needsUpdate();
+        }
+    }
+
+    public static void onRendererReload() {
+        var client = Minecraft.getInstance();
+        if (client.level != null) {
+            client.levelRenderer.allChanged();
+        }
+    }
+
+    public static void onAssetReload() {
+        var client = Minecraft.getInstance();
+        client.updateMaxMipLevel(client.options.mipmapLevels().get());
+        client.delayTextureReload();
+    }
+
+    public static void onVideoModeReload() {
+        var client = Minecraft.getInstance();
+        client.getWindow().changeFullscreenVideoMode();
+    }
+
+    public static void onGameNeedsRestart() {
+        Console.instance().logMessage(MessageLevel.WARN,
+                "sodium.console.game_restart", true, 10.0);
     }
 
     public boolean readBooleanOption(Identifier id, boolean appliedValue) {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumConfigBuilder.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumConfigBuilder.java
@@ -16,11 +16,13 @@ import net.caffeinemc.mods.sodium.api.config.structure.*;
 import net.caffeinemc.mods.sodium.client.SodiumClientMod;
 import net.caffeinemc.mods.sodium.client.compatibility.environment.OsUtils;
 import net.caffeinemc.mods.sodium.client.compatibility.workarounds.Workarounds;
+import net.caffeinemc.mods.sodium.client.config.structure.Config;
 import net.caffeinemc.mods.sodium.client.gl.arena.staging.MappedStagingBuffer;
 import net.caffeinemc.mods.sodium.client.gl.device.RenderDevice;
 import net.caffeinemc.mods.sodium.client.gui.options.control.ControlValueFormatterImpls;
 import net.caffeinemc.mods.sodium.client.render.chunk.DeferMode;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.QuadSplittingMode;
+import net.caffeinemc.mods.sodium.mixin.features.gui.OptionsAccessor;
 import net.minecraft.client.*;
 import net.minecraft.client.renderer.texture.MipmapStrategy;
 import net.minecraft.client.renderer.texture.ReloadableTexture;
@@ -80,6 +82,12 @@ public class SodiumConfigBuilder implements ConfigEntryPoint {
             return null;
         }
         return this.window.findBestMonitor();
+    }
+
+    public enum FullscreenMode {
+        OFF,
+        EXCLUSIVE,
+        BORDERLESS
     }
 
     public static void registerIcon(TextureManager textureManager) {
@@ -194,7 +202,7 @@ public class SodiumConfigBuilder implements ConfigEntryPoint {
                                 .setBinding(this.vanillaOpts.guiScale()::set, this.vanillaOpts.guiScale()::get)
                 )
                 .addOption(
-                        builder.createEnumOption(Identifier.parse("sodium:general.fullscreen_mode"), SodiumOptions.FullscreenMode.class)
+                        builder.createEnumOption(Identifier.parse("sodium:general.fullscreen_mode"), FullscreenMode.class)
                                 .setStorageHandler(this.vanillaStorage)
                                 .setName(Component.translatable("sodium.options.fullscreen_mode.name"))
                                 .setTooltip(Component.translatable("sodium.options.fullscreen_mode.tooltip"))
@@ -205,17 +213,13 @@ public class SodiumConfigBuilder implements ConfigEntryPoint {
                                     case BORDERLESS ->
                                             Component.translatable("sodium.options.fullscreen_mode.borderless");
                                 })
-                                .setDefaultValue(SodiumOptions.FullscreenMode.OFF)
-                                .setFlags(OptionFlag.REQUIRES_GAME_RESTART) // TODO: needs to be conditional
+                                .setDefaultValue(FullscreenMode.OFF)
                                 .setImpact(OptionImpact.HIGH)
                                 .setBinding(
                                         // modifies fullscreen and exclusive fullscreen together since they are interdependent in Vanilla's implementation
                                         value -> {
                                             switch (value) {
-                                                case OFF -> {
-                                                    this.vanillaOpts.fullscreen().set(false);
-                                                    this.vanillaOpts.exclusiveFullscreen().set(false);
-                                                }
+                                                case OFF -> this.vanillaOpts.fullscreen().set(false);
                                                 case EXCLUSIVE -> {
                                                     this.vanillaOpts.fullscreen().set(true);
                                                     this.vanillaOpts.exclusiveFullscreen().set(true);
@@ -238,13 +242,21 @@ public class SodiumConfigBuilder implements ConfigEntryPoint {
                                             boolean fullscreen = this.vanillaOpts.fullscreen().get();
                                             boolean exclusive = this.vanillaOpts.exclusiveFullscreen().get();
                                             if (fullscreen && exclusive) {
-                                                return SodiumOptions.FullscreenMode.EXCLUSIVE;
+                                                return FullscreenMode.EXCLUSIVE;
                                             } else if (fullscreen) {
-                                                return SodiumOptions.FullscreenMode.BORDERLESS;
+                                                return FullscreenMode.BORDERLESS;
                                             } else {
-                                                return SodiumOptions.FullscreenMode.OFF;
+                                                return FullscreenMode.OFF;
                                             }
                                         })
+                                .setApplyHook((_) -> {
+                                    // check for a change in the exclusivity of the fullscreen mode (though don't care if fullscreen mode has been turned off)
+                                    var initialExclusiveFullscreen = ((OptionsAccessor) Minecraft.getInstance().options).sodium$initialExclusiveFullscreen();
+                                    var currentExclusiveFullscreen = this.vanillaOpts.exclusiveFullscreen().get();
+                                    if (initialExclusiveFullscreen != currentExclusiveFullscreen) {
+                                        Config.onGameNeedsRestart();
+                                    }
+                                })
                 )
                 .addOption(
                         builder.createIntegerOption(Identifier.parse("sodium:general.fullscreen_resolution"))
@@ -276,9 +288,9 @@ public class SodiumConfigBuilder implements ConfigEntryPoint {
                                                 return false;
                                             }
                                             var os = OsUtils.getOs();
-                                            var fullscreenMode = state.readEnumOption(Identifier.parse("sodium:general.fullscreen_mode"), SodiumOptions.FullscreenMode.class);
+                                            var fullscreenMode = state.readEnumOption(Identifier.parse("sodium:general.fullscreen_mode"), FullscreenMode.class);
                                             return (os == OsUtils.OperatingSystem.WIN || os == OsUtils.OperatingSystem.MAC) &&
-                                                    fullscreenMode == SodiumOptions.FullscreenMode.EXCLUSIVE;
+                                                    fullscreenMode == FullscreenMode.EXCLUSIVE;
                                         },
                                         Identifier.parse("sodium:general.fullscreen_mode"))
                                 .setFlags(OptionFlag.REQUIRES_VIDEOMODE_RELOAD)

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumConfigBuilder.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumConfigBuilder.java
@@ -194,21 +194,57 @@ public class SodiumConfigBuilder implements ConfigEntryPoint {
                                 .setBinding(this.vanillaOpts.guiScale()::set, this.vanillaOpts.guiScale()::get)
                 )
                 .addOption(
-                        builder.createBooleanOption(Identifier.parse("sodium:general.fullscreen"))
+                        builder.createEnumOption(Identifier.parse("sodium:general.fullscreen_mode"), SodiumOptions.FullscreenMode.class)
                                 .setStorageHandler(this.vanillaStorage)
-                                .setName(Component.translatable("options.fullscreen"))
-                                .setTooltip(Component.translatable("sodium.options.fullscreen.tooltip"))
-                                .setDefaultValue(false)
-                                .setBinding(value -> {
-                                    this.vanillaOpts.fullscreen().set(value);
+                                .setName(Component.translatable("sodium.options.fullscreen_mode.name"))
+                                .setTooltip(Component.translatable("sodium.options.fullscreen_mode.tooltip"))
+                                .setElementNameProvider(mode -> switch (mode) {
+                                    case OFF -> Component.translatable("sodium.options.fullscreen_mode.off");
+                                    case EXCLUSIVE ->
+                                            Component.translatable("sodium.options.fullscreen_mode.exclusive");
+                                    case BORDERLESS ->
+                                            Component.translatable("sodium.options.fullscreen_mode.borderless");
+                                })
+                                .setDefaultValue(SodiumOptions.FullscreenMode.OFF)
+                                .setFlags(OptionFlag.REQUIRES_GAME_RESTART) // TODO: needs to be conditional
+                                .setImpact(OptionImpact.HIGH)
+                                .setBinding(
+                                        // modifies fullscreen and exclusive fullscreen together since they are interdependent in Vanilla's implementation
+                                        value -> {
+                                            switch (value) {
+                                                case OFF -> {
+                                                    this.vanillaOpts.fullscreen().set(false);
+                                                    this.vanillaOpts.exclusiveFullscreen().set(false);
+                                                }
+                                                case EXCLUSIVE -> {
+                                                    this.vanillaOpts.fullscreen().set(true);
+                                                    this.vanillaOpts.exclusiveFullscreen().set(true);
+                                                }
+                                                case BORDERLESS -> {
+                                                    this.vanillaOpts.fullscreen().set(true);
+                                                    this.vanillaOpts.exclusiveFullscreen().set(false);
+                                                }
+                                            }
 
-                                    if (this.window.isFullscreen() != this.vanillaOpts.fullscreen().get()) {
-                                        this.window.toggleFullScreen();
+                                            // apply the fullscreen state
+                                            if (this.window.isFullscreen() != this.vanillaOpts.fullscreen().get()) {
+                                                this.window.toggleFullScreen();
 
-                                        // The client might not be able to enter full-screen mode
-                                        this.vanillaOpts.fullscreen().set(this.window.isFullscreen());
-                                    }
-                                }, this.vanillaOpts.fullscreen()::get)
+                                                // The client might not be able to enter full-screen mode
+                                                this.vanillaOpts.fullscreen().set(this.window.isFullscreen());
+                                            }
+                                        },
+                                        () -> {
+                                            boolean fullscreen = this.vanillaOpts.fullscreen().get();
+                                            boolean exclusive = this.vanillaOpts.exclusiveFullscreen().get();
+                                            if (fullscreen && exclusive) {
+                                                return SodiumOptions.FullscreenMode.EXCLUSIVE;
+                                            } else if (fullscreen) {
+                                                return SodiumOptions.FullscreenMode.BORDERLESS;
+                                            } else {
+                                                return SodiumOptions.FullscreenMode.OFF;
+                                            }
+                                        })
                 )
                 .addOption(
                         builder.createIntegerOption(Identifier.parse("sodium:general.fullscreen_resolution"))
@@ -240,10 +276,11 @@ public class SodiumConfigBuilder implements ConfigEntryPoint {
                                                 return false;
                                             }
                                             var os = OsUtils.getOs();
+                                            var fullscreenMode = state.readEnumOption(Identifier.parse("sodium:general.fullscreen_mode"), SodiumOptions.FullscreenMode.class);
                                             return (os == OsUtils.OperatingSystem.WIN || os == OsUtils.OperatingSystem.MAC) &&
-                                                    state.readBooleanOption(Identifier.parse("sodium:general.fullscreen"));
+                                                    fullscreenMode == SodiumOptions.FullscreenMode.EXCLUSIVE;
                                         },
-                                        Identifier.parse("sodium:general.fullscreen"))
+                                        Identifier.parse("sodium:general.fullscreen_mode"))
                                 .setFlags(OptionFlag.REQUIRES_VIDEOMODE_RELOAD)
                 )
                 .addOption(
@@ -263,16 +300,6 @@ public class SodiumConfigBuilder implements ConfigEntryPoint {
                                 .setRange(10, 260, 10)
                                 .setDefaultValue(60)
                                 .setBinding(this.vanillaOpts.framerateLimit()::set, this.vanillaOpts.framerateLimit()::get)
-                )
-                .addOption(
-                        builder.createBooleanOption(Identifier.parse("sodium:general.exclusive_fullscreen"))
-                                .setStorageHandler(this.vanillaStorage)
-                                .setName(Component.translatable("options.exclusiveFullscreen"))
-                                .setTooltip(Component.translatable("sodium.options.exclusive_fullscreen.tooltip"))
-                                .setDefaultValue(false)
-                                .setFlags(OptionFlag.REQUIRES_GAME_RESTART)
-                                .setImpact(OptionImpact.HIGH)
-                                .setBinding(this.vanillaOpts.exclusiveFullscreen()::set, this.vanillaOpts.exclusiveFullscreen()::get)
                 )
         );
         generalPage.addOptionGroup(builder.createOptionGroup()

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumOptions.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumOptions.java
@@ -69,12 +69,6 @@ public class SodiumOptions {
         public boolean hasSeenDonationPrompt = false;
     }
 
-    public enum FullscreenMode {
-        OFF,
-        EXCLUSIVE,
-        BORDERLESS
-    }
-
     private static final Gson GSON = new GsonBuilder()
             .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
             .setPrettyPrinting()

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumOptions.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumOptions.java
@@ -69,6 +69,12 @@ public class SodiumOptions {
         public boolean hasSeenDonationPrompt = false;
     }
 
+    public enum FullscreenMode {
+        OFF,
+        EXCLUSIVE,
+        BORDERLESS
+    }
+
     private static final Gson GSON = new GsonBuilder()
             .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
             .setPrettyPrinting()

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/gui/OptionsAccessor.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/gui/OptionsAccessor.java
@@ -1,0 +1,9 @@
+package net.caffeinemc.mods.sodium.mixin.features.gui;
+
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@org.spongepowered.asm.mixin.Mixin(net.minecraft.client.Options.class)
+public interface OptionsAccessor {
+    @Accessor("initialExclusiveFullscreen")
+    boolean sodium$initialExclusiveFullscreen();
+}

--- a/common/src/main/resources/assets/sodium/lang/en_us.json
+++ b/common/src/main/resources/assets/sodium/lang/en_us.json
@@ -12,7 +12,11 @@
   "sodium.options.simulation_distance.tooltip": "The simulation distance controls how far away terrain and entities will be loaded and ticked. Shorter distances can reduce the internal server's load and may improve frame rates.",
   "sodium.options.brightness.tooltip": "Controls the minimum brightness in the world. When increased, darker areas of the world will appear brighter. This does not affect the brightness of already well-lit areas.",
   "sodium.options.gui_scale.tooltip": "Sets the maximum scale factor to be used for the user interface. If \"auto\" is used, then the largest scale factor will always be used.",
-  "sodium.options.fullscreen.tooltip": "If enabled, the game will display in full-screen (if supported).",
+  "sodium.options.fullscreen_mode.name" : "Fullscreen Mode",
+  "sodium.options.fullscreen_mode.off" : "Off",
+  "sodium.options.fullscreen_mode.exclusive" : "Exclusive",
+  "sodium.options.fullscreen_mode.borderless" : "Borderless",
+  "sodium.options.fullscreen_mode.tooltip" : "Exclusive fullscreen can improve latency, but may prevent some input methods from working and slow down switching out of the game. Borderless fullscreen can cause significant performance degradation.",
   "sodium.options.fullscreen_resolution.tooltip": "The monitor resolution and refresh rate to be used when in fullscreen mode. Changing this option may interfere with other applications and cause a delay when switching between applications.\n\nThis is only supported on the Windows or macOS operating systems.",
   "sodium.options.v_sync.tooltip": "If enabled, the game's frame rate will be synchronized to the monitor's refresh rate, making for a generally smoother experience at the expense of overall input latency. This setting might reduce performance if your system is too slow.",
   "sodium.options.fps_limit.tooltip": "Limits the maximum number of frames per second. This can help reduce battery usage and system load when multi-tasking. If VSync is enabled, this option will be ignored unless it is lower than your display's refresh rate.",
@@ -83,6 +87,5 @@
   "sodium.console.config_file_was_reset": "The config file has been reset to known-good defaults.",
   "sodium.options.search": "Search",
   "sodium.options.search.hint": "Search...",
-  "sodium.options.open_external_page_button": "Open",
-  "sodium.options.exclusive_fullscreen.tooltip" : "Toggles exclusive fullscreen mode, which takes exclusive access of a monitor. This option can improve latency, but may prevent some input methods from working and slow down switching out of the game. Non-exclusive fullscreen can cause significant performance degradation."
+  "sodium.options.open_external_page_button" : "Open"
 }

--- a/common/src/main/resources/sodium-common.mixins.json
+++ b/common/src/main/resources/sodium-common.mixins.json
@@ -43,6 +43,7 @@
     "core.world.map.ClientChunkCacheMixin",
     "core.world.map.ClientLevelMixin",
     "core.world.map.ClientPacketListenerMixin",
+    "features.gui.OptionsAccessor",
     "features.gui.hooks.console.GameRendererMixin",
     "features.gui.hooks.debug.DebugEntryMemoryMixin",
     "features.gui.hooks.debug.DebugScreenEntriesAccessor",


### PR DESCRIPTION
instead of two separate interdependent options this turns them into one cycler option and handles the state changes.