### PR TITLE
Fix Double Driver Workaround Application

### DIFF
--- a/neoforge/src/main/java/net/caffeinemc/mods/sodium/service/SodiumWorkarounds.java
+++ b/neoforge/src/main/java/net/caffeinemc/mods/sodium/service/SodiumWorkarounds.java
@@ -3,8 +3,9 @@ package net.caffeinemc.mods.sodium.service;
 import net.caffeinemc.mods.sodium.client.compatibility.checks.PreLaunchChecks;
 import net.caffeinemc.mods.sodium.client.compatibility.environment.probe.GraphicsAdapterProbe;
 import net.caffeinemc.mods.sodium.client.compatibility.workarounds.Workarounds;
-import net.caffeinemc.mods.sodium.client.compatibility.workarounds.nvidia.NvidiaWorkarounds;
 import net.caffeinemc.mods.sodium.client.compatibility.workarounds.amd.AmdWorkarounds;
+import net.caffeinemc.mods.sodium.client.compatibility.workarounds.nvidia.NvidiaWorkarounds;
+import net.neoforged.fml.loading.FMLConfig;
 import net.neoforged.neoforgespi.earlywindow.GraphicsBootstrapper;
 
 public class SodiumWorkarounds implements GraphicsBootstrapper {
@@ -19,8 +20,11 @@ public class SodiumWorkarounds implements GraphicsBootstrapper {
         GraphicsAdapterProbe.findAdapters();
         Workarounds.init();
 
-        // Context creation happens earlier on NeoForge, so we need to apply this now
-        NvidiaWorkarounds.applyEnvironmentChanges();
-        AmdWorkarounds.applyEnvironmentChanges();
+        // When early window control is disabled, NeoForge creates no early GL context, so context creation happens later in Window#createGlfwWindow. We want to avoid doing the workarounds twice if the context is going to be created later and thus our mixin to Window#createGlfwWindow runs that also applies them.
+        // See https://github.com/CaffeineMC/sodium/issues/3664 for more details.
+        if (FMLConfig.getBoolConfigValue(FMLConfig.ConfigValue.EARLY_WINDOW_CONTROL)) {
+            NvidiaWorkarounds.applyEnvironmentChanges();
+            AmdWorkarounds.applyEnvironmentChanges();
+        }
     }
 }


### PR DESCRIPTION
Only make environment changes if the early window will create a gl context early

Closes #3664