### PR TITLE
Fixes water color with zero-alpha being invisible on neoforge with terralith

### DIFF
--- a/neoforge/src/mod/java/net/caffeinemc/mods/sodium/neoforge/render/FluidRendererImpl.java
+++ b/neoforge/src/mod/java/net/caffeinemc/mods/sodium/neoforge/render/FluidRendererImpl.java
@@ -155,7 +155,7 @@ public class FluidRendererImpl extends FluidRenderer {
                             .getFluidStateModelSet()
                             .get(state)
                             .fluidTintSource();
-                    return tintSource != null ? tintSource.colorInWorld(state, state.createLegacyBlock(), slice, pos) : -1;
+                    return tintSource != null ? tintSource.colorInWorld(state, state.createLegacyBlock(), slice, pos) | 0xFF000000 : -1;
                 }
             };
         }
@@ -170,7 +170,7 @@ public class FluidRendererImpl extends FluidRenderer {
                             .getFluidStateModelSet()
                             .get(state.getFluidState().isEmpty() ? Fluids.WATER.defaultFluidState() : state.getFluidState())
                             .fluidTintSource();
-                    return tintSource != null ? tintSource.colorInWorld(state, slice, pos) : -1;
+                    return tintSource != null ? tintSource.colorInWorld(state, slice, pos) | 0xFF000000 : -1;
                 }
             };
         }


### PR DESCRIPTION
In the 26.1 port this code changed to use a different path because it seems getTint was removed from the neoforge class, but the new tint source code doesn't properly do masking.

For comparison, the [fabric variant of this code](https://github.com/CaffeineMC/sodium-fabric/blob/eeed957a1c900ecfc09d1350eeec291a2fa1585d/fabric/src/main/java/net/caffeinemc/mods/sodium/fabric/render/FluidRendererImpl.java#L164) has the appropriate masking.

Fixes https://github.com/CaffeineMC/sodium/issues/3576

@IMS212 please review whether this is the correct location for this masking. You're the code owner here so I don't know what should go where.