### PR TITLE
Fix: Handle fog effects (blindness/darkness) properly to prevent chunk flickering

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -202,7 +202,10 @@ public class SodiumWorldRenderer {
             this.cullMatrix = new Matrix4f(cullMatrix);
         }
         boolean cameraLocationChanged = !pos.equals(this.lastCameraPos);
-        boolean fogDistanceChanged = fogParameters.renderEnd() != this.lastFogParameters.renderEnd();
+        // Check if the fog distance (renderEnd - renderStart) has changed, not just renderEnd.
+        // This prevents unnecessary camera updates when effects like blindness/darkness change
+        // both fog parameters together without actually changing the visible chunk area.
+        boolean fogDistanceChanged = this.computeFogDistance(fogParameters) != this.computeFogDistance(this.lastFogParameters);
         boolean cameraAngleChanged = pitch != this.lastCameraPitch || yaw != this.lastCameraYaw;
         boolean cameraProjectionChanged = !cullMatrix.equals(this.cullMatrix, 0.0001f);
 
@@ -260,6 +263,15 @@ public class SodiumWorldRenderer {
         profiler.pop();
 
         Entity.setViewScale(Mth.clamp((double) this.client.options.getEffectiveRenderDistance() / 8.0D, 1.0D, 2.5D) * this.client.options.entityDistanceScaling().get());
+    }
+
+    /**
+     * Computes the effective fog distance by calculating renderEnd - renderStart.
+     * This is used to detect meaningful changes in fog distance while ignoring
+     * changes in individual parameters that occur together (e.g., during blindness effects).
+     */
+    private static float computeFogDistance(FogParameters parameters) {
+        return parameters.renderEnd() - parameters.renderStart();
     }
 
     private void processChunkEvents() {


### PR DESCRIPTION
## Description

Fixes rendering issues with fog effects (blindness/darkness) where chunks flicker or disappear when these potion effects are active.

### Root Cause

When blindness or darkness potion effects are active, Minecraft's `FogRenderer.setupFog()` changes both `renderStart` and `renderEnd` values on every tick. 

In the original code, `SodiumWorldRenderer.setupTerrain()` only checked if `renderEnd` had changed:
```java
boolean fogDistanceChanged = fogParameters.renderEnd() != this.lastFogParameters.renderEnd();
```

When the fog effect parameters changed, this triggered `notifyChangedCamera()` which caused the chunk system to re-evaluate visibility, resulting in chunks flickering or disappearing.

### The Fix

The fix computes the **effective fog distance** (`renderEnd - renderStart`) and compares that instead of just `renderEnd`. When blindness/darkness effects change both fog parameters together, the effective distance remains constant, so no unnecessary camera updates occur.

```java
// Old: Only checked renderEnd
boolean fogDistanceChanged = fogParameters.renderEnd() != this.lastFogParameters.renderEnd();

// New: Check the effective distance
boolean fogDistanceChanged = this.computeFogDistance(fogParameters) != this.computeFogDistance(this.lastFogParameters);

private static float computeFogDistance(FogParameters parameters) {
    return parameters.renderEnd() - parameters.renderStart();
}
```

This is a more semantically correct check because what actually matters for chunk culling is the **distance** to which chunks are visible, not the absolute end position of the fog.

### Testing

- Tested with `/effect give @s minecraft:blindness 5` - chunks no longer flicker
- Tested with `/effect give @s minecraft:darkness 5` - chunks no longer flicker
- Normal fog (rain, underwater) still works correctly as those change the effective distance

## Issue Fixed

Closes #3563