### PR TITLE
Fix: Forced overriding of BlockTintSource in fabric fluid rendering

### DIFF
--- a/fabric/src/main/java/net/caffeinemc/mods/sodium/fabric/render/FluidRendererImpl.java
+++ b/fabric/src/main/java/net/caffeinemc/mods/sodium/fabric/render/FluidRendererImpl.java
@@ -135,7 +135,7 @@ public class FluidRendererImpl extends FluidRenderer {
         public ColorProvider<FluidState> getColorProvider(Fluid fluid, @Nullable BlockTintSource blockTintSource) {
             var override = this.colorProviderRegistry.getColorProvider(fluid);
 
-            if (!hasModOverride && override != null) {
+            if (hasModOverride && override != null) {
                 return override;
             }
 


### PR DESCRIPTION
In the fabric version of sodium a fluid rendering registry override check had inverted conditions.
This led to all instances where a mod registered a custom fluid renderer to have a vanilla BlockTintSource applied instead of whatever was intended.

Partially fixes #3675 