### PR TITLE
Check for Windows OS before applying AMD workaround

### DIFF
--- a/common/src/boot/java/net/caffeinemc/mods/sodium/client/compatibility/workarounds/Workarounds.java
+++ b/common/src/boot/java/net/caffeinemc/mods/sodium/client/compatibility/workarounds/Workarounds.java
@@ -41,7 +41,7 @@ public class Workarounds {
             workarounds.add(Reference.NVIDIA_THREADED_OPTIMIZATIONS_BROKEN);
         }
 
-        if (AmdWorkarounds.isAmdGraphicsCardPresent()) {
+        if (AmdWorkarounds.isAmdGraphicsCardPresent() && OsUtils.getOs() == OsUtils.OperatingSystem.WIN) {
             workarounds.add(Reference.AMD_GAME_OPTIMIZATION_BROKEN);
         }
 

--- a/common/src/boot/java/net/caffeinemc/mods/sodium/client/compatibility/workarounds/Workarounds.java
+++ b/common/src/boot/java/net/caffeinemc/mods/sodium/client/compatibility/workarounds/Workarounds.java
@@ -41,7 +41,7 @@ public class Workarounds {
             workarounds.add(Reference.NVIDIA_THREADED_OPTIMIZATIONS_BROKEN);
         }
 
-        if (AmdWorkarounds.isAmdGraphicsCardPresent() && OsUtils.getOs() == OsUtils.OperatingSystem.WIN) {
+        if (AmdWorkarounds.isAmdGraphicsCardPresent() && operatingSystem == OsUtils.OperatingSystem.WIN) {
             workarounds.add(Reference.AMD_GAME_OPTIMIZATION_BROKEN);
         }
 

--- a/common/src/boot/java/net/caffeinemc/mods/sodium/client/compatibility/workarounds/amd/AmdWorkarounds.java
+++ b/common/src/boot/java/net/caffeinemc/mods/sodium/client/compatibility/workarounds/amd/AmdWorkarounds.java
@@ -41,10 +41,10 @@ public class AmdWorkarounds {
             return;
         }
 
-        LOGGER.info("Modifying process environment to apply workarounds for the AMD graphics driver...");
-
         try {
             if (OsUtils.getOs() == OsUtils.OperatingSystem.WIN) {
+                LOGGER.info("Modifying process environment to apply workarounds for the AMD graphics driver...");
+
                 applyEnvironmentChanges$Windows();
             }
         } catch (Throwable t) {


### PR DESCRIPTION
Note that, the workaround is only added to list of Workarounds applied and the message falsely claims the process environment is going to be modified; but the modification was not actually done. So this is mostly a visual only fix.

Fixes #3533