### PR TITLE
[1.21.11] Publishing Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 Everything above the line is ignored and not included in the changelog. Everything below will be in the
 changelog on GitHub, Modrinth and CurseForge.
 ----------
-Sodium [SodiumVersion]() fixes bugs and makes some miscellaneous improvements.  It also updates to the latest NeoForge version.
+Sodium [SodiumVersion]() fixes bugs and makes some miscellaneous improvements. It also updates to the latest NeoForge version.
 
 - Fixed vanilla performance regression in item models when using high resolution texture packs ([PR](https://github.com/CaffeineMC/sodium/pull/3551) and [port to 1.21.11](https://github.com/CaffeineMC/sodium/pull/3581))
 - Better error messages for option override/overlay conflicts

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,6 @@ gradle.projectsEvaluated {
             modVersion.contains("beta") -> ReleaseType.BETA
             else -> ReleaseType.STABLE
         }
-        version = modVersion
         changelog = BuildConfig.getChangelog(project)
 
         val curseforgeShared = curseforgeOptions {
@@ -45,7 +44,7 @@ gradle.projectsEvaluated {
             accessToken = project.providers.environmentVariable("GITHUB_TOKEN")
             repository = "CaffeineMC/sodium"
             commitish = BuildConfig.calculateGitHash(project)
-            tagName = BuildConfig.RELEASE_TAG
+            version = BuildConfig.RELEASE_TAG
             displayName = "Sodium ${BuildConfig.MOD_VERSION} for Minecraft ${BuildConfig.MINECRAFT_VERSION}"
             file.unset()
             file.unsetConvention()
@@ -59,13 +58,18 @@ fun me.modmuss50.mpp.ModPublishExtension.setupFor(loaderName: String, releasePla
     val loaderLowercase = loaderName.lowercase(Locale.ROOT)
 
     if (releasePlatform == "both" || releasePlatform == loaderLowercase) {
-        val jar = project(":$loaderLowercase").tasks.named<Jar>("jar").get().archiveFile
+        val taskName = if (loaderLowercase == "fabric") "remapJar" else "jar"
+        val jar = project(":$loaderLowercase").tasks.getByName(taskName).outputs.files.singleFile
+
+        val releaseTitle = "Sodium ${BuildConfig.MOD_VERSION} for $loaderName on ${BuildConfig.MINECRAFT_VERSION}"
+        val releaseVersion = "${BuildConfig.RELEASE_TAG}-$loaderLowercase"
 
         curseforge("curseforge$loaderName") {
             from(curseforgeOptions)
             
             file.set(jar)
-            displayName = "Sodium ${BuildConfig.MOD_VERSION} for $loaderName"
+            displayName = releaseTitle
+            version = releaseVersion
             modLoaders.add(loaderLowercase)
 
             clientRequired = true
@@ -76,8 +80,8 @@ fun me.modmuss50.mpp.ModPublishExtension.setupFor(loaderName: String, releasePla
             from(modrinthOptions)
 
             file.set(jar)
-            displayName = "Sodium ${BuildConfig.MOD_VERSION} for $loaderName on ${BuildConfig.MINECRAFT_VERSION}"
-            version = "mc${BuildConfig.MINECRAFT_VERSION}-${BuildConfig.MOD_VERSION}-$loaderLowercase"
+            displayName = releaseTitle
+            version = releaseVersion
             modLoaders.add(loaderLowercase)
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,7 +61,7 @@ fun me.modmuss50.mpp.ModPublishExtension.setupFor(loaderName: String, releasePla
         val taskName = if (loaderLowercase == "fabric") "remapJar" else "jar"
         val jar = project(":$loaderLowercase").tasks.getByName(taskName).outputs.files.singleFile
 
-        val releaseTitle = "Sodium ${BuildConfig.MOD_VERSION} for $loaderName on ${BuildConfig.MINECRAFT_VERSION}"
+        val releaseTitle = "Sodium ${BuildConfig.MOD_VERSION} for $loaderName ${BuildConfig.MINECRAFT_VERSION}"
         val releaseVersion = "${BuildConfig.RELEASE_TAG}-$loaderLowercase"
 
         curseforge("curseforge$loaderName") {

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -199,9 +199,6 @@ tasks {
     }
 
     getByName<ProcessResources>("processModResources") {
-        eachFile {
-            println(path)
-        }
         filesMatching(listOf("META-INF/neoforge.mods.toml")) {
             expand(mapOf("version" to BuildConfig.createVersionString(rootProject)))
         }


### PR DESCRIPTION
Contains cherrypicked changes from: https://github.com/CaffeineMC/sodium/pull/3623
Supersedes https://github.com/CaffeineMC/sodium/pull/3610

Dry run output: https://hst.sh/wifuyunubu.md