### PR TITLE
Fix redundant item side quads generated since 1.21.11

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/model/ImprovedItemModelBuilder.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/model/ImprovedItemModelBuilder.java
@@ -18,30 +18,19 @@ import org.joml.Vector3f;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
+import static net.minecraft.client.resources.model.cuboid.ItemModelGenerator.LAYERS;
+import static net.minecraft.client.resources.model.cuboid.ItemModelGenerator.TEXTURE_SLOTS;
+import static net.minecraft.client.resources.model.cuboid.ItemModelGenerator.SOUTH_FACE_UVS;
+import static net.minecraft.client.resources.model.cuboid.ItemModelGenerator.NORTH_FACE_UVS;
+import static net.minecraft.client.resources.model.cuboid.ItemModelGenerator.MIN_Z;
+import static net.minecraft.client.resources.model.cuboid.ItemModelGenerator.MAX_Z;
+import static net.minecraft.client.resources.model.cuboid.ItemModelGenerator.UV_SHRINK;
 import static net.minecraft.client.resources.model.cuboid.ItemModelGenerator.SideDirection;
 import static net.minecraft.client.resources.model.cuboid.ItemModelGenerator.isTransparent;
 
 public class ImprovedItemModelBuilder implements UnbakedModel {
-	public static final List<String> LAYERS = List.of(
-			"layer0",
-			"layer1",
-			"layer2",
-			"layer3",
-			"layer4"
-	);
-
-	private	static final TextureSlots.Data TEXTURE_SLOTS = new TextureSlots.Data.Builder().addReference("particle", "layer0").build();
-
-	private	static final CuboidFace.UVs SOUTH_FACE_UVS = new CuboidFace.UVs(0.0F, 0.0F, 16.0F, 16.0F);
-	private	static final CuboidFace.UVs NORTH_FACE_UVS = new CuboidFace.UVs(16.0F, 0.0F, 0.0F, 16.0F);
-
-	private	static final float MIN_Z = 7.5F;
-	private	static final float MAX_Z = 8.5F;
-	private	static final float UV_SHRINK = 0.1F;
-
 	@Override
 	public TextureSlots.@NotNull Data textureSlots() {
 		return TEXTURE_SLOTS;
@@ -249,7 +238,7 @@ public class ImprovedItemModelBuilder implements UnbakedModel {
 			int width,
 			int height
 	) {
-		var nneighborTansparent = isTransparent(
+		var neighborTransparent = isTransparent(
 				sprite,
 				frame,
 				pixelX - sideFacing.getDirection().getStepX(),
@@ -258,7 +247,7 @@ public class ImprovedItemModelBuilder implements UnbakedModel {
 				height
 		);
 
-		if (nneighborTansparent) {
+		if (neighborTransparent) {
 			insertOrMergeFace(
 					sideFaces,
 					sideFacing,

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/model/ImprovedItemModelBuilder.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/model/ImprovedItemModelBuilder.java
@@ -1,0 +1,373 @@
+package net.caffeinemc.mods.sodium.client.render.immediate.model;
+
+import com.mojang.math.Quadrant;
+import net.minecraft.client.renderer.block.dispatch.ModelState;
+import net.minecraft.client.renderer.texture.SpriteContents;
+import net.minecraft.client.resources.model.ModelBaker;
+import net.minecraft.client.resources.model.ModelDebugName;
+import net.minecraft.client.resources.model.UnbakedModel;
+import net.minecraft.client.resources.model.cuboid.CuboidFace;
+import net.minecraft.client.resources.model.cuboid.FaceBakery;
+import net.minecraft.client.resources.model.geometry.BakedQuad;
+import net.minecraft.client.resources.model.geometry.QuadCollection;
+import net.minecraft.client.resources.model.geometry.UnbakedGeometry;
+import net.minecraft.client.resources.model.sprite.TextureSlots;
+import net.minecraft.core.Direction;
+import org.jetbrains.annotations.NotNull;
+import org.joml.Vector3f;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static net.minecraft.client.resources.model.cuboid.ItemModelGenerator.SideDirection;
+import static net.minecraft.client.resources.model.cuboid.ItemModelGenerator.isTransparent;
+
+public class ImprovedItemModelBuilder implements UnbakedModel {
+	public static final List<String> LAYERS = List.of(
+			"layer0",
+			"layer1",
+			"layer2",
+			"layer3",
+			"layer4"
+	);
+
+	private	static final TextureSlots.Data TEXTURE_SLOTS = new TextureSlots.Data.Builder().addReference("particle", "layer0").build();
+
+	private	static final CuboidFace.UVs SOUTH_FACE_UVS = new CuboidFace.UVs(0.0F, 0.0F, 16.0F, 16.0F);
+	private	static final CuboidFace.UVs NORTH_FACE_UVS = new CuboidFace.UVs(16.0F, 0.0F, 0.0F, 16.0F);
+
+	private	static final float MIN_Z = 7.5F;
+	private	static final float MAX_Z = 8.5F;
+	private	static final float UV_SHRINK = 0.1F;
+
+	@Override
+	public TextureSlots.@NotNull Data textureSlots() {
+		return TEXTURE_SLOTS;
+	}
+
+	@Override
+	public UnbakedGeometry geometry() {
+		return ImprovedItemModelBuilder::bake;
+	}
+
+	@Override
+	public GuiLight guiLight() {
+		return GuiLight.FRONT;
+	}
+
+	private static QuadCollection bake(
+			TextureSlots textureSlots,
+			ModelBaker modelBaker,
+			ModelState modelState,
+			ModelDebugName debugName
+	) {
+		var builder	= new QuadCollection.Builder();
+
+		for (var index = 0; index < LAYERS.size(); index ++) {
+			var material = textureSlots.getMaterial(LAYERS.get(index));
+
+			if (material == null) {
+				break;
+			}
+
+			var bakedMaterial = modelBaker.materials().get(material, debugName);
+			var quadMaterial = BakedQuad.MaterialInfo.of(
+					bakedMaterial,
+					bakedMaterial.sprite().transparency(),
+					index,
+					true,
+					0
+			);
+
+			builder.addAll(modelBaker.compute(new ItemLayerKey(quadMaterial, modelState)));
+		}
+
+		return builder.build();
+	}
+
+	private static void bakeItemQuads(
+			QuadCollection.Builder builder,
+			ModelBaker.Interner interner,
+			BakedQuad.MaterialInfo materialInfo,
+			ModelState modelState
+	) {
+		var material = interner.materialInfo(materialInfo);
+
+		var from = new Vector3f(0.0F, 0.0F, MIN_Z);
+		var to = new Vector3f(16.0F, 16.0F, MAX_Z);
+
+		builder.addUnculledFace(FaceBakery.bakeQuad(interner, from, to, SOUTH_FACE_UVS, Quadrant.R0, material, Direction.SOUTH, modelState, null));
+		builder.addUnculledFace(FaceBakery.bakeQuad(interner, from, to, NORTH_FACE_UVS, Quadrant.R0, material, Direction.NORTH, modelState, null));
+
+		bakeSideQuads(
+				material,
+				interner,
+				builder,
+				modelState
+		);
+	}
+
+	private static void bakeSideQuads(
+			BakedQuad.MaterialInfo materialInfo,
+			ModelBaker.Interner interner,
+			QuadCollection.Builder builder,
+			ModelState modelState
+	) {
+		var sprite = materialInfo.sprite().contents();
+
+		var xScale = 16.0F / sprite.width();
+		var yScale = 16.0F / sprite.height();
+
+		for (SideFace sideFace : buildSideFaces(sprite)) {
+			var faceFacing = sideFace.facing();
+			var faceAnchor = sideFace.anchor();
+			var faceMin = sideFace.min();
+			var faceMax = sideFace.max();
+
+			float minX = faceFacing.isHorizontal() ? faceMin : faceAnchor;
+			float minY = faceFacing.isHorizontal() ? faceAnchor : faceMin;
+			float length = faceMax - faceMin + 1.0F;
+
+			var u0 = 0.0F;
+			var v0 = 0.0F;
+
+			var u1 = 0.0F;
+			var v1 = 0.0F;
+
+			if (faceFacing.isHorizontal()) {
+				u0 = minX + UV_SHRINK;
+				v0 = minY + UV_SHRINK;
+				u1 = minX + length - UV_SHRINK;
+				v1 = minY + 1.0F - UV_SHRINK;
+			} else {
+				u0 = minX + UV_SHRINK;
+				v0 = minY + length - UV_SHRINK;
+				u1 = minX + 1.0F - UV_SHRINK;
+				v1 = minY + UV_SHRINK;
+			}
+
+			var fromX = minX;
+			var fromY = minY;
+			var toX = minX;
+			var toY = minY;
+
+			switch (faceFacing) {
+				case UP -> {
+					toX = minX + length;
+				}
+				case LEFT -> {
+					toY = minY + length;
+				}
+				case DOWN -> {
+					fromY = minY + 1.0F;
+					toY = minY + 1.0F;
+					toX = minX + length;
+				}
+				case RIGHT -> {
+					fromX = minX + 1.0F;
+					toX = minX + 1.0F;
+					toY = minY + length;
+				}
+			}
+
+			fromX *= xScale;
+			fromY *= yScale;
+			toX *= xScale;
+			toY *= yScale;
+
+			fromY = 16.0F - fromY;
+			toY = 16.0F - toY;
+
+			switch (faceFacing) {
+				case RIGHT -> fromX = toX;
+				case DOWN -> fromY = toY;
+				case LEFT -> toX = fromX;
+				case UP -> toY = fromY;
+				default -> throw new UnsupportedOperationException();
+			}
+
+			builder.addUnculledFace(
+					FaceBakery.bakeQuad(
+							interner,
+							new Vector3f(fromX, fromY, MIN_Z),
+							new Vector3f(toX, toY, MAX_Z),
+							new CuboidFace.UVs(
+									u0 * xScale,
+									v0 * yScale,
+									u1 * xScale,
+									v1 * yScale
+							),
+							Quadrant.R0,
+							materialInfo,
+							faceFacing.getDirection(),
+							modelState,
+							null
+					)
+			);
+		}
+	}
+
+	private static Collection<SideFace> buildSideFaces(SpriteContents sprite) {
+		var width = sprite.width();
+		var height = sprite.height();
+		var sideFaces = new HashSet<SideFace>();
+
+		sprite.getUniqueFrames().forEach(frame -> {
+			for (var pixelY = 0; pixelY < height; pixelY ++) {
+				for (var pixelX = 0; pixelX < width; pixelX ++) {
+					var opaque = !isTransparent(
+							sprite,
+							frame,
+							pixelX,
+							pixelY,
+							width,
+							height
+					);
+
+					if (opaque) {
+						tryInsertFace(SideDirection.UP, sideFaces, sprite, frame, pixelX, pixelY, width, height);
+						tryInsertFace(SideDirection.DOWN, sideFaces, sprite, frame, pixelX, pixelY, width, height);
+						tryInsertFace(SideDirection.LEFT, sideFaces, sprite, frame, pixelX, pixelY, width, height);
+						tryInsertFace(SideDirection.RIGHT, sideFaces, sprite, frame, pixelX, pixelY, width, height);
+					}
+				}
+			}
+		});
+
+		return sideFaces;
+	}
+
+	private static void tryInsertFace(
+			SideDirection sideFacing,
+			Set<SideFace> sideFaces,
+			SpriteContents sprite,
+			int frame,
+			int pixelX,
+			int pixelY,
+			int width,
+			int height
+	) {
+		var nneighborTansparent = isTransparent(
+				sprite,
+				frame,
+				pixelX - sideFacing.getDirection().getStepX(),
+				pixelY - sideFacing.getDirection().getStepY(),
+				width,
+				height
+		);
+
+		if (nneighborTansparent) {
+			insertOrMergeFace(
+					sideFaces,
+					sideFacing,
+					pixelX,
+					pixelY
+			);
+		}
+	}
+
+	private static void insertOrMergeFace(
+			Set<SideFace> sideFaces,
+			SideDirection sideFacing,
+			int pixelX,
+			int pixelY
+	) {
+		var newFace = new SideFace(
+				sideFacing,
+				sideFacing.isHorizontal() ? pixelX : pixelY,
+				sideFacing.isHorizontal() ? pixelY : pixelX
+		);
+
+		while (true) {
+			var newAnchor = newFace.anchor();
+			var newMin = newFace.min();
+			var newMax = newFace.max();
+			var merged = false;
+
+			for (var oldFace : sideFaces) {
+				var oldFacing = oldFace.facing();
+
+                if (oldFacing != sideFacing) {
+                    continue;
+                }
+
+				var oldAnchor = oldFace.anchor();
+
+                if (newAnchor != oldAnchor) {
+                    continue;
+                }
+
+				var oldMin = oldFace.min();
+				var oldMax = oldFace.max();
+
+				if (newMin == oldMax + 1) {
+					merged = true;
+					newFace = new SideFace(
+							sideFacing,
+							oldMin,
+							newMax,
+							newAnchor
+					);
+				}
+
+				if (newMax == oldMin - 1) {
+					merged = true;
+					newFace = new SideFace(
+							sideFacing,
+							newMin,
+							oldMax,
+							newAnchor
+					);
+				}
+
+				if (merged) {
+					sideFaces.remove(oldFace);
+					break;
+				}
+			}
+
+			if (!merged) {
+				sideFaces.add(newFace);
+				break;
+			}
+		}
+	}
+
+	private record ItemLayerKey(BakedQuad.MaterialInfo quadMaterial, ModelState modelState) implements ModelBaker.SharedOperationKey<@NotNull QuadCollection> {
+        @Override
+		public QuadCollection compute(ModelBaker modelBakery) {
+			var builder = new QuadCollection.Builder();
+
+			bakeItemQuads(
+					builder,
+					modelBakery.interner(),
+					this.quadMaterial,
+					this.modelState
+			);
+
+			return builder.build();
+		}
+	}
+
+	public record SideFace(
+			SideDirection facing,
+			int min,
+			int max,
+			int anchor
+	) {
+		public SideFace(
+				SideDirection facing,
+				int minMax,
+				int anchor
+		) {
+			this(
+					facing,
+					minMax,
+					minMax,
+					anchor
+			);
+		}
+	}
+}

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/model/ModelManagerMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/model/ModelManagerMixin.java
@@ -1,0 +1,20 @@
+package net.caffeinemc.mods.sodium.mixin.features.render.model;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.caffeinemc.mods.sodium.client.render.immediate.model.ImprovedItemModelBuilder;
+import net.minecraft.client.resources.model.ModelDiscovery;
+import net.minecraft.client.resources.model.ModelManager;
+import net.minecraft.client.resources.model.UnbakedModel;
+import net.minecraft.resources.Identifier;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(ModelManager.class)
+public class ModelManagerMixin {
+
+    @WrapOperation(method = "discoverModelDependencies", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/resources/model/ModelDiscovery;addSpecialModel(Lnet/minecraft/resources/Identifier;Lnet/minecraft/client/resources/model/UnbakedModel;)V"))
+    private static void replaceItemModelGenerator(ModelDiscovery instance, Identifier identifier, UnbakedModel model, Operation<Void> original) {
+        original.call(instance, identifier, new ImprovedItemModelBuilder());
+    }
+}

--- a/common/src/main/resources/sodium-common.accesswidener
+++ b/common/src/main/resources/sodium-common.accesswidener
@@ -18,6 +18,12 @@ accessible class com/mojang/blaze3d/opengl/GlDevice
 accessible field net/minecraft/world/level/GrassColor pixels [I
 accessible field net/minecraft/world/level/FoliageColor pixels [I
 
+accessible field net/minecraft/client/resources/model/cuboid/ItemModelGenerator MIN_Z F
+accessible field net/minecraft/client/resources/model/cuboid/ItemModelGenerator MAX_Z F
+accessible field net/minecraft/client/resources/model/cuboid/ItemModelGenerator TEXTURE_SLOTS Lnet/minecraft/client/resources/model/sprite/TextureSlots$Data;
+accessible field net/minecraft/client/resources/model/cuboid/ItemModelGenerator SOUTH_FACE_UVS Lnet/minecraft/client/resources/model/cuboid/CuboidFace$UVs;
+accessible field net/minecraft/client/resources/model/cuboid/ItemModelGenerator NORTH_FACE_UVS Lnet/minecraft/client/resources/model/cuboid/CuboidFace$UVs;
+accessible field net/minecraft/client/resources/model/cuboid/ItemModelGenerator UV_SHRINK F
 accessible method net/minecraft/client/resources/model/cuboid/ItemModelGenerator isTransparent (Lnet/minecraft/client/renderer/texture/SpriteContents;IIIII)Z
 accessible class net/minecraft/client/resources/model/cuboid/ItemModelGenerator$SideDirection
 accessible method net/minecraft/client/resources/model/cuboid/ItemModelGenerator$SideDirection isHorizontal ()Z

--- a/common/src/main/resources/sodium-common.accesswidener
+++ b/common/src/main/resources/sodium-common.accesswidener
@@ -17,3 +17,7 @@ accessible class com/mojang/blaze3d/opengl/GlDevice
 
 accessible field net/minecraft/world/level/GrassColor pixels [I
 accessible field net/minecraft/world/level/FoliageColor pixels [I
+
+accessible method net/minecraft/client/resources/model/cuboid/ItemModelGenerator isTransparent (Lnet/minecraft/client/renderer/texture/SpriteContents;IIIII)Z
+accessible class net/minecraft/client/resources/model/cuboid/ItemModelGenerator$SideDirection
+accessible method net/minecraft/client/resources/model/cuboid/ItemModelGenerator$SideDirection isHorizontal ()Z

--- a/common/src/main/resources/sodium-common.mixins.json
+++ b/common/src/main/resources/sodium-common.mixins.json
@@ -54,6 +54,7 @@
     "features.render.entity.cull.EntityRendererMixin",
     "features.render.entity.shadows.ShadowFeatureRendererMixin",
     "features.render.gui.font.BakedGlyphMixin",
+    "features.render.model.ModelManagerMixin",
     "features.render.immediate.DirectionMixin",
     "features.render.immediate.buffer_builder.intrinsics.BufferBuilderMixin",
     "features.render.immediate.buffer_builder.sorting.MeshDataAccessor",

--- a/fabric/src/main/resources/sodium-fabric.accesswidener
+++ b/fabric/src/main/resources/sodium-fabric.accesswidener
@@ -18,6 +18,12 @@ accessible class com/mojang/blaze3d/opengl/GlDevice
 accessible field net/minecraft/world/level/GrassColor pixels [I
 accessible field net/minecraft/world/level/FoliageColor pixels [I
 
+accessible field net/minecraft/client/resources/model/cuboid/ItemModelGenerator MIN_Z F
+accessible field net/minecraft/client/resources/model/cuboid/ItemModelGenerator MAX_Z F
+accessible field net/minecraft/client/resources/model/cuboid/ItemModelGenerator TEXTURE_SLOTS Lnet/minecraft/client/resources/model/sprite/TextureSlots$Data;
+accessible field net/minecraft/client/resources/model/cuboid/ItemModelGenerator SOUTH_FACE_UVS Lnet/minecraft/client/resources/model/cuboid/CuboidFace$UVs;
+accessible field net/minecraft/client/resources/model/cuboid/ItemModelGenerator NORTH_FACE_UVS Lnet/minecraft/client/resources/model/cuboid/CuboidFace$UVs;
+accessible field net/minecraft/client/resources/model/cuboid/ItemModelGenerator UV_SHRINK F
 accessible method net/minecraft/client/resources/model/cuboid/ItemModelGenerator isTransparent (Lnet/minecraft/client/renderer/texture/SpriteContents;IIIII)Z
 accessible class net/minecraft/client/resources/model/cuboid/ItemModelGenerator$SideDirection
 accessible method net/minecraft/client/resources/model/cuboid/ItemModelGenerator$SideDirection isHorizontal ()Z

--- a/fabric/src/main/resources/sodium-fabric.accesswidener
+++ b/fabric/src/main/resources/sodium-fabric.accesswidener
@@ -17,3 +17,7 @@ accessible class com/mojang/blaze3d/opengl/GlDevice
 
 accessible field net/minecraft/world/level/GrassColor pixels [I
 accessible field net/minecraft/world/level/FoliageColor pixels [I
+
+accessible method net/minecraft/client/resources/model/cuboid/ItemModelGenerator isTransparent (Lnet/minecraft/client/renderer/texture/SpriteContents;IIIII)Z
+accessible class net/minecraft/client/resources/model/cuboid/ItemModelGenerator$SideDirection
+accessible method net/minecraft/client/resources/model/cuboid/ItemModelGenerator$SideDirection isHorizontal ()Z

--- a/neoforge/src/mod/resources/META-INF/accesstransformer.cfg
+++ b/neoforge/src/mod/resources/META-INF/accesstransformer.cfg
@@ -20,6 +20,12 @@ public net.minecraft.world.level.GrassColor pixels
 public net.minecraft.world.level.FoliageColor pixels
 public net.minecraft.client.renderer.FogRenderer getPriorityFogFunction(Lnet/minecraft/world/entity/Entity;F)Lnet/minecraft/client/renderer/FogRenderer$MobEffectFogFunction;
 
+public net.minecraft.client.resources.model.cuboid.ItemModelGenerator MIN_Z
+public net.minecraft.client.resources.model.cuboid.ItemModelGenerator MAX_Z
+public net.minecraft.client.resources.model.cuboid.ItemModelGenerator TEXTURE_SLOTS
+public net.minecraft.client.resources.model.cuboid.ItemModelGenerator SOUTH_FACE_UVS
+public net.minecraft.client.resources.model.cuboid.ItemModelGenerator NORTH_FACE_UVS
+public net.minecraft.client.resources.model.cuboid.ItemModelGenerator UV_SHRINK
 public net.minecraft.client.resources.model.cuboid.ItemModelGenerator isTransparent(Lnet/minecraft/client/renderer/texture/SpriteContents;IIIII)Z
 public net.minecraft.client.resources.model.cuboid.ItemModelGenerator$SideDirection
 public net.minecraft.client.resources.model.cuboid.ItemModelGenerator$SideDirection isHorizontal()Z

--- a/neoforge/src/mod/resources/META-INF/accesstransformer.cfg
+++ b/neoforge/src/mod/resources/META-INF/accesstransformer.cfg
@@ -19,3 +19,7 @@ public com.mojang.blaze3d.opengl.GlDevice
 public net.minecraft.world.level.GrassColor pixels
 public net.minecraft.world.level.FoliageColor pixels
 public net.minecraft.client.renderer.FogRenderer getPriorityFogFunction(Lnet/minecraft/world/entity/Entity;F)Lnet/minecraft/client/renderer/FogRenderer$MobEffectFogFunction;
+
+public net.minecraft.client.resources.model.cuboid.ItemModelGenerator isTransparent(Lnet/minecraft/client/renderer/texture/SpriteContents;IIIII)Z
+public net.minecraft.client.resources.model.cuboid.ItemModelGenerator$SideDirection
+public net.minecraft.client.resources.model.cuboid.ItemModelGenerator$SideDirection isHorizontal()Z


### PR DESCRIPTION
This PR provides a completely rewrite version of `ItemModelGenerator` to avoid generating redundant per-pixel side quads by merging neighbor faces together while keeping the baked model seamless. 