### PR TITLE
Fix multipart block model rendering

### DIFF
--- a/buildSrc/src/main/kotlin/BuildConfig.kt
+++ b/buildSrc/src/main/kotlin/BuildConfig.kt
@@ -2,7 +2,7 @@ import org.gradle.api.Project
 
 object BuildConfig {
     val MINECRAFT_VERSION: String = "1.21.1"
-    val NEOFORGE_VERSION: String = "21.1.143"
+    val NEOFORGE_VERSION: String = "21.1.219"
     val FABRIC_LOADER_VERSION: String = "0.16.9"
     val FABRIC_API_VERSION: String = "0.110.0+1.21.1"
 

--- a/neoforge/src/main/java/net/caffeinemc/mods/sodium/mixin/features/model/MultiPartBakedModelMixin.java
+++ b/neoforge/src/main/java/net/caffeinemc/mods/sodium/mixin/features/model/MultiPartBakedModelMixin.java
@@ -41,6 +41,11 @@ public class MultiPartBakedModelMixin {
     @Unique
     private boolean canSkipRenderTypeCheck;
 
+    @Unique
+    private static ModelData getModelDataForPart(ModelData modelData, BakedModel model) {
+        return MultipartModelData.resolve(modelData, model);
+    }
+
     @Inject(method = "<init>", at = @At("RETURN"))
     private void storeClassInfo(List<Pair<Predicate<BlockState>, BakedModel>> list, CallbackInfo ci) {
         this.canSkipRenderTypeCheck = this.selectors.stream().allMatch(model -> (model.getRight() instanceof SimpleBakedModel simpleModel && ((SimpleBakedModelAccessor) simpleModel).getBlockRenderTypes() == null));
@@ -88,9 +93,10 @@ public class MultiPartBakedModelMixin {
 
         for (BakedModel model : models) {
             random.setSeed(seed);
-
-            if (canSkipRenderTypeCheck || renderType == null || model.getRenderTypes(state, random, modelData).contains(renderType)) {
-                quads.addAll(model.getQuads(state, direction, random, MultipartModelData.resolve(modelData, model), renderType));
+            ModelData partData = getModelDataForPart(modelData, model);
+            ChunkRenderTypeSet childRenderTypes = canSkipRenderTypeCheck ? null : model.getRenderTypes(state, random, partData);
+            if (canSkipRenderTypeCheck || renderType == null || childRenderTypes.contains(renderType)) {
+                quads.addAll(model.getQuads(state, direction, random, partData, renderType));
             }
         }
 
@@ -140,8 +146,9 @@ public class MultiPartBakedModelMixin {
 
         for (BakedModel model : models) {
             random.setSeed(seed);
-
-            bits.or((((ChunkRenderTypeSetAccessor) (Object) model.getRenderTypes(state, random, data)).getBits()));
+            ModelData partData = getModelDataForPart(data, model);
+            ChunkRenderTypeSet childRenderTypes = model.getRenderTypes(state, random, partData);
+            bits.or((((ChunkRenderTypeSetAccessor) (Object) childRenderTypes).getBits()));
         }
 
         return ChunkRenderTypeSetAccessor.create(bits);

--- a/neoforge/src/main/java/net/caffeinemc/mods/sodium/mixin/platform/neoforge/BlockRendererMixin.java
+++ b/neoforge/src/main/java/net/caffeinemc/mods/sodium/mixin/platform/neoforge/BlockRendererMixin.java
@@ -1,0 +1,41 @@
+package net.caffeinemc.mods.sodium.mixin.platform.neoforge;
+
+import net.caffeinemc.mods.sodium.client.render.chunk.compile.pipeline.BlockRenderer;
+import net.caffeinemc.mods.sodium.client.render.frapi.render.AbstractBlockRenderContext;
+import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
+import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.client.resources.model.MultiPartBakedModel;
+import net.minecraft.core.BlockPos;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.function.Supplier;
+
+@Mixin(BlockRenderer.class)
+public abstract class BlockRendererMixin {
+
+    // NeoForge multipart models have a render-type-aware getQuads(...) path, but FRAPI's multipart
+    // emitBlockQuads(...) recurses into child models directly and loses that top-level pass filtering.
+    // Redirect only multipart models back through bufferDefaultModel(...) to query the
+    // multipart model itself for the current pass. This is intentionally NeoForge-only.
+    @Redirect(
+            method = "renderModel",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/fabricmc/fabric/api/renderer/v1/model/FabricBakedModel;emitBlockQuads(Lnet/minecraft/world/level/BlockAndTintGetter;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;Ljava/util/function/Supplier;Lnet/fabricmc/fabric/api/renderer/v1/render/RenderContext;)V"
+            )
+    )
+    private void sodium$renderMultipartThroughVanillaPath(FabricBakedModel model, BlockAndTintGetter level, BlockState state, BlockPos pos, Supplier<RandomSource> randomSupplier, RenderContext context) {
+        if (model instanceof MultiPartBakedModel) {
+            ((AbstractBlockRenderContext) context).bufferDefaultModel((BakedModel) model, state);
+            return;
+        }
+
+        model.emitBlockQuads(level, state, pos, randomSupplier, context);
+    }
+}

--- a/neoforge/src/main/resources/sodium-neoforge.mixins.json
+++ b/neoforge/src/main/resources/sodium-neoforge.mixins.json
@@ -16,6 +16,7 @@
       "features.world.biome.BiomeMixin",
       "platform.neoforge.AbstractBlockRenderContextMixin",
       "platform.neoforge.AuxiliaryLightManagerMixin",
+      "platform.neoforge.BlockRendererMixin",
       "platform.neoforge.ChunkRenderTypeSetAccessor",
       "platform.neoforge.ClientHooksMixin",
       "platform.neoforge.EntrypointMixin",


### PR DESCRIPTION
Fixes NeoForge multipart model rendering so each child part is evaluated with the correct ModelData and render-pass information instead of being rendered through a path that loses top-level pass filtering. 

Fixes https://github.com/SuperMartijn642/Fusion/issues/227 . Likely fixes #3400 and/or #3164 , not tested yet. 