### PR TITLE
Fix the animation when fluid sprites are obtained directly via FluidModel

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/textures/animations/tracking/FluidStateModelSetMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/textures/animations/tracking/FluidStateModelSetMixin.java
@@ -1,0 +1,31 @@
+package net.caffeinemc.mods.sodium.mixin.features.textures.animations.tracking;
+
+import net.caffeinemc.mods.sodium.api.texture.SpriteUtil;
+import net.minecraft.client.renderer.block.FluidModel;
+import net.minecraft.client.renderer.block.FluidStateModelSet;
+import net.minecraft.client.resources.model.sprite.Material;
+import net.minecraft.world.level.material.FluidState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(FluidStateModelSet.class)
+public class FluidStateModelSetMixin {
+    // Catches fluid sprites accessed outside the chunk fluid rendering path, e.g. FramedBlocks' framed tank.
+    @Inject(method = "get", at = @At(value = "RETURN"))
+    private void sodium$catchUsedSprites(FluidState state, CallbackInfoReturnable<FluidModel> cir) {
+        FluidModel model = cir.getReturnValue();
+        if (model == null) {
+            return;
+        }
+
+        SpriteUtil.INSTANCE.markSpriteActive(model.stillMaterial().sprite());
+        SpriteUtil.INSTANCE.markSpriteActive(model.flowingMaterial().sprite());
+
+        Material.Baked overlay = model.overlayMaterial();
+        if (overlay != null) {
+            SpriteUtil.INSTANCE.markSpriteActive(overlay.sprite());
+        }
+    }
+}

--- a/common/src/main/resources/sodium-common.mixins.json
+++ b/common/src/main/resources/sodium-common.mixins.json
@@ -69,6 +69,7 @@
     "features.textures.NativeImageAccessor",
     "features.textures.animations.tracking.AtlasGlyphProviderMixin",
     "features.textures.animations.tracking.AtlasManagerMixin",
+    "features.textures.animations.tracking.FluidStateModelSetMixin",
     "features.textures.animations.tracking.GuiGraphicsMixin",
     "features.textures.animations.tracking.ModelBlockRendererMixin",
     "features.textures.animations.tracking.SpriteContentsMixin",


### PR DESCRIPTION
https://github.com/CaffeineMC/sodium/blob/dev/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/textures/animations/tracking/AtlasManagerMixin.java

I used this as a base, just added the null check for the overlay; `still` and `flowing` are non-nullable
fix https://github.com/CaffeineMC/sodium/issues/2967