### PR TITLE
Fixed FULL_BRIGHT blocks increasing nearby sky light level

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/model/light/smooth/AoFaceData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/model/light/smooth/AoFaceData.java
@@ -273,16 +273,20 @@ class AoFaceData {
         // FIX: Apply the fullbright lightmap from emissive blocks at the very end so it cannot influence
         // the minimum lightmap and produce incorrect results (for example, sculk sensors in a dark room)
         if (aem) {
-            a = LightCoordsUtil.FULL_BRIGHT;
+            a &= 0xFF0000;
+            a |= 0xF0;
         }
         if (bem) {
-            b = LightCoordsUtil.FULL_BRIGHT;
+            b &= 0xFF0000;
+            b |= 0xF0;
         }
         if (cem) {
-            c = LightCoordsUtil.FULL_BRIGHT;
+            c &= 0xFF0000;
+            c |= 0xF0;
         }
         if (dem) {
-            d = LightCoordsUtil.FULL_BRIGHT;
+            d &= 0xFF0000;
+            d |= 0xF0;
         }
 
         return ((a + b + c + d) >> 2) & 0xFF00FF;


### PR DESCRIPTION
Mostly magma and active sculk sensor, I'm not sure if there is any FULL_BRIGHT blocks in vanilla. They will consider themselves have full sky and block brightness, and then increasing nearby sky light level even inside dark caves if smooth lighting is on. This will result in lighting around them brighter during day, and darker during night.

Day:
<img width="1920" height="1017" alt="2026-05-09_11 20 34" src="https://github.com/user-attachments/assets/d0b8aa66-e57a-4b79-a88b-16b3fe2b2ceb" />
Night:
<img width="1920" height="1017" alt="2026-05-09_11 20 45" src="https://github.com/user-attachments/assets/e7d39759-f563-49a7-b35d-ad8574773ee5" />

After only apply full block light level on them, they no longer contribute sky light level to nearby blocks, and keeps the same lighting no matter what daytime it is. (And more yellow to be block light color instead of white sky light color right?)
<img width="1920" height="1017" alt="2026-05-09_11 33 42" src="https://github.com/user-attachments/assets/05b70723-de77-4250-ad44-5256beddeb91" />

Quads of those block themselves still have full sky light strength, which might similar to `light_emission`. Vanilla `light_emission` also increase the minumum value of sky light, but I'm not sure if injecting into [net/minecraft/util/LightCoordsUtil#L51](https://mcsrc.dev/1/26.1.2/net/minecraft/util/LightCoordsUtil#L51) is a wise thing so it does not included in this pr.
