### PR TITLE
Fix rendering regions with deleted resources

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/DefaultChunkRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/DefaultChunkRenderer.java
@@ -82,6 +82,12 @@ public class DefaultChunkRenderer extends ShaderChunkRenderer {
                 continue;
             }
 
+            var resources = region.getResources();
+            if (resources == null) {
+                region.clearCachedBatchFor(renderPass);
+                continue;
+            }
+
             var batch = region.getCachedBatch(renderPass);
             if (!batch.isFilled) {
                 fillCommandBuffer(batch, region, storage, renderList, camera, renderPass, useBlockFaceCulling, useIndexedTessellation);
@@ -134,6 +140,11 @@ public class DefaultChunkRenderer extends ShaderChunkRenderer {
                     continue;
                 }
 
+                var resources = region.getResources();
+                if (resources == null) {
+                    continue;
+                }
+
                 var batch = region.getCachedBatch(renderPass);
                 if (batch.isEmpty()) {
                     continue;
@@ -141,10 +152,10 @@ public class DefaultChunkRenderer extends ShaderChunkRenderer {
 
 
                 if (useIndexedTessellation) {
-                    pass.setIndexBuffer(region.getResources().getIndexBuffer(), IndexType.INT);
+                    pass.setIndexBuffer(resources.getIndexBuffer(), IndexType.INT);
                 }
 
-                pass.setVertexBuffer(0, region.getResources().getGeometryBuffer().slice());
+                pass.setVertexBuffer(0, resources.getGeometryBuffer().slice());
 
                 drawContext.updateData(region, camera);
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/region/RenderRegion.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/region/RenderRegion.java
@@ -299,6 +299,7 @@ public class RenderRegion {
         if (this.resources != null && this.resources.shouldDelete()) {
             this.resources.delete();
             this.resources = null;
+            this.clearAllCachedBatches();
         }
     }
 


### PR DESCRIPTION
Fixes #3744.

I was able to reproduce this with a command-block stress test world that repeatedly rebuilds translucent glass pane sections while trying to replicate another issue.

Steps:
1. [Load the attached test world.](https://github.com/user-attachments/files/29191250/2026-06-21_23-25-29_3744.zip)
2. Stand near the test area: `/tp @p 16 82 16`
3. Teleport away from it: `/tp @p 500 90 500`
4. The game crashes during the render frame.

The crash happens because a render region can have its GPU resources deleted while an old cached draw batch still makes the renderer try to draw it.

This clears cached batches when region resources are deleted, and skips rendering regions that no longer have resources.

Edit:

I managed to reproduce another crash while retesting this world by teleporting back and forth quickly. I'm not sure about the fix for that one yet, but it looks like a separate async culling race. Seems timing-sensitive, only managed to reproduce once.

Crash log: [crash-2026-06-21_23.35.58-client.txt](https://github.com/user-attachments/files/29191814/crash-2026-06-21_23.35.58-client.txt)

