### PR TITLE
fix: respect ambient occlusion flag in FRAPI AltModelBlockRenderer

### DIFF
--- a/frapi/src/main/java/net/caffeinemc/mods/sodium/client/render/frapi/render/NonTerrainBlockRenderContext.java
+++ b/frapi/src/main/java/net/caffeinemc/mods/sodium/client/render/frapi/render/NonTerrainBlockRenderContext.java
@@ -154,6 +154,9 @@ public class NonTerrainBlockRenderContext extends AbstractBlockRenderContext imp
         this.offset.set(x + offset.x, y + offset.y, z + offset.z);
         defaultAo = allowAO && blockState.getLightEmission() == 0;
 
+        this.useAmbientOcclusion = allowAO;
+        this.defaultLightMode = useAmbientOcclusion && defaultAo ? LightMode.SMOOTH : LightMode.FLAT;
+
         this.lightDataCache.reset(pos, level);
         this.prepareCulling(enableCulling);
 
@@ -178,7 +181,7 @@ public class NonTerrainBlockRenderContext extends AbstractBlockRenderContext imp
         if (aoMode == TriState.DEFAULT) {
             lightMode = this.defaultLightMode;
         } else {
-            lightMode = this.useAmbientOcclusion && aoMode != TriState.FALSE && defaultAo ? LightMode.SMOOTH : LightMode.FLAT;
+            lightMode = this.useAmbientOcclusion && aoMode != TriState.FALSE ? LightMode.SMOOTH : LightMode.FLAT;
         }
         final boolean emissive = quad.emissive();
 


### PR DESCRIPTION
The AltModelBlockRenderer implementation in FRAPI (NonTerrainBlockRenderContext) was missing ambient occlusion initialization. The prepareAoInfo() method that sets useAmbientOcclusion and defaultLightMode fields inherited from AbstractBlockRenderContext was never called, so both fields remained at their defaults (false and FLAT), causing all quads to be rendered with flat shading regardless of the ambientOcclusion parameter passed to the constructor.

Closes #3594