### PR TITLE
Fixed #3603 (incorrect AO and sky light level around light sources)

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/model/light/data/LightDataAccess.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/model/light/data/LightDataAccess.java
@@ -89,13 +89,7 @@ public abstract class LightDataAccess {
             }
         }
 
-        // FIX: Do not apply AO from blocks that emit light
-        float ao;
-        if (lu == 0) {
-            ao = state.getShadeBrightness(level, pos);
-        } else {
-            ao = 1.0f;
-        }
+        float ao = state.getShadeBrightness(level, pos);
 
         return packFC(fc) | packFO(fo) | packOP(op) | packEM(em) | packAO(ao) | packLU(lu) | packSL(sl) | packBL(bl);
     }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/model/light/smooth/AoFaceData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/model/light/smooth/AoFaceData.java
@@ -237,16 +237,38 @@ class AoFaceData {
     private static int calculateCornerBrightness(int a, int b, int c, int d, boolean aem, boolean bem, boolean cem, boolean dem) {
         // FIX: Normalize corner vectors correctly to the minimum non-zero value between each one to prevent
         // strange issues
-        if ((a == 0) || (b == 0) || (c == 0) || (d == 0)) {
+        int ab = a & 255;
+        int bb = b & 255;
+        int cb = c & 255;
+        int db = d & 255;
+        if ((ab == 0) || (bb == 0) || (cb == 0) || (db == 0)) {
             // Find the minimum value between all corners
-            final int min = minNonZero(minNonZero(a, b), minNonZero(c, d));
+            final int min = minNonZero(minNonZero(ab, bb), minNonZero(cb, db));
 
             // Normalize the corner values
-            a = Math.max(a, min);
-            b = Math.max(b, min);
-            c = Math.max(c, min);
-            d = Math.max(d, min);
+            ab = Math.max(ab, min);
+            bb = Math.max(bb, min);
+            cb = Math.max(cb, min);
+            db = Math.max(db, min);
         }
+        int as = a & 16711680;
+        int bs = b & 16711680;
+        int cs = c & 16711680;
+        int ds = d & 16711680;
+        if ((as == 0) || (bs == 0) || (cs == 0) || (ds == 0)) {
+            // Find the minimum value between all corners
+            final int min = minNonZero(minNonZero(as, bs), minNonZero(cs, ds));
+
+            // Normalize the corner values
+            as = Math.max(as, min);
+            bs = Math.max(bs, min);
+            cs = Math.max(cs, min);
+            ds = Math.max(ds, min);
+        }
+        a = ab | as;
+        b = bb | bs;
+        c = cb | cs;
+        d = db | ds;
 
         // FIX: Apply the fullbright lightmap from emissive blocks at the very end so it cannot influence
         // the minimum lightmap and produce incorrect results (for example, sculk sensors in a dark room)

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/model/light/smooth/AoFaceData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/model/light/smooth/AoFaceData.java
@@ -237,10 +237,10 @@ class AoFaceData {
     private static int calculateCornerBrightness(int a, int b, int c, int d, boolean aem, boolean bem, boolean cem, boolean dem) {
         // FIX: Normalize corner vectors correctly to the minimum non-zero value between each one to prevent
         // strange issues
-        int ab = a & 255;
-        int bb = b & 255;
-        int cb = c & 255;
-        int db = d & 255;
+        int ab = a & 0xFF;
+        int bb = b & 0xFF;
+        int cb = c & 0xFF;
+        int db = d & 0xFF;
         if ((ab == 0) || (bb == 0) || (cb == 0) || (db == 0)) {
             // Find the minimum value between all corners
             final int min = minNonZero(minNonZero(ab, bb), minNonZero(cb, db));
@@ -251,10 +251,10 @@ class AoFaceData {
             cb = Math.max(cb, min);
             db = Math.max(db, min);
         }
-        int as = a & 16711680;
-        int bs = b & 16711680;
-        int cs = c & 16711680;
-        int ds = d & 16711680;
+        int as = a & 0xFF0000;
+        int bs = b & 0xFF0000;
+        int cs = c & 0xFF0000;
+        int ds = d & 0xFF0000;
         if ((as == 0) || (bs == 0) || (cs == 0) || (ds == 0)) {
             // Find the minimum value between all corners
             final int min = minNonZero(minNonZero(as, bs), minNonZero(cs, ds));


### PR DESCRIPTION
This is a draft because:
- There is comments in [LightDataAccess.java#L92](https://github.com/CaffeineMC/sodium/blob/dev/common/src/main/java/net/caffeinemc/mods/sodium/client/model/light/data/LightDataAccess.java#L92) which shows the lack of AO around opaque light sources might be work as intended. However, imo sky brightness during day is much stronger than blocks, so it should create AO at least during day.
- Changes for [AoFaceData.java](https://github.com/CaffeineMC/sodium/blob/dev/common/src/main/java/net/caffeinemc/mods/sodium/client/model/light/smooth/AoFaceData.java) can be optimized like split sky and block light level outside that function, so we will only have to do 9 splits instead of 16. But I'm not sure if it meet your tastes.

Changes for AO in LightDataAccess.java is simple enough so I guess I don't have to explain for it.

Changes for smoothed light levels is similar to how vanilla handle it in [net/minecraft/client/renderer/block/BlockModelLighter#L166-169](https://mcsrc.dev/1/26.1.2/net/minecraft/client/renderer/block/BlockModelLighter#L166-169), the [smoothBlend()](https://mcsrc.dev/1/26.1.2/net/minecraft/util/LightCoordsUtil#L61) function do sky and block light levels separately, to avoid the 0 sky light level inside opaque light sources reducing smoothed sky light level.

Fixes #3603 