### PR TITLE
Fix TS Crash With Specific Resource Packs

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/bsp_tree/BSPSortState.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/bsp_tree/BSPSortState.java
@@ -1,12 +1,11 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.bsp_tree;
 
-import java.nio.IntBuffer;
-import java.lang.Math;
-
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntConsumer;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data.TranslucentData;
 import net.caffeinemc.mods.sodium.client.util.NativeBuffer;
+
+import java.nio.IntBuffer;
 
 /**
  * The sort state is passed around the tree (similar to visitor pattern) and
@@ -210,14 +209,13 @@ class BSPSortState {
         return compressed;
     }
 
-    static int decompressOrRead(int[] indexes, IntConsumer consumer) {
+    static void decompressOrRead(int[] indexes, IntConsumer consumer) {
         if (isCompressed(indexes)) {
-            return decompress(indexes, consumer);
+            decompress(indexes, consumer);
         } else {
             for (int i = 0; i < indexes.length; i++) {
                 consumer.accept(indexes[i]);
             }
-            return indexes.length;
         }
     }
 
@@ -278,10 +276,10 @@ class BSPSortState {
         return indexes[0] < 0;
     }
 
-    private IntConsumer indexConsumer = (int index) -> TranslucentData.writeQuadVertexIndexes(
+    private final IntConsumer indexConsumer = (int index) -> TranslucentData.writeQuadVertexIndexes(
             this.indexBuffer, index);
 
-    private IntConsumer indexMapConsumer = (int index) -> TranslucentData.writeQuadVertexIndexes(
+    private final IntConsumer indexMapConsumer = (int index) -> TranslucentData.writeQuadVertexIndexes(
             this.indexBuffer, this.indexMap[index]);
 
     void writeIndexes(int[] indexes) {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/bsp_tree/InnerPartitionBSPNode.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/bsp_tree/InnerPartitionBSPNode.java
@@ -79,7 +79,7 @@ abstract class InnerPartitionBSPNode extends BSPNode {
      * Since the indexes might be compressed, the count needs to be stored
      * separately from before compression.
      */
-    record NodeReuseData(float[][] quadExtents, int[] indexes, int indexCount, int maxIndex) {
+    record NodeReuseData(int quadHash, int[] indexes, int indexCount, int maxIndex) {
     }
 
     InnerPartitionBSPNode(NodeReuseData reuseData, int axis) {
@@ -101,20 +101,19 @@ abstract class InnerPartitionBSPNode extends BSPNode {
         // root node and not anything deeper than its children)
         if (workspace.prepareNodeReuse && depth == 1 && indexes.size() > NODE_REUSE_THRESHOLD) {
             // collect the extents of the indexed quads and hash them
-            var quadExtents = new float[indexes.size()][];
+            var quadHash = 1;
             int maxIndex = -1;
             for (int i = 0; i < indexes.size(); i++) {
                 var index = indexes.getInt(i);
                 var quad = workspace.get(index);
-                var extents = quad.getExtents();
-                quadExtents[i] = extents;
+                quadHash = quadHash * 31 + quad.getQuadHash();
                 maxIndex = Math.max(maxIndex, index);
             }
 
             // compress indexes but without sorting them, as the order needs to be the same
             // for the extents comparison loop to work
             return new NodeReuseData(
-                    quadExtents,
+                    quadHash,
                     BSPSortState.compressIndexes(indexes, false),
                     indexes.size(),
                     maxIndex);
@@ -166,15 +165,18 @@ abstract class InnerPartitionBSPNode extends BSPNode {
             return null;
         }
 
-        var oldExtents = reuseData.quadExtents;
-        if (oldExtents.length != newIndexes.size()) {
+        if (reuseData.indexCount != newIndexes.size()) {
             return null;
         }
 
+        var newQuadHash = 1;
         for (int i = 0; i < newIndexes.size(); i++) {
-            if (!workspace.get(newIndexes.getInt(i)).extentsEqual(oldExtents[i])) {
-                return null;
-            }
+            var index = newIndexes.getInt(i);
+            var quad = workspace.get(index);
+            newQuadHash = newQuadHash * 31 + quad.getQuadHash();
+        }
+        if (newQuadHash != reuseData.quadHash) {
+            return null;
         }
 
         // reuse old node and either apply a fixed offset or calculate an index map to


### PR DESCRIPTION
Fix rare translucency sorting crash when repeatedly interacting with specific chunks with some resource packs.

In rare cases, specific combinations of resource packs and world geometry can cause quad splitting to enter the sorting system into a state where it attempts to reuse a BSP node even though the involved quads have changed and there's many more quads. In particular through Safe-mode quad splitting this collision can occur when a quad was previously not split and then when a block is placed the quad splitting budget is higher, which results in more quads being split. The axis-aligned extents of the quads in some BSP node don't necessarily change when one of its candidate quads becomes split, especially in the case of "bushy leaves" packs where there are diagonal quads. This is a recent problem because they can cause translucent geometry through stray translucent pixels, which as of 26.1 cause the material to be translucent. When BSP nodes are wrongly reused they try to remap indices they aren't equipped to handle and run into an out of bounds exception. In this patch the extent comparison is replaced by a better quad hashing strategy, namely the same one we also use for translucent data reuse in TranslucentGeometryCollector.

Aside from this patch, resource pack authors are recommended to ensure the alpha values all in their textures, including ones where it didn't previously matter, are either 0 or 255 to ensure geometry isn't translucent when it shouldn't be. This can have a performance impact, not just because it needs to be sorted, which is typically efficient, but also a rendering impact because alpha-blended shading is more expensive than cutout or opaque.

I'm not sure yet whether this fixes the same issue as #3605 since the crash I was able to reproduce as an `ArrayIndexOutOfBoundsException` and not a buffer overflow.