### PR TITLE
Fix Light Emission Type Error

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/model/quad/BakedQuadView.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/model/quad/BakedQuadView.java
@@ -10,4 +10,6 @@ public interface BakedQuadView extends ModelQuadView {
     boolean hasShade();
 
     boolean hasAO();
+
+    int getLightEmission();
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/model/BakedModelEncoder.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/model/BakedModelEncoder.java
@@ -16,6 +16,14 @@ import org.lwjgl.system.MemoryStack;
 public class BakedModelEncoder {
     private static final boolean USE_COLOR_MULTIPLICATION = PlatformRuntimeInformation.getInstance().usesBakedQuadColorMultiplication();
 
+    /**
+     * Encodes the given quad into the provided writer, applying the transformations and combining the data from {@code quad} and {@code instance}, where {@code instance} is modified dynamically and {@code quad} comes from the baked model.
+     *
+     * @param writer The writer to write the vertex data into.
+     * @param matrices The current transformation matrices to apply to the vertex data.
+     * @param quad The quad to encode, providing the base vertex data.
+     * @param instance The instance providing dynamic data such as color and light, which may also modify the base vertex data from the quad.
+     */
     public static void writeQuadVertices(VertexBufferWriter writer, PoseStack.Pose matrices, BakedQuadView quad, QuadInstance instance) {
         Matrix3f matNormal = matrices.normal();
         Matrix4f matPosition = matrices.pose();
@@ -30,6 +38,7 @@ public class BakedModelEncoder {
                 float y = quad.getY(i);
                 float z = quad.getZ(i);
 
+                // take the base quad's material's emission and apply it to the instance's light
                 int newLight = instance.getLightCoordsWithEmission(i, quad.getLightEmission());
 
                 //  NeoForge patches the default VertexConsumer.putBakedQuad to do ARGB.multiply(instance.getColor(vertex), quad.bakedColors().color(vertex)), but Sodium short-circuits that path via BufferBuilderMixin, so the multiplication is lost. Blocks that encode their tint only in element.color(...) (XyCraft ores) lose all color, and blocks combining a BlockTintSource with a baked color get only one factor applied.

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/model/BakedModelEncoder.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/model/BakedModelEncoder.java
@@ -7,7 +7,7 @@ import net.caffeinemc.mods.sodium.api.util.ColorARGB;
 import net.caffeinemc.mods.sodium.api.util.ColorMixer;
 import net.caffeinemc.mods.sodium.api.vertex.buffer.VertexBufferWriter;
 import net.caffeinemc.mods.sodium.api.vertex.format.common.EntityVertex;
-import net.caffeinemc.mods.sodium.client.model.quad.ModelQuadView;
+import net.caffeinemc.mods.sodium.client.model.quad.BakedQuadView;
 import net.caffeinemc.mods.sodium.client.services.PlatformRuntimeInformation;
 import org.joml.Matrix3f;
 import org.joml.Matrix4f;
@@ -16,7 +16,7 @@ import org.lwjgl.system.MemoryStack;
 public class BakedModelEncoder {
     private static final boolean USE_COLOR_MULTIPLICATION = PlatformRuntimeInformation.getInstance().usesBakedQuadColorMultiplication();
 
-    public static void writeQuadVertices(VertexBufferWriter writer, PoseStack.Pose matrices, ModelQuadView quad, QuadInstance instance) {
+    public static void writeQuadVertices(VertexBufferWriter writer, PoseStack.Pose matrices, BakedQuadView quad, QuadInstance instance) {
         Matrix3f matNormal = matrices.normal();
         Matrix4f matPosition = matrices.pose();
 
@@ -30,7 +30,7 @@ public class BakedModelEncoder {
                 float y = quad.getY(i);
                 float z = quad.getZ(i);
 
-                int newLight = instance.getLightCoordsWithEmission(i, quad.getMaxLightQuad(i));
+                int newLight = instance.getLightCoordsWithEmission(i, quad.getLightEmission());
 
                 //  NeoForge patches the default VertexConsumer.putBakedQuad to do ARGB.multiply(instance.getColor(vertex), quad.bakedColors().color(vertex)), but Sodium short-circuits that path via BufferBuilderMixin, so the multiplication is lost. Blocks that encode their tint only in element.color(...) (XyCraft ores) lose all color, and blocks combining a BlockTintSource with a baked color get only one factor applied.
                 //  The platform flag is needed because Fabric's default implementation does not perform this multiplication.

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/immediate/buffer_builder/intrinsics/BufferBuilderMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/immediate/buffer_builder/intrinsics/BufferBuilderMixin.java
@@ -6,9 +6,8 @@ import com.mojang.blaze3d.vertex.QuadInstance;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.caffeinemc.mods.sodium.api.memory.MemoryIntrinsics;
 import net.caffeinemc.mods.sodium.api.texture.SpriteUtil;
-import net.caffeinemc.mods.sodium.api.util.ColorABGR;
 import net.caffeinemc.mods.sodium.api.vertex.buffer.VertexBufferWriter;
-import net.caffeinemc.mods.sodium.client.model.quad.ModelQuadView;
+import net.caffeinemc.mods.sodium.client.model.quad.BakedQuadView;
 import net.caffeinemc.mods.sodium.client.render.immediate.model.BakedModelEncoder;
 import net.minecraft.client.resources.model.geometry.BakedQuad;
 import org.spongepowered.asm.mixin.Final;
@@ -62,7 +61,7 @@ public abstract class BufferBuilderMixin implements VertexConsumer {
 
         VertexBufferWriter writer = VertexBufferWriter.of(this);
 
-        ModelQuadView quadX = (ModelQuadView) (Object) quad;
+        BakedQuadView quadX = (BakedQuadView) (Object) quad;
 
         BakedModelEncoder.writeQuadVertices(writer, pose, quadX, instance);
 

--- a/fabric/src/main/java/net/caffeinemc/mods/sodium/mixin/core/model/quad/BakedQuadMixin.java
+++ b/fabric/src/main/java/net/caffeinemc/mods/sodium/mixin/core/model/quad/BakedQuadMixin.java
@@ -3,10 +3,9 @@ package net.caffeinemc.mods.sodium.mixin.core.model.quad;
 import net.caffeinemc.mods.sodium.client.model.quad.BakedQuadView;
 import net.caffeinemc.mods.sodium.client.model.quad.properties.ModelQuadFacing;
 import net.caffeinemc.mods.sodium.client.model.quad.properties.ModelQuadFlags;
-import net.caffeinemc.mods.sodium.client.util.ModelQuadUtil;
 import net.minecraft.client.model.geom.builders.UVPair;
-import net.minecraft.client.resources.model.geometry.BakedQuad;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.model.geometry.BakedQuad;
 import net.minecraft.core.Direction;
 import net.minecraft.util.LightCoordsUtil;
 import org.joml.Vector3fc;
@@ -121,7 +120,12 @@ public abstract class BakedQuadMixin implements BakedQuadView {
 
     @Override
     public int getMaxLightQuad(int idx) {
-        return LightCoordsUtil.lightCoordsWithEmission(getLight(idx), materialInfo.lightEmission());
+        return LightCoordsUtil.lightCoordsWithEmission(getLight(idx), this.materialInfo.lightEmission());
+    }
+
+    @Override
+    public int getLightEmission() {
+        return this.materialInfo.lightEmission();
     }
 
     @Override

--- a/neoforge/src/mod/java/net/caffeinemc/mods/sodium/mixin/core/model/quad/BakedQuadMixin.java
+++ b/neoforge/src/mod/java/net/caffeinemc/mods/sodium/mixin/core/model/quad/BakedQuadMixin.java
@@ -3,10 +3,9 @@ package net.caffeinemc.mods.sodium.mixin.core.model.quad;
 import net.caffeinemc.mods.sodium.client.model.quad.BakedQuadView;
 import net.caffeinemc.mods.sodium.client.model.quad.properties.ModelQuadFacing;
 import net.caffeinemc.mods.sodium.client.model.quad.properties.ModelQuadFlags;
-import net.caffeinemc.mods.sodium.client.util.ModelQuadUtil;
 import net.minecraft.client.model.geom.builders.UVPair;
-import net.minecraft.client.resources.model.geometry.BakedQuad;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.model.geometry.BakedQuad;
 import net.minecraft.core.Direction;
 import net.minecraft.util.LightCoordsUtil;
 import net.neoforged.neoforge.client.model.quad.BakedColors;
@@ -131,6 +130,11 @@ public abstract class BakedQuadMixin implements BakedQuadView {
     @Override
     public int getMaxLightQuad(int idx) {
         return LightCoordsUtil.lightCoordsWithEmission(getLight(idx), this.materialInfo.lightEmission());
+    }
+
+    @Override
+    public int getLightEmission() {
+        return this.materialInfo.lightEmission();
     }
 
     @Override


### PR DESCRIPTION
Fix type error where instead of the quad's light emission a packed coordinate is passed into lightCoordsWithEmission.

This is a draft PR because before this is merged I would like to document this code so that it becomes somewhat more comprehensible. Currently this is completely opaque and impossible to properly work with without prior knowledge.

@IMS212 @jellysquid3 or anyone else who happens to know about this, please supply a description of the following:

1. What is `instance` and where does it come from?
2. What is `quad` and where does it come from?
3. In which contexts and why is `BakedModelEncoder.writeQuadVertices` called?
4. What was `int newLight = instance.getLightCoordsWithEmission(i, quad.getMaxLightQuad(i));` supposed to be doing and how is it different from doing `int newLight = quad.getMaxLightQuad(i);`?

If you feel we can solve this issue in another way than adding a method to BakedQuadView, such as adding a `lightEmission`parameter to `writeQuadVertices` [like this](https://discord.com/channels/602796788608401408/651120262129123330/1502841918466424985).

Closes https://github.com/CaffeineMC/sodium/issues/3639