### PR TITLE
refactor: make ShapeComparisonCache to be lazy

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/DefaultFluidRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/DefaultFluidRenderer.java
@@ -72,7 +72,7 @@ public class DefaultFluidRenderer {
     private final IntList stack = new IntArrayList();
     private long visited = 0;
 
-    private final Supplier<ShapeComparisonCache> occlusionCache = Suppliers.memorize(ShapeComparisonCache::new);
+    private final Supplier<ShapeComparisonCache> occlusionCache = Suppliers.memoize(ShapeComparisonCache::new);
 
     private final ModelQuadViewMutable quad = new ModelQuad();
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/DefaultFluidRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/DefaultFluidRenderer.java
@@ -1,6 +1,6 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.compile.pipeline;
 
-
+import com.google.common.base.Suppliers;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import net.caffeinemc.mods.sodium.api.util.ColorARGB;
@@ -38,6 +38,8 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 
+import java.util.function.Supplier;
+
 /**
  * The default fluid renderer implementation generates fluid geometry for each fluid block based on its fluid state, the block state, and other blocks around it.
  * <p>
@@ -70,7 +72,7 @@ public class DefaultFluidRenderer {
     private final IntList stack = new IntArrayList();
     private long visited = 0;
 
-    private final ShapeComparisonCache occlusionCache = new ShapeComparisonCache();
+    private final Supplier<ShapeComparisonCache> occlusionCache = Suppliers.memorize(ShapeComparisonCache::new);
 
     private final ModelQuadViewMutable quad = new ModelQuad();
 
@@ -157,7 +159,7 @@ public class DefaultFluidRenderer {
                 }
 
                 // perform occlusion of the fluid by the block it's contained in
-                return this.occlusionCache.lookup(fluidShape, selfShape);
+                return this.occlusionCache.get().lookup(fluidShape, selfShape);
             }
         }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/DefaultFluidRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/DefaultFluidRenderer.java
@@ -219,7 +219,7 @@ public class DefaultFluidRenderer {
         }
 
         var ownShape = ownBlockState.getFaceOcclusionShape(facing);
-        return this.occlusionCache.lookup(fluidShape, neighborShape, ownShape);
+        return this.occlusionCache.get().lookup(fluidShape, neighborShape, ownShape);
     }
 
     private boolean isSideExposedOffset(BlockAndTintGetter world, BlockState ownBlockState, BlockPos originPos, Direction dir, float height) {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/ShapeComparisonCache.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/ShapeComparisonCache.java
@@ -17,7 +17,7 @@ public class ShapeComparisonCache {
     private final ShapeComparison cachedComparisonObject = new ShapeComparison();
 
     public ShapeComparisonCache() {
-        this.comparisonLookupTable = new Object2IntLinkedOpenCustomHashMap<>(CACHE_SIZE, 0.5F, new ShapeComparison.ShapeComparisonStrategy());
+        this.comparisonLookupTable = new Object2IntLinkedOpenCustomHashMap<>(CACHE_SIZE, 0.5F, ShapeComparison.ShapeComparisonStrategy.INSTANCE);
         this.comparisonLookupTable.defaultReturnValue(ENTRY_ABSENT);
     }
 
@@ -81,6 +81,11 @@ public class ShapeComparisonCache {
         }
 
         public static class ShapeComparisonStrategy implements Hash.Strategy<ShapeComparison> {
+            public static final ShapeComparisonStrategy INSTANCE = new ShapeComparisonStrategy();
+
+            private ShapeComparisonStrategy() {
+            }
+
             @Override
             public int hashCode(ShapeComparison value) {
                 int result = System.identityHashCode(value.self);

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/model/AbstractBlockRenderContext.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/model/AbstractBlockRenderContext.java
@@ -75,7 +75,7 @@ public abstract class AbstractBlockRenderContext extends AbstractRenderContext {
      */
     protected BlockPos pos;
 
-    private final Supplier<ShapeComparisonCache> occlusionCache = Suppliers.memorize(ShapeComparisonCache::new);
+    private final Supplier<ShapeComparisonCache> occlusionCache = Suppliers.memoize(ShapeComparisonCache::new);
     private final BlockPos.MutableBlockPos cachedPositionObject = new BlockPos.MutableBlockPos();
     protected boolean enableCulling = true;
     // Cull cache (as it's checked per-quad instead of once per side like in vanilla)

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/model/AbstractBlockRenderContext.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/model/AbstractBlockRenderContext.java
@@ -1,5 +1,6 @@
 package net.caffeinemc.mods.sodium.client.render.model;
 
+import com.google.common.base.Suppliers;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.caffeinemc.mods.sodium.client.model.light.LightMode;
 import net.caffeinemc.mods.sodium.client.model.light.LightPipeline;
@@ -29,6 +30,7 @@ import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 /**
  * Base class for the functions that can be shared between the terrain and non-terrain pipelines.
@@ -73,7 +75,7 @@ public abstract class AbstractBlockRenderContext extends AbstractRenderContext {
      */
     protected BlockPos pos;
 
-    private final ShapeComparisonCache occlusionCache = new ShapeComparisonCache();
+    private final Supplier<ShapeComparisonCache> occlusionCache = Suppliers.memorize(ShapeComparisonCache::new);
     private final BlockPos.MutableBlockPos cachedPositionObject = new BlockPos.MutableBlockPos();
     protected boolean enableCulling = true;
     // Cull cache (as it's checked per-quad instead of once per side like in vanilla)
@@ -144,7 +146,7 @@ public abstract class AbstractBlockRenderContext extends AbstractRenderContext {
         }
 
         // No other simplifications apply, so we need to perform a full shape comparison, which is very slow
-        return this.occlusionCache.lookup(selfShape, neighborShape);
+        return this.occlusionCache.get().lookup(selfShape, neighborShape);
     }
 
     public boolean isFaceCulled(@Nullable Direction face) {


### PR DESCRIPTION
Avoiding useless big map allocation