### PR TITLE
Sort Entity Quads by Closest Point

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumConfigBuilder.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumConfigBuilder.java
@@ -569,6 +569,15 @@ public class SodiumConfigBuilder implements ConfigEntryPoint {
                                 .setBinding(value -> this.sodiumOpts.quality.improvedFluidShaping = value, () -> this.sodiumOpts.quality.improvedFluidShaping)
                                 .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)
                 )
+                .addOption(
+                        builder.createBooleanOption(Identifier.parse("sodium:quality.closest_point_entity_sort"))
+                                .setStorageHandler(this.sodiumStorage)
+                                .setName(Component.translatable("sodium.options.closest_point_entity_sort.name"))
+                                .setTooltip(Component.translatable("sodium.options.closest_point_entity_sort.tooltip"))
+                                .setImpact(OptionImpact.MEDIUM)
+                                .setDefaultValue(DEFAULTS.quality.useClosestPointEntitySort)
+                                .setBinding(value -> this.sodiumOpts.quality.useClosestPointEntitySort = value, () -> this.sodiumOpts.quality.useClosestPointEntitySort)
+                )
         );
         return qualityPage;
     }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumOptions.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumOptions.java
@@ -39,6 +39,7 @@ public class SodiumOptions {
     public static class QualitySettings {
         public boolean hiddenFluidCulling = true;
         public boolean improvedFluidShaping = false;
+        public boolean useClosestPointEntitySort = false;
         public FilterMode pixelFilteringMode = FilterMode.NEAREST;
     }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/util/sorting/VertexSorters.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/util/sorting/VertexSorters.java
@@ -3,6 +3,7 @@ package net.caffeinemc.mods.sodium.client.util.sorting;
 import com.mojang.blaze3d.vertex.CompactVectorArray;
 import com.mojang.blaze3d.vertex.VertexSorting;
 import net.caffeinemc.mods.sodium.api.memory.MemoryIntrinsics;
+import net.caffeinemc.mods.sodium.client.SodiumClientMod;
 import net.caffeinemc.mods.sodium.client.util.MathUtil;
 import org.apache.commons.lang3.Validate;
 import org.joml.Intersectionf;
@@ -103,12 +104,18 @@ public class VertexSorters {
         Validate.isTrue(buffer.remaining() >= vertexStride * vertexCount,
                 "Vertex buffer is not large enough to contain all vertices");
 
-        if (sorting instanceof SortByDistanceToPoint pointMetric) {
-            return sortWithPerspective(buffer, vertexCount, vertexStride, pointMetric, pointMetric.x, pointMetric.y, pointMetric.z);
-        } else if (sorting instanceof SortByDistanceToOrigin) {
-            return sortWithPerspective(buffer, vertexCount, vertexStride, sorting, 0.0f, 0.0f, 0.0f);
+        if (SodiumClientMod.options().quality.useClosestPointEntitySort) {
+            if (sorting instanceof VertexSorters.SortByDistanceToPoint pointMetric) {
+                return sortWithPerspective(buffer, vertexCount, vertexStride, pointMetric, pointMetric.x, pointMetric.y, pointMetric.z);
+            } else if (sorting instanceof VertexSorters.SortByDistanceToOrigin) {
+                return sortWithPerspective(buffer, vertexCount, vertexStride, sorting, 0.0f, 0.0f, 0.0f);
+            }
         }
 
+        return sortWithCentroid(buffer, vertexCount, vertexStride, sorting);
+    }
+
+    public static int[] sortWithCentroid(ByteBuffer buffer, int vertexCount, int vertexStride, VertexSortingExtended sorting) {
         long pVertex0 = MemoryUtil.memAddress(buffer);
         long pVertex2 = MemoryUtil.memAddress(buffer, vertexStride * 2);
 
@@ -148,7 +155,7 @@ public class VertexSorters {
         return perm;
     }
 
-    private static int[] sortWithPerspective(ByteBuffer buffer, int vertexCount, int vertexStride, VertexSortingExtended metric, float refX, float refY, float refZ) {
+    public static int[] sortWithPerspective(ByteBuffer buffer, int vertexCount, int vertexStride, VertexSortingExtended metric, float refX, float refY, float refZ) {
         long pVertex0 = MemoryUtil.memAddress(buffer);
         long pVertex1 = MemoryUtil.memAddress(buffer, vertexStride);
         long pVertex2 = MemoryUtil.memAddress(buffer, vertexStride * 2);

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/util/sorting/VertexSorters.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/util/sorting/VertexSorters.java
@@ -2,11 +2,12 @@ package net.caffeinemc.mods.sodium.client.util.sorting;
 
 import com.mojang.blaze3d.vertex.CompactVectorArray;
 import com.mojang.blaze3d.vertex.VertexSorting;
+import net.caffeinemc.mods.sodium.api.memory.MemoryIntrinsics;
 import net.caffeinemc.mods.sodium.client.util.MathUtil;
 import org.apache.commons.lang3.Validate;
-import org.jspecify.annotations.NonNull;
+import org.joml.Intersectionf;
 import org.joml.Vector3f;
-import net.caffeinemc.mods.sodium.api.memory.MemoryIntrinsics;
+import org.jspecify.annotations.NonNull;
 import org.lwjgl.system.MemoryUtil;
 
 import java.nio.ByteBuffer;
@@ -102,6 +103,12 @@ public class VertexSorters {
         Validate.isTrue(buffer.remaining() >= vertexStride * vertexCount,
                 "Vertex buffer is not large enough to contain all vertices");
 
+        if (sorting instanceof SortByDistanceToPoint pointMetric) {
+            return sortWithPerspective(buffer, vertexCount, vertexStride, pointMetric, pointMetric.x, pointMetric.y, pointMetric.z);
+        } else if (sorting instanceof SortByDistanceToOrigin) {
+            return sortWithPerspective(buffer, vertexCount, vertexStride, sorting, 0.0f, 0.0f, 0.0f);
+        }
+
         long pVertex0 = MemoryUtil.memAddress(buffer);
         long pVertex2 = MemoryUtil.memAddress(buffer, vertexStride * 2);
 
@@ -133,6 +140,55 @@ public class VertexSorters {
             perm[primitiveId] = primitiveId;
 
             pVertex0 += primitiveStride;
+            pVertex2 += primitiveStride;
+        }
+
+        RadixSort.sortIndirect(perm, keys, true);
+
+        return perm;
+    }
+
+    private static int[] sortWithPerspective(ByteBuffer buffer, int vertexCount, int vertexStride, VertexSortingExtended metric, float refX, float refY, float refZ) {
+        long pVertex0 = MemoryUtil.memAddress(buffer);
+        long pVertex1 = MemoryUtil.memAddress(buffer, vertexStride);
+        long pVertex2 = MemoryUtil.memAddress(buffer, vertexStride * 2);
+
+        int primitiveCount = vertexCount / 4;
+        int primitiveStride = vertexStride * 4;
+
+        final int[] keys = new int[primitiveCount];
+        final int[] perm = new int[primitiveCount];
+
+        final var scratch = new Vector3f();
+
+        for (int primitiveId = 0; primitiveId < primitiveCount; primitiveId++) {
+            // instead of calculating the centroid, calculate the closest point on the quad (assuming it's flat and rectangular) to the reference, which may not be the centroid
+            float v0x = MemoryUtil.memGetFloat(pVertex0 + 0L);
+            float v0y = MemoryUtil.memGetFloat(pVertex0 + 4L);
+            float v0z = MemoryUtil.memGetFloat(pVertex0 + 8L);
+
+            float v1x = MemoryUtil.memGetFloat(pVertex1 + 0L);
+            float v1y = MemoryUtil.memGetFloat(pVertex1 + 4L);
+            float v1z = MemoryUtil.memGetFloat(pVertex1 + 8L);
+
+            float v2x = MemoryUtil.memGetFloat(pVertex2 + 0L);
+            float v2y = MemoryUtil.memGetFloat(pVertex2 + 4L);
+            float v2z = MemoryUtil.memGetFloat(pVertex2 + 8L);
+
+            // this method requires the first point to be between the second and third in the rectangle
+            Intersectionf.findClosestPointOnRectangle(
+                    v1x, v1y, v1z,
+                    v0x, v0y, v0z,
+                    v2x, v2y, v2z,
+                    refX, refY, refZ,
+                    scratch);
+
+            // The sign bit of the metric is negated as we need back-to-front (descending) ordering.
+            keys[primitiveId] = MathUtil.floatToComparableInt(-metric.applyMetric(scratch.x, scratch.y, scratch.z));
+            perm[primitiveId] = primitiveId;
+
+            pVertex0 += primitiveStride;
+            pVertex1 += primitiveStride;
             pVertex2 += primitiveStride;
         }
 

--- a/common/src/main/resources/assets/sodium/lang/en_us.json
+++ b/common/src/main/resources/assets/sodium/lang/en_us.json
@@ -73,6 +73,8 @@
   "sodium.options.hidden_fluid_culling.tooltip" : "If enabled, applies more aggressive culling to fluids, which can improve performance of flooded caves and underwater areas. Interruptions in the fluid surface may become visible at very shallow viewing angles.",
   "sodium.options.improved_fluid_shaping.name" : "Improved Fluid Shaping",
   "sodium.options.improved_fluid_shaping.tooltip" : "Changes how fluids are shaped around waterlogged blocks. This can improve the consistency of fluid surfaces, at the expense of not slanting the fluid in the direction of the physical flow in some situations. This does not affect the physical behavior of fluids in any way.",
+  "sodium.options.closest_point_entity_sort.name" : "Closest-Point Entity Sorting",
+  "sodium.options.closest_point_entity_sort.tooltip" : "Sorts the geometry of entities by the closest point to the camera. This improves rendering accuracy for translucent quads with different sizes, at a small CPU cost.",
   "sodium.options.pixel_filtering_mode.name" : "Texel Interpolation",
   "sodium.options.pixel_filtering_mode.tooltip" : "Controls the appearance of edges between pixels within textures. \"Nearest\" mode results in sharp pixel boundaries, while \"Linear\" mode makes them a little blurry. \"Nearest\" can be slightly faster.",
   "sodium.options.pixel_filtering_mode.nearest" : "Nearest",


### PR DESCRIPTION
Adds a default-off option to sort entity quads by their closest point to the camera. This improves the sorting order for entities that contain many differently sized quads arranged in specific unfortunate ways.

Fixes #3343