### PR TITLE
Implement Alt shortcuts and ESC discard behavior (#2769)

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/VideoSettingsScreen.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/VideoSettingsScreen.java
@@ -198,15 +198,15 @@ public class VideoSettingsScreen extends Screen implements ScreenPromptable, Scr
             reserveBottomSpace = true;
         }
 
-        this.closeButton = new FlatButtonWidget(new Dim2i(this.getLimitX() - Layout.BUTTON_LONG - ifNotInsetX(Layout.INNER_MARGIN), this.getLimitY() - (ifNotInsetY(Layout.INNER_MARGIN) + Layout.BUTTON_SHORT), Layout.BUTTON_LONG, Layout.BUTTON_SHORT), Component.translatable("gui.done"), this::onClose, true, false);
+        this.closeButton = new KeyBoundButtonWidget(new Dim2i(this.getLimitX() - Layout.BUTTON_LONG - ifNotInsetX(Layout.INNER_MARGIN), this.getLimitY() - (ifNotInsetY(Layout.INNER_MARGIN) + Layout.BUTTON_SHORT), Layout.BUTTON_LONG, Layout.BUTTON_SHORT), Component.translatable("gui.done"), this::onClose, true, false);
         this.addRenderableWidget(this.closeButton);
 
         if (stackVertically) {
-            this.applyButton = new FlatButtonWidget(new Dim2i(this.closeButton.getX(), this.closeButton.getY() - (Layout.INNER_MARGIN + Layout.BUTTON_SHORT), Layout.BUTTON_LONG, Layout.BUTTON_SHORT), Component.translatable("sodium.options.buttons.apply"), ConfigManager.CONFIG::applyAllOptions, true, false);
-            this.undoButton = new FlatButtonWidget(new Dim2i(this.applyButton.getX(), this.applyButton.getY() - (Layout.INNER_MARGIN + Layout.BUTTON_SHORT), Layout.BUTTON_LONG, Layout.BUTTON_SHORT), Component.translatable("sodium.options.buttons.undo"), this::undoChanges, true, false);
+            this.applyButton = new KeyBoundButtonWidget(new Dim2i(this.closeButton.getX(), this.closeButton.getY() - (Layout.INNER_MARGIN + Layout.BUTTON_SHORT), Layout.BUTTON_LONG, Layout.BUTTON_SHORT), Component.translatable("sodium.options.buttons.apply"), this::applyChanges, true, false);
+            this.undoButton = new KeyBoundButtonWidget(new Dim2i(this.applyButton.getX(), this.applyButton.getY() - (Layout.INNER_MARGIN + Layout.BUTTON_SHORT), Layout.BUTTON_LONG, Layout.BUTTON_SHORT), Component.translatable("sodium.options.buttons.undo"), this::undoChanges, true, false);
         } else {
-            this.applyButton = new FlatButtonWidget(new Dim2i(this.closeButton.getX() - Layout.INNER_MARGIN - Layout.BUTTON_LONG, this.getLimitY() - (Layout.INNER_MARGIN + Layout.BUTTON_SHORT), Layout.BUTTON_LONG, Layout.BUTTON_SHORT), Component.translatable("sodium.options.buttons.apply"), ConfigManager.CONFIG::applyAllOptions, true, false);
-            this.undoButton = new FlatButtonWidget(new Dim2i(this.applyButton.getX() - Layout.INNER_MARGIN - Layout.BUTTON_LONG, this.getLimitY() - (Layout.INNER_MARGIN + Layout.BUTTON_SHORT), Layout.BUTTON_LONG, Layout.BUTTON_SHORT), Component.translatable("sodium.options.buttons.undo"), this::undoChanges, true, false);
+            this.applyButton = new KeyBoundButtonWidget(new Dim2i(this.closeButton.getX() - Layout.INNER_MARGIN - Layout.BUTTON_LONG, this.getLimitY() - (Layout.INNER_MARGIN + Layout.BUTTON_SHORT), Layout.BUTTON_LONG, Layout.BUTTON_SHORT), Component.translatable("sodium.options.buttons.apply"), this::applyChanges, true, false);
+            this.undoButton = new KeyBoundButtonWidget(new Dim2i(this.applyButton.getX() - Layout.INNER_MARGIN - Layout.BUTTON_LONG, this.getLimitY() - (Layout.INNER_MARGIN + Layout.BUTTON_SHORT), Layout.BUTTON_LONG, Layout.BUTTON_SHORT), Component.translatable("sodium.options.buttons.undo"), this::undoChanges, true, false);
         }
         this.addRenderableWidget(this.undoButton);
         this.addRenderableWidget(this.applyButton);
@@ -366,6 +366,10 @@ public class VideoSettingsScreen extends Screen implements ScreenPromptable, Scr
         ConfigManager.CONFIG.resetAllOptionsFromBindings();
     }
 
+    private void applyChanges() {
+        ConfigManager.CONFIG.applyAllOptions();
+    }
+
     private void openDonationPage() {
         Util.getPlatform().openUri("https://caffeinemc.net/donate");
     }
@@ -397,6 +401,30 @@ public class VideoSettingsScreen extends Screen implements ScreenPromptable, Scr
                 this.setFocused(this.searchWidget);
                 return true;
             }
+        }
+
+        // Alt + A applies all unsaved changes
+        if (this.applyButton.isEnabled() && (event.key() == GLFW.GLFW_KEY_A && event.modifiers() == GLFW.GLFW_MOD_ALT)) {
+            this.applyChanges();
+        }
+
+        // Alt + U undoes all unsaved changes
+        if (this.undoButton.isEnabled() && (event.key() == GLFW.GLFW_KEY_U && event.modifiers() == GLFW.GLFW_MOD_ALT)) {
+            this.undoChanges();
+        }
+
+        // Alt + D exits the video settings screen
+        if (this.closeButton.isEnabled() && (event.key() == GLFW.GLFW_KEY_D && event.modifiers() == GLFW.GLFW_MOD_ALT)) {
+            this.onClose();
+        }
+
+        // ESC closes this screen without saving any pending changes
+        if (event.key() == GLFW.GLFW_KEY_ESCAPE) {
+            if (this.hasPendingChanges) {
+                this.undoChanges();
+            }
+
+            this.onClose();
         }
 
         return super.keyReleased(event);

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/VideoSettingsScreen.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/VideoSettingsScreen.java
@@ -47,7 +47,8 @@ public class VideoSettingsScreen extends Screen implements ScreenPromptable, Scr
     private SearchWidget searchWidget;
     private OptionListWidget optionList;
 
-    private FlatButtonWidget applyButton, closeButton, undoButton;
+    private KeyBoundButtonWidget applyButton, closeButton, undoButton;
+    private List<KeyBoundButtonWidget> shortcutButtons = List.of();
     private DonationButtonWidget donateButton;
 
     private boolean hasPendingChanges;
@@ -198,18 +199,7 @@ public class VideoSettingsScreen extends Screen implements ScreenPromptable, Scr
             reserveBottomSpace = true;
         }
 
-        this.closeButton = new KeyBoundButtonWidget(new Dim2i(this.getLimitX() - Layout.BUTTON_LONG - ifNotInsetX(Layout.INNER_MARGIN), this.getLimitY() - (ifNotInsetY(Layout.INNER_MARGIN) + Layout.BUTTON_SHORT), Layout.BUTTON_LONG, Layout.BUTTON_SHORT), Component.translatable("gui.done"), this::onClose, true, false);
-        this.addRenderableWidget(this.closeButton);
-
-        if (stackVertically) {
-            this.applyButton = new KeyBoundButtonWidget(new Dim2i(this.closeButton.getX(), this.closeButton.getY() - (Layout.INNER_MARGIN + Layout.BUTTON_SHORT), Layout.BUTTON_LONG, Layout.BUTTON_SHORT), Component.translatable("sodium.options.buttons.apply"), this::applyChanges, true, false);
-            this.undoButton = new KeyBoundButtonWidget(new Dim2i(this.applyButton.getX(), this.applyButton.getY() - (Layout.INNER_MARGIN + Layout.BUTTON_SHORT), Layout.BUTTON_LONG, Layout.BUTTON_SHORT), Component.translatable("sodium.options.buttons.undo"), this::undoChanges, true, false);
-        } else {
-            this.applyButton = new KeyBoundButtonWidget(new Dim2i(this.closeButton.getX() - Layout.INNER_MARGIN - Layout.BUTTON_LONG, this.getLimitY() - (Layout.INNER_MARGIN + Layout.BUTTON_SHORT), Layout.BUTTON_LONG, Layout.BUTTON_SHORT), Component.translatable("sodium.options.buttons.apply"), this::applyChanges, true, false);
-            this.undoButton = new KeyBoundButtonWidget(new Dim2i(this.applyButton.getX() - Layout.INNER_MARGIN - Layout.BUTTON_LONG, this.getLimitY() - (Layout.INNER_MARGIN + Layout.BUTTON_SHORT), Layout.BUTTON_LONG, Layout.BUTTON_SHORT), Component.translatable("sodium.options.buttons.undo"), this::undoChanges, true, false);
-        }
-        this.addRenderableWidget(this.undoButton);
-        this.addRenderableWidget(this.applyButton);
+        this.rebuildActionButtons(stackVertically);
 
         this.donateButton = new DonationButtonWidget(this, this::openDonationPage, this::hideDonationButton);
         this.addRenderableWidget(this.searchWidget);
@@ -233,6 +223,27 @@ public class VideoSettingsScreen extends Screen implements ScreenPromptable, Scr
                         this.getLimitY() - tooltipAreaY - ifNotInsetY(Layout.TOOLTIP_OUTER_MARGIN)
                 )
         );
+    }
+
+    private void rebuildActionButtons(boolean stackVertically) {
+        int buttonW = Layout.BUTTON_LONG;
+        int buttonH = Layout.BUTTON_SHORT;
+        int closeX = this.getLimitX() - buttonW - ifNotInsetX(Layout.INNER_MARGIN);
+        int closeY = this.getLimitY() - (ifNotInsetY(Layout.INNER_MARGIN) + buttonH);
+
+        int dx = stackVertically ? 0 : -(Layout.INNER_MARGIN + buttonW);
+        int dy = stackVertically ? -(Layout.INNER_MARGIN + buttonH) : 0;
+        int actionRowX = closeX + dx;
+        int actionRowY = stackVertically ? closeY + dy : this.getLimitY() - (Layout.INNER_MARGIN + buttonH);
+
+        this.closeButton = new KeyBoundButtonWidget(new Dim2i(closeX, closeY, buttonW, buttonH), Component.translatable("gui.done"), this::onClose, true, false, GLFW.GLFW_KEY_D);
+        this.applyButton = new KeyBoundButtonWidget(new Dim2i(actionRowX, actionRowY, buttonW, buttonH), Component.translatable("sodium.options.buttons.apply"), ConfigManager.CONFIG::applyAllOptions, true, false, GLFW.GLFW_KEY_A);
+        this.undoButton = new KeyBoundButtonWidget(new Dim2i(actionRowX + dx, actionRowY + dy, buttonW, buttonH), Component.translatable("sodium.options.buttons.undo"), this::undoChanges, true, false, GLFW.GLFW_KEY_U);
+
+        this.addRenderableWidget(this.closeButton);
+        this.addRenderableWidget(this.undoButton);
+        this.addRenderableWidget(this.applyButton);
+        this.shortcutButtons = List.of(this.closeButton, this.applyButton, this.undoButton);
     }
 
     private void updateScreenDimensions() {
@@ -366,10 +377,6 @@ public class VideoSettingsScreen extends Screen implements ScreenPromptable, Scr
         ConfigManager.CONFIG.resetAllOptionsFromBindings();
     }
 
-    private void applyChanges() {
-        ConfigManager.CONFIG.applyAllOptions();
-    }
-
     private void openDonationPage() {
         Util.getPlatform().openUri("https://caffeinemc.net/donate");
     }
@@ -403,19 +410,11 @@ public class VideoSettingsScreen extends Screen implements ScreenPromptable, Scr
             }
         }
 
-        // Alt + A applies all unsaved changes
-        if (this.applyButton.isEnabled() && (event.key() == GLFW.GLFW_KEY_A && event.modifiers() == GLFW.GLFW_MOD_ALT)) {
-            this.applyChanges();
-        }
-
-        // Alt + U undoes all unsaved changes
-        if (this.undoButton.isEnabled() && (event.key() == GLFW.GLFW_KEY_U && event.modifiers() == GLFW.GLFW_MOD_ALT)) {
-            this.undoChanges();
-        }
-
-        // Alt + D exits the video settings screen
-        if (this.closeButton.isEnabled() && (event.key() == GLFW.GLFW_KEY_D && event.modifiers() == GLFW.GLFW_MOD_ALT)) {
-            this.onClose();
+        // dispatch ALT+letter shortcuts to any keybound buttons on this screen
+        for (var button : this.shortcutButtons) {
+            if (button.tryActivateShortcut(event)) {
+                return true;
+            }
         }
 
         // ESC closes this screen without saving any pending changes

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/widgets/FlatButtonWidget.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/widgets/FlatButtonWidget.java
@@ -23,7 +23,7 @@ public class FlatButtonWidget extends AbstractWidget implements Renderable {
     private final boolean drawFrame;
     private final boolean leftAlign;
     private final ButtonTheme theme;
-    protected Component label;
+    private final Component label;
 
     private boolean selected;
     private boolean enabled = true;
@@ -67,8 +67,9 @@ public class FlatButtonWidget extends AbstractWidget implements Renderable {
         }
 
         if (this.label != null) {
-            int strWidth = this.font.width(this.label);
-            this.drawString(graphics, this.label, this.leftAlign ? this.getX() + Layout.TEXT_LEFT_PADDING : (this.getCenterX() - (strWidth / 2)), this.getCenterY() - this.font.lineHeight / 2, textColor);
+            Component rendered = this.getRenderedLabel();
+            int strWidth = this.font.width(rendered);
+            this.drawString(graphics, rendered, this.leftAlign ? this.getX() + Layout.TEXT_LEFT_PADDING : (this.getCenterX() - (strWidth / 2)), this.getCenterY() - this.font.lineHeight / 2, textColor);
         }
 
         if (this.enabled && this.selected) {
@@ -82,6 +83,10 @@ public class FlatButtonWidget extends AbstractWidget implements Renderable {
 
     protected int getTextColor() {
         return this.enabled ? this.theme.themeLighter : this.theme.themeDarker;
+    }
+
+    protected Component getRenderedLabel() {
+        return this.label;
     }
 
     public void setSelected(boolean selected) {
@@ -116,7 +121,7 @@ public class FlatButtonWidget extends AbstractWidget implements Renderable {
         return false;
     }
 
-    private void doAction() {
+    protected void doAction() {
         this.action.run();
         this.playClickSound();
     }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/widgets/FlatButtonWidget.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/widgets/FlatButtonWidget.java
@@ -23,7 +23,7 @@ public class FlatButtonWidget extends AbstractWidget implements Renderable {
     private final boolean drawFrame;
     private final boolean leftAlign;
     private final ButtonTheme theme;
-    private final Component label;
+    protected Component label;
 
     private boolean selected;
     private boolean enabled = true;
@@ -138,5 +138,9 @@ public class FlatButtonWidget extends AbstractWidget implements Renderable {
 
     public boolean isVisible() {
         return this.visible;
+    }
+
+    public boolean isEnabled() {
+        return this.enabled;
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/widgets/KeyBoundButtonWidget.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/widgets/KeyBoundButtonWidget.java
@@ -1,79 +1,63 @@
 package net.caffeinemc.mods.sodium.client.gui.widgets;
 
-import net.caffeinemc.mods.sodium.client.gui.ButtonTheme;
 import net.caffeinemc.mods.sodium.client.util.Dim2i;
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.input.KeyEvent;
 import net.minecraft.network.chat.Component;
-import org.lwjgl.glfw.GLFW;
 
-// A button widget that updates its label dynamically when the ALT key is pressed.
-// When active, the first character of the label is underlined to indicate a keybinding.
+/**
+ * Activates when its bound key is pressed with ALT held. While ALT is held, underlines the first occurrence of the shortcut key in the label; if the label doesn't contain the key (e.g. due to translation), appends the key in square brackets so the binding stays discoverable.
+ */
 public class KeyBoundButtonWidget extends FlatButtonWidget {
+    private final int shortcutKey;
+    private final Component underlinedLabel;
 
-    private boolean altPressed = false;
-    private boolean labelNeedsRebuild = false;
-
-    public KeyBoundButtonWidget(Dim2i dim, Component label, Runnable action, boolean drawBackground, boolean drawFrame, boolean leftAlign, ButtonTheme theme) {
-        super(dim, label, action, drawBackground, drawFrame, leftAlign, theme);
-    }
-
-    public KeyBoundButtonWidget(Dim2i dim, Component label, Runnable action, boolean drawBackground, boolean leftAlign, ButtonTheme theme) {
-        super(dim, label, action, drawBackground, leftAlign, theme);
-    }
-
-    public KeyBoundButtonWidget(Dim2i dim, Component label, Runnable action, boolean drawBackground, boolean leftAlign) {
+    public KeyBoundButtonWidget(Dim2i dim, Component label, Runnable action, boolean drawBackground, boolean leftAlign, int shortcutKey) {
         super(dim, label, action, drawBackground, leftAlign);
+        this.shortcutKey = shortcutKey;
+        this.underlinedLabel = buildUnderlinedLabel(label, shortcutKey);
     }
 
-    public KeyBoundButtonWidget(Dim2i dim, Component label, Runnable action, boolean drawBackground, boolean drawFrame, boolean leftAlign) {
-        super(dim, label, action, drawBackground, drawFrame, leftAlign);
-    }
+    private static Component buildUnderlinedLabel(Component label, int shortcutKey) {
+        var text = label.getString();
+        var keyChar = (char) shortcutKey; // GLFW letter key codes equal their uppercase ASCII char
+        var index = indexOfIgnoreCase(text, keyChar);
 
-    // Changes the first letter of a label to be underlined only whe ALT state changes.
-    private Component buildLabel() {
-        this.labelNeedsRebuild = false;
-
-        String label = this.label.getString();
-
-        if ((this.isAltDown() && this.isEnabled()) && !label.isEmpty()) {
-            Component firstLetter = Component.literal(String.valueOf(label.charAt(0)))
-                    .withStyle(style -> style.withUnderlined(true));
-
-            Component restOfLabel = Component.literal(label.substring(1));
-
-            return Component.literal("").append(firstLetter).append(restOfLabel);
+        if (index >= 0) {
+            return Component.empty()
+                    .append(Component.literal(text.substring(0, index)))
+                    .append(Component.literal(text.substring(index, index + 1)).withStyle(ChatFormatting.UNDERLINE))
+                    .append(Component.literal(text.substring(index + 1)));
         }
 
-        return Component.literal(label);
+        return Component.empty()
+                .append(label)
+                .append(Component.literal(" ["))
+                .append(Component.literal(String.valueOf(keyChar)).withStyle(ChatFormatting.UNDERLINE))
+                .append(Component.literal("]"));
     }
 
-    private boolean isAltDown() {
-        long windowHandle = Minecraft.getInstance().getWindow().handle();
-        return GLFW.glfwGetKey(windowHandle, GLFW.GLFW_KEY_LEFT_ALT) == GLFW.GLFW_PRESS;
-    }
-
-    // Detects ALT press/release transitions to avoid unnecessary work every frame
-    private void verifyAlt() {
-        if (this.isAltDown() && !this.altPressed) {
-            this.altPressed = true;
-            this.labelNeedsRebuild = true;
+    private static int indexOfIgnoreCase(String text, char target) {
+        var lowerTarget = Character.toLowerCase(target);
+        for (int i = 0; i < text.length(); i++) {
+            if (Character.toLowerCase(text.charAt(i)) == lowerTarget) {
+                return i;
+            }
         }
-
-        if (!this.isAltDown() && this.altPressed) {
-            this.altPressed = false;
-            this.labelNeedsRebuild = true;
-        }
+        return -1;
     }
 
     @Override
-    public void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
-        super.render(graphics, mouseX, mouseY, delta);
+    protected Component getRenderedLabel() {
+        return this.isEnabled() && Minecraft.getInstance().hasAltDown() ? this.underlinedLabel : super.getRenderedLabel();
+    }
 
-        this.verifyAlt();
-
-        if (this.labelNeedsRebuild) {
-            this.label = this.buildLabel();
+    public boolean tryActivateShortcut(KeyEvent event) {
+        if (this.isEnabled() && this.isVisible() && event.hasAltDown() && event.key() == this.shortcutKey) {
+            this.doAction();
+            return true;
         }
+        return false;
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/widgets/KeyBoundButtonWidget.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/widgets/KeyBoundButtonWidget.java
@@ -1,0 +1,79 @@
+package net.caffeinemc.mods.sodium.client.gui.widgets;
+
+import net.caffeinemc.mods.sodium.client.gui.ButtonTheme;
+import net.caffeinemc.mods.sodium.client.util.Dim2i;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.network.chat.Component;
+import org.lwjgl.glfw.GLFW;
+
+// A button widget that updates its label dynamically when the ALT key is pressed.
+// When active, the first character of the label is underlined to indicate a keybinding.
+public class KeyBoundButtonWidget extends FlatButtonWidget {
+
+    private boolean altPressed = false;
+    private boolean labelNeedsRebuild = false;
+
+    public KeyBoundButtonWidget(Dim2i dim, Component label, Runnable action, boolean drawBackground, boolean drawFrame, boolean leftAlign, ButtonTheme theme) {
+        super(dim, label, action, drawBackground, drawFrame, leftAlign, theme);
+    }
+
+    public KeyBoundButtonWidget(Dim2i dim, Component label, Runnable action, boolean drawBackground, boolean leftAlign, ButtonTheme theme) {
+        super(dim, label, action, drawBackground, leftAlign, theme);
+    }
+
+    public KeyBoundButtonWidget(Dim2i dim, Component label, Runnable action, boolean drawBackground, boolean leftAlign) {
+        super(dim, label, action, drawBackground, leftAlign);
+    }
+
+    public KeyBoundButtonWidget(Dim2i dim, Component label, Runnable action, boolean drawBackground, boolean drawFrame, boolean leftAlign) {
+        super(dim, label, action, drawBackground, drawFrame, leftAlign);
+    }
+
+    // Changes the first letter of a label to be underlined only whe ALT state changes.
+    private Component buildLabel() {
+        this.labelNeedsRebuild = false;
+
+        String label = this.label.getString();
+
+        if ((this.isAltDown() && this.isEnabled()) && !label.isEmpty()) {
+            Component firstLetter = Component.literal(String.valueOf(label.charAt(0)))
+                    .withStyle(style -> style.withUnderlined(true));
+
+            Component restOfLabel = Component.literal(label.substring(1));
+
+            return Component.literal("").append(firstLetter).append(restOfLabel);
+        }
+
+        return Component.literal(label);
+    }
+
+    private boolean isAltDown() {
+        long windowHandle = Minecraft.getInstance().getWindow().handle();
+        return GLFW.glfwGetKey(windowHandle, GLFW.GLFW_KEY_LEFT_ALT) == GLFW.GLFW_PRESS;
+    }
+
+    // Detects ALT press/release transitions to avoid unnecessary work every frame
+    private void verifyAlt() {
+        if (this.isAltDown() && !this.altPressed) {
+            this.altPressed = true;
+            this.labelNeedsRebuild = true;
+        }
+
+        if (!this.isAltDown() && this.altPressed) {
+            this.altPressed = false;
+            this.labelNeedsRebuild = true;
+        }
+    }
+
+    @Override
+    public void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+        super.render(graphics, mouseX, mouseY, delta);
+
+        this.verifyAlt();
+
+        if (this.labelNeedsRebuild) {
+            this.label = this.buildLabel();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements keyboard shortcuts for the main actions in the Video Settings screen, as discussed in the issue.

Users can now use Alt-based shortcuts for Apply, Done, and Undo, with the corresponding letter underlined in each button to make the interaction more discoverable.

For the ESC behavior, it was implemented as an immediate “abort” action: it discards any pending changes and exits the screen.

## Changes

* Added Alt + key shortcuts for:

  * Apply
  * Done
  * Undo
* Underlined the first letter of each button label to reflect the shortcut
* Implemented ESC to discard pending changes and exit the Video Settings screen
* Extracted `applyChanges()` to centralize applying pending configuration changes

## Notes

A confirmation prompt on ESC (e.g. asking whether to apply changes before exiting, optionally with a “don’t show again” checkbox) was considered, I decided not to include it in this PR to keep the scope focused and avoid introducing additional UI/UX complexity here, that behavior could be explored separately as a follow-up improvement if needed

## Issue

#2769
