### PR TITLE
(1.21.11) Upload the correct jar file

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,7 +59,9 @@ fun me.modmuss50.mpp.ModPublishExtension.setupFor(loaderName: String, releasePla
     val loaderLowercase = loaderName.lowercase(Locale.ROOT)
 
     if (releasePlatform == "both" || releasePlatform == loaderLowercase) {
-        val jar = project(":$loaderLowercase").tasks.named<Jar>("remapJar").get().archiveFile
+        val jar = if (loaderLowercase == "fabric")
+            project(":$loaderLowercase").tasks.named<Jar>("remapJar").get().archiveFile
+        else project(":$loaderLowercase").tasks.named<Jar>("jar").get().archiveFile
 
         curseforge("curseforge$loaderName") {
             from(curseforgeOptions)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,7 +59,7 @@ fun me.modmuss50.mpp.ModPublishExtension.setupFor(loaderName: String, releasePla
     val loaderLowercase = loaderName.lowercase(Locale.ROOT)
 
     if (releasePlatform == "both" || releasePlatform == loaderLowercase) {
-        val jar = project(":$loaderLowercase").tasks.named<Jar>("jar").get().archiveFile
+        val jar = project(":$loaderLowercase").tasks.named<Jar>("remapJar").get().archiveFile
 
         curseforge("curseforge$loaderName") {
             from(curseforgeOptions)


### PR DESCRIPTION
All Fabric <26.1 versions require the jar from the `remapJar` task to be uploaded.
The jar from the normal `jar` task can be used for Neoforge and 26.1+