### PR TITLE
Fix crashes resulting from unsafe concurrency in async culling

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -1,8 +1,5 @@
 package net.caffeinemc.mods.sodium.client.render.chunk;
 
-import it.unimi.dsi.fastutil.longs.Long2ReferenceMap;
-import it.unimi.dsi.fastutil.longs.Long2ReferenceMaps;
-import it.unimi.dsi.fastutil.longs.Long2ReferenceOpenHashMap;
 import it.unimi.dsi.fastutil.objects.*;
 import net.caffeinemc.mods.sodium.api.texture.SpriteUtil;
 import net.caffeinemc.mods.sodium.client.SodiumClientMod;
@@ -21,6 +18,8 @@ import net.caffeinemc.mods.sodium.client.render.chunk.lists.*;
 import net.caffeinemc.mods.sodium.client.render.chunk.occlusion.*;
 import net.caffeinemc.mods.sodium.client.render.chunk.region.RenderRegion;
 import net.caffeinemc.mods.sodium.client.render.chunk.region.RenderRegionManager;
+import net.caffeinemc.mods.sodium.client.render.chunk.storage.QueuedSectionStorage;
+import net.caffeinemc.mods.sodium.client.render.chunk.storage.SectionStorage;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.SortBehavior;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.SortBehavior.PriorityMode;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data.*;
@@ -69,7 +68,7 @@ public class RenderSectionManager {
     private final RenderRegionManager regions;
     private final ClonedChunkSectionCache sectionCache;
 
-    private final Long2ReferenceMap<RenderSection> sectionByPosition = new Long2ReferenceOpenHashMap<>();
+    private final SectionStorage renderSections = new QueuedSectionStorage();
 
     private final ConcurrentLinkedDeque<ChunkJobResult<? extends BuilderTaskOutput>> buildResults = new ConcurrentLinkedDeque<>();
     private final JobDurationEstimator jobDurationEstimator = new JobDurationEstimator();
@@ -144,7 +143,7 @@ public class RenderSectionManager {
         this.sectionCache = new ClonedChunkSectionCache(this.level);
 
         this.renderLists = SortedRenderLists.empty();
-        this.occlusionCuller = new OcclusionCuller(Long2ReferenceMaps.unmodifiable(this.sectionByPosition), this.level);
+        this.occlusionCuller = new OcclusionCuller(this.renderSections, this.level);
 
         this.renderableSectionTree = new RemovableMultiForest(renderDistance);
 
@@ -209,6 +208,9 @@ public class RenderSectionManager {
     }
 
     private void consumeCullTaskResults(boolean waitForCompletion) {
+        // end the safe read phase even if the pending task is null since it might have been canceled
+        this.renderSections.endSafeReadPhase();
+
         if (this.pendingTask == null) {
             return;
         }
@@ -257,6 +259,7 @@ public class RenderSectionManager {
 
         var useOcclusionCulling = this.shouldUseOcclusionCulling(camera, spectator);
         this.pendingTask = new CullTask(viewport, searchDistanceRegular, searchDistanceLocal, this.frame, this.occlusionCuller, useOcclusionCulling, this.level);
+        this.renderSections.startSafeReadPhase();
         this.pendingTask.submitTo(this.asyncCullExecutor);
 
         // only clear the graph update if we actually scheduled a task. Otherwise, the currently running task might not pick up on the change and no additional task would have been scheduled.
@@ -309,7 +312,7 @@ public class RenderSectionManager {
 
     private void renderOutOfGraph(Viewport viewport, FogParameters fogParameters) {
         var searchDistance = this.getSearchDistance(fogParameters);
-        var visitor = new FallbackVisibleChunkCollector(viewport, searchDistance, this.frame, this.sectionByPosition, this.regions, this.level);
+        var visitor = new FallbackVisibleChunkCollector(viewport, searchDistance, this.frame, this.renderSections, this.regions, this.level);
 
         this.renderableSectionTree.prepareForTraversal();
         this.renderableSectionTree.traverse(visitor, viewport, searchDistance);
@@ -323,7 +326,9 @@ public class RenderSectionManager {
 
     private boolean isOutOfGraph(SectionPos pos) {
         var sectionY = pos.getY();
-        return this.level.getMinSectionY() <= sectionY && sectionY <= this.level.getMaxSectionY() && !this.sectionByPosition.containsKey(pos.asLong());
+        return this.level.getMinSectionY() <= sectionY &&
+                sectionY <= this.level.getMaxSectionY() &&
+                !this.renderSections.hasSectionConsistent(pos.asLong());
     }
 
     public void markGraphDirty() {
@@ -383,7 +388,7 @@ public class RenderSectionManager {
     public void onSectionAdded(int x, int y, int z) {
         long key = SectionPos.asLong(x, y, z);
 
-        if (this.sectionByPosition.containsKey(key)) {
+        if (this.renderSections.hasSectionConsistent(key)) {
             return;
         }
 
@@ -392,7 +397,7 @@ public class RenderSectionManager {
         RenderSection renderSection = new RenderSection(region, x, y, z);
         region.addSection(renderSection);
 
-        this.sectionByPosition.put(key, renderSection);
+        this.renderSections.queuePut(key, renderSection);
 
         ChunkAccess chunk = this.level.getChunk(x, z);
         LevelChunkSection section = chunk.getSections()[this.level.getSectionIndexFromSectionY(y)];
@@ -412,7 +417,7 @@ public class RenderSectionManager {
 
     public void onSectionRemoved(int x, int y, int z) {
         long sectionPos = SectionPos.asLong(x, y, z);
-        RenderSection section = this.sectionByPosition.remove(sectionPos);
+        RenderSection section = this.renderSections.queueRemove(sectionPos);
 
         if (section == null) {
             return;
@@ -467,8 +472,7 @@ public class RenderSectionManager {
     }
 
     private boolean isSectionEmpty(int x, int y, int z) {
-        long key = SectionPos.asLong(x, y, z);
-        RenderSection section = this.sectionByPosition.get(key);
+        RenderSection section = this.renderSections.getCurrent(x, y, z);
 
         if (section == null) {
             return true;
@@ -764,7 +768,7 @@ public class RenderSectionManager {
         }
 
         while (!this.taskLists.isEmpty() && collector.hasBudgetRemaining() && uploadBudget.isAvailable()) {
-            var section = this.sectionByPosition.get(this.taskLists.dequeueNextSectionPos());
+            var section = this.renderSections.getConsistent(this.taskLists.dequeueNextSectionPos());
             if (section != null) {
                 submitSectionTask(collector, section, uploadBudget);
             }
@@ -898,9 +902,7 @@ public class RenderSectionManager {
             result.destroy(); // delete resources for any pending tasks (including those that were cancelled)
         }
 
-        for (var section : this.sectionByPosition.values()) {
-            section.delete();
-        }
+        this.renderSections.deleteAll();
 
         this.sectionsWithGlobalEntities.clear();
 
@@ -911,7 +913,7 @@ public class RenderSectionManager {
     }
 
     public int getTotalSections() {
-        return this.sectionByPosition.size();
+        return this.renderSections.size();
     }
 
     public int getVisibleChunkCount() {
@@ -951,7 +953,7 @@ public class RenderSectionManager {
     }
 
     public void scheduleSort(long sectionPos, boolean isDirectTrigger) {
-        RenderSection section = this.sectionByPosition.get(sectionPos);
+        RenderSection section = this.renderSections.getConsistent(sectionPos);
 
         if (section != null) {
             int pendingUpdate = ChunkUpdateTypes.SORT;
@@ -969,9 +971,10 @@ public class RenderSectionManager {
     public void scheduleRebuild(int x, int y, int z, boolean playerChanged) {
         RenderAsserts.validateCurrentThread();
 
-        this.sectionCache.invalidate(x, y, z);
+        var key = SectionPos.asLong(x, y, z);
+        this.sectionCache.invalidate(key);
 
-        RenderSection section = this.sectionByPosition.get(SectionPos.asLong(x, y, z));
+        RenderSection section = this.renderSections.getConsistent(key);
 
         if (section != null && section.isBuilt()) {
             int pendingUpdate;
@@ -1036,7 +1039,7 @@ public class RenderSectionManager {
     }
 
     private RenderSection getRenderSection(int x, int y, int z) {
-        return this.sectionByPosition.get(SectionPos.asLong(x, y, z));
+        return this.renderSections.getConsistent(SectionPos.asLong(x, y, z));
     }
 
     public Collection<String> getDebugStrings(boolean verbose) {
@@ -1116,7 +1119,11 @@ public class RenderSectionManager {
 
         var cullState = this.pendingTask == null ? "Idle" : this.pendingTask.isDone() ? "Done" : "Running";
         var cullDuration = this.averageCullDurationNanos == -1 ? "?" : String.format("%.1fms", this.averageCullDurationNanos / 1_000_000.0);
-        list.add(String.format("Async Culling: %s (avg %s)", cullState, cullDuration));
+        if (verbose) {
+            list.add(String.format("%s AC: %s (avg %s)", this.renderSections.getDebugInfo(), cullState, cullDuration));
+        } else {
+            list.add(String.format("Async Culling: %s (avg %s)", cullState, cullDuration));
+        }
 
         return list;
     }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -180,7 +180,7 @@ public class RenderSectionManager {
         if (this.pendingTask != null && this.pendingTask.cancelIfNotStarted()) {
             this.pendingTask = null;
 
-            // end the safe read phase on cancellation
+            // end the safe read phase on task cancellation
             this.renderSections.endSafeReadPhase();
         }
 
@@ -241,7 +241,7 @@ public class RenderSectionManager {
         this.invalidateRenderLists();
         this.pendingTask = null;
 
-        // exit safe read phase of the section storage
+        // end the safe read phase on task completion
         this.renderSections.endSafeReadPhase();
     }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -54,6 +54,7 @@ import java.util.*;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 public class RenderSectionManager {
     private static final float NEARBY_REBUILD_DISTANCE = Mth.square(16.0f);
@@ -897,9 +898,18 @@ public class RenderSectionManager {
     }
 
     public void destroy() {
-        this.builder.shutdown(); // stop all the workers, and cancel any tasks
+        // stop all the workers and cancel any tasks
+        this.builder.shutdown();
 
+        // shutdown async task executor and wait for it to terminate
         this.asyncCullExecutor.shutdownNow();
+        try {
+            if (!this.asyncCullExecutor.awaitTermination(10, TimeUnit.SECONDS)) {
+                throw new RuntimeException("Shutting down async culling task executor timed out");
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Interrupted while waiting for async culling task executor to shutdown", e);
+        }
 
         for (var result : this.collectChunkBuildResults()) {
             result.destroy(); // delete resources for any pending tasks (including those that were cancelled)

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -179,6 +179,9 @@ public class RenderSectionManager {
         // cancel task if not in progress
         if (this.pendingTask != null && this.pendingTask.cancelIfNotStarted()) {
             this.pendingTask = null;
+
+            // end the safe read phase on cancellation
+            this.renderSections.endSafeReadPhase();
         }
 
         // consume the results of completed tasks
@@ -209,9 +212,6 @@ public class RenderSectionManager {
 
     private void consumeCullTaskResults(boolean waitForCompletion) {
         if (this.pendingTask == null) {
-            // end the safe read phase even if the pending task is null since it might have been canceled
-            this.renderSections.endSafeReadPhase();
-
             return;
         }
 
@@ -219,8 +219,6 @@ public class RenderSectionManager {
         if (!waitForCompletion && !this.pendingTask.isDone()) {
             return;
         }
-
-        this.renderSections.endSafeReadPhase();
 
         var result = this.pendingTask.getResult();
 
@@ -242,6 +240,9 @@ public class RenderSectionManager {
 
         this.invalidateRenderLists();
         this.pendingTask = null;
+
+        // exit safe read phase of the section storage
+        this.renderSections.endSafeReadPhase();
     }
 
     private static Thread makeAsyncCullThread(Runnable runnable) {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -208,10 +208,10 @@ public class RenderSectionManager {
     }
 
     private void consumeCullTaskResults(boolean waitForCompletion) {
-        // end the safe read phase even if the pending task is null since it might have been canceled
-        this.renderSections.endSafeReadPhase();
-
         if (this.pendingTask == null) {
+            // end the safe read phase even if the pending task is null since it might have been canceled
+            this.renderSections.endSafeReadPhase();
+
             return;
         }
 
@@ -219,6 +219,8 @@ public class RenderSectionManager {
         if (!waitForCompletion && !this.pendingTask.isDone()) {
             return;
         }
+
+        this.renderSections.endSafeReadPhase();
 
         var result = this.pendingTask.getResult();
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/FallbackVisibleChunkCollector.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/FallbackVisibleChunkCollector.java
@@ -1,20 +1,18 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.lists;
 
-import it.unimi.dsi.fastutil.longs.Long2ReferenceMap;
-import net.caffeinemc.mods.sodium.client.render.chunk.RenderSection;
 import net.caffeinemc.mods.sodium.client.render.chunk.occlusion.CullType;
 import net.caffeinemc.mods.sodium.client.render.chunk.region.RenderRegionManager;
+import net.caffeinemc.mods.sodium.client.render.chunk.storage.SectionStorage;
 import net.caffeinemc.mods.sodium.client.render.viewport.Viewport;
-import net.minecraft.core.SectionPos;
 import net.minecraft.world.level.Level;
 
 public class FallbackVisibleChunkCollector extends TaskCollectingTree implements CoordinateSectionVisitor {
-    private final Long2ReferenceMap<RenderSection> sectionByPosition;
+    private final SectionStorage sections;
     private final VisibleChunkCollector renderListCollector;
 
-    public FallbackVisibleChunkCollector(Viewport viewport, float buildDistance, int frame, Long2ReferenceMap<RenderSection> sectionByPosition, RenderRegionManager regions, Level level) {
+    public FallbackVisibleChunkCollector(Viewport viewport, float buildDistance, int frame, SectionStorage sections, RenderRegionManager regions, Level level) {
         super(viewport, buildDistance, frame, CullType.LOCAL, level);
-        this.sectionByPosition = sectionByPosition;
+        this.sections = sections;
         this.renderListCollector = new VisibleChunkCollector(regions, frame);
     }
 
@@ -26,7 +24,7 @@ public class FallbackVisibleChunkCollector extends TaskCollectingTree implements
     public void visit(int x, int y, int z) {
         this.renderListCollector.visit(x, y, z);
 
-        var section = this.sectionByPosition.get(SectionPos.asLong(x, y, z));
+        var section = this.sections.getCurrent(x, y, z);
 
         if (section == null) {
             return;

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/occlusion/OcclusionCuller.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/occlusion/OcclusionCuller.java
@@ -1,7 +1,7 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.occlusion;
 
-import it.unimi.dsi.fastutil.longs.Long2ReferenceMap;
 import net.caffeinemc.mods.sodium.client.render.chunk.RenderSection;
+import net.caffeinemc.mods.sodium.client.render.chunk.storage.SectionStorage;
 import net.caffeinemc.mods.sodium.client.render.viewport.CameraTransform;
 import net.caffeinemc.mods.sodium.client.render.viewport.Viewport;
 import net.caffeinemc.mods.sodium.client.util.collections.DoubleBufferedQueue;
@@ -19,7 +19,7 @@ import net.minecraft.world.level.Level;
  * Not wide visible implies not regular visible implies not frustum visible.
  */
 public class OcclusionCuller {
-    private final Long2ReferenceMap<RenderSection> sections;
+    private final SectionStorage sections;
     private final Level level;
     private final DoubleBufferedQueue<RenderSection> queue = new DoubleBufferedQueue<>();
 
@@ -204,7 +204,7 @@ public class OcclusionCuller {
     }
 
 
-    public OcclusionCuller(Long2ReferenceMap<RenderSection> sections, Level level) {
+    public OcclusionCuller(SectionStorage sections, Level level) {
         this.sections = sections;
         this.level = level;
     }
@@ -246,7 +246,7 @@ public class OcclusionCuller {
             }
         }
 
-        if (this.getRenderSection(this.origin) == null) {
+        if (this.sections.getCurrent(this.origin) == null) {
             // origin outside of world
             this.inBoundsOrigin = null;
         }
@@ -506,7 +506,7 @@ public class OcclusionCuller {
                         continue;
                     }
 
-                    var section = this.getRenderSection(originX + dx, originY + dy, originZ + dz);
+                    var section = this.sections.getCurrent(originX + dx, originY + dy, originZ + dz);
 
                     // additionally render not yet visited but visible sections
                     if (section != null && section.getSearchToken() != this.token && isWithinNearbySectionFrustum(viewport, section)) {
@@ -538,7 +538,7 @@ public class OcclusionCuller {
     }
 
     private void initWithinWorld(WriteQueue<RenderSection> queue) {
-        var originSection = this.getRenderSection(this.origin.getX(), this.origin.getY(), this.origin.getZ());
+        var originSection = this.sections.getCurrent(this.origin);
 
         if (originSection == null) {
             return;
@@ -639,20 +639,12 @@ public class OcclusionCuller {
     }
 
     private void tryInitNode(WriteQueue<RenderSection> queue, int x, int y, int z, int direction) {
-        var section = this.getRenderSection(x, y, z);
+        var section = this.sections.getCurrent(x, y, z);
 
         if (section == null) {
             return;
         }
 
         this.visitNode(queue, section, direction, true, true, true);
-    }
-
-    private RenderSection getRenderSection(int x, int y, int z) {
-        return this.sections.get(SectionPos.asLong(x, y, z));
-    }
-
-    private RenderSection getRenderSection(SectionPos pos) {
-        return this.sections.get(pos.asLong());
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/storage/QueuedSectionStorage.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/storage/QueuedSectionStorage.java
@@ -69,13 +69,15 @@ public class QueuedSectionStorage implements SectionStorage {
     @Override
     public RenderSection queueRemove(long key) {
         if (this.isQueueing) {
-            this.queuedPuts.remove(key);
-            var section = this.sections.get(key);
-            if (section == null) {
-                return null;
+            var present = this.sections.get(key);
+            if (present != null) {
+                this.queuedRemovals.add(key);
             }
-            this.queuedRemovals.add(key);
-            return section;
+            var removedPut = this.queuedPuts.remove(key);
+            if (removedPut != null) {
+                return removedPut;
+            }
+            return present;
         } else {
             return this.sections.remove(key);
         }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/storage/QueuedSectionStorage.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/storage/QueuedSectionStorage.java
@@ -37,6 +37,9 @@ public class QueuedSectionStorage implements SectionStorage {
             if (result == null) {
                 return this.queuedPuts.get(key);
             } else {
+                if (this.queuedRemovals.contains(key)) {
+                    return null;
+                }
                 return result;
             }
         } else {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/storage/QueuedSectionStorage.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/storage/QueuedSectionStorage.java
@@ -50,7 +50,7 @@ public class QueuedSectionStorage implements SectionStorage {
     @Override
     public boolean hasSectionConsistent(long key) {
         if (this.isQueueing) {
-            return this.sections.containsKey(key) || this.queuedPuts.containsKey(key);
+            return this.sections.containsKey(key) && !this.queuedRemovals.contains(key) || this.queuedPuts.containsKey(key);
         } else {
             return this.sections.containsKey(key);
         }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/storage/QueuedSectionStorage.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/storage/QueuedSectionStorage.java
@@ -32,28 +32,25 @@ public class QueuedSectionStorage implements SectionStorage {
 
     @Override
     public RenderSection getConsistent(long key) {
-        if (this.isQueueing) {
-            var result = this.sections.get(key);
-            if (result == null) {
-                return this.queuedPuts.get(key);
-            } else {
-                if (this.queuedRemovals.contains(key)) {
-                    return null;
-                }
-                return result;
-            }
-        } else {
+        if (!this.isQueueing) {
             return this.sections.get(key);
         }
+
+        var queuedPut = this.queuedPuts.get(key);
+        if (queuedPut != null) {
+            return queuedPut;
+        }
+
+        if (this.queuedRemovals.contains(key)) {
+            return null;
+        }
+
+        return this.sections.get(key);
     }
 
     @Override
     public boolean hasSectionConsistent(long key) {
-        if (this.isQueueing) {
-            return this.sections.containsKey(key) && !this.queuedRemovals.contains(key) || this.queuedPuts.containsKey(key);
-        } else {
-            return this.sections.containsKey(key);
-        }
+        return this.getConsistent(key) != null;
     }
 
     @Override

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/storage/QueuedSectionStorage.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/storage/QueuedSectionStorage.java
@@ -1,0 +1,138 @@
+package net.caffeinemc.mods.sodium.client.render.chunk.storage;
+
+import it.unimi.dsi.fastutil.longs.Long2ReferenceMap;
+import it.unimi.dsi.fastutil.longs.Long2ReferenceOpenHashMap;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
+import net.caffeinemc.mods.sodium.client.render.chunk.RenderSection;
+import net.minecraft.core.SectionPos;
+
+public class QueuedSectionStorage implements SectionStorage {
+    private final Long2ReferenceMap<RenderSection> sections = new Long2ReferenceOpenHashMap<>();
+    private final Long2ReferenceMap<RenderSection> queuedPuts = new Long2ReferenceOpenHashMap<>();
+    private final LongSet queuedRemovals = new LongOpenHashSet();
+    private boolean isQueueing = false;
+    private int lastPutQueueSize = 0;
+    private int lastRemoveQueueSize = 0;
+
+    @Override
+    public RenderSection getCurrent(SectionPos pos) {
+        return this.sections.get(pos.asLong());
+    }
+
+    @Override
+    public RenderSection getCurrent(int x, int y, int z) {
+        return this.sections.get(SectionPos.asLong(x, y, z));
+    }
+
+    @Override
+    public RenderSection getCurrent(long key) {
+        return this.sections.get(key);
+    }
+
+    @Override
+    public RenderSection getConsistent(long key) {
+        if (this.isQueueing) {
+            var result = this.sections.get(key);
+            if (result == null) {
+                return this.queuedPuts.get(key);
+            } else {
+                return result;
+            }
+        } else {
+            return this.sections.get(key);
+        }
+    }
+
+    @Override
+    public boolean hasSectionConsistent(long key) {
+        if (this.isQueueing) {
+            return this.sections.containsKey(key) || this.queuedPuts.containsKey(key);
+        } else {
+            return this.sections.containsKey(key);
+        }
+    }
+
+    @Override
+    public void queuePut(long key, RenderSection newSection) {
+        if (this.isQueueing) {
+            this.queuedRemovals.remove(key);
+            this.queuedPuts.put(key, newSection);
+        } else {
+            this.sections.put(key, newSection);
+        }
+    }
+
+    @Override
+    public RenderSection queueRemove(long key) {
+        if (this.isQueueing) {
+            this.queuedPuts.remove(key);
+            var section = this.sections.get(key);
+            if (section == null) {
+                return null;
+            }
+            this.queuedRemovals.add(key);
+            return section;
+        } else {
+            return this.sections.remove(key);
+        }
+    }
+
+    @Override
+    public void deleteAll() {
+        for (var section : this.sections.values()) {
+            section.delete();
+        }
+        for (var section : this.queuedPuts.values()) {
+            section.delete();
+        }
+        this.sections.clear();
+        this.queuedPuts.clear();
+        this.queuedRemovals.clear();
+    }
+
+    @Override
+    public int size() {
+        return this.sections.size();
+    }
+
+    @Override
+    public void startSafeReadPhase() {
+        this.isQueueing = true;
+    }
+
+    @Override
+    public void endSafeReadPhase() {
+        if (this.isQueueing && (!this.queuedPuts.isEmpty() || !this.queuedRemovals.isEmpty())) {
+            this.lastPutQueueSize = this.queuedPuts.size();
+            this.lastRemoveQueueSize = this.queuedRemovals.size();
+
+            // interleave puts and removals to avoid hashmap rehashing if possible
+            var putIterator = this.queuedPuts.long2ReferenceEntrySet().iterator();
+            var removeIterator = this.queuedRemovals.longIterator();
+            var madeChange = true;
+            while (madeChange) {
+                madeChange = false;
+                if (putIterator.hasNext()) {
+                    var entry = putIterator.next();
+                    this.sections.put(entry.getLongKey(), entry.getValue());
+                    madeChange = true;
+                }
+                if (removeIterator.hasNext()) {
+                    this.sections.remove(removeIterator.nextLong());
+                    madeChange = true;
+                }
+            }
+
+            this.queuedPuts.clear();
+            this.queuedRemovals.clear();
+        }
+
+        this.isQueueing = false;
+    }
+
+    @Override
+    public String getDebugInfo() {
+        return String.format("QD: put %03d/del %03d", this.lastPutQueueSize, this.lastRemoveQueueSize);
+    }
+}

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/storage/SectionStorage.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/storage/SectionStorage.java
@@ -1,0 +1,39 @@
+package net.caffeinemc.mods.sodium.client.render.chunk.storage;
+
+import net.caffeinemc.mods.sodium.client.render.chunk.RenderSection;
+import net.minecraft.core.SectionPos;
+
+/**
+ * Controls access to the map of render sections.
+ *
+ * During the safe read phase it is safe to call {@code getCurrent} methods on a thread other than the one that started the phase. Otherwise, only one thread may use this structure at a time, and starting and ending the safe phase is also not allowed concurrently with other operations.
+ */
+public interface SectionStorage {
+    default RenderSection getCurrent(SectionPos pos) {
+        return this.getCurrent(pos.asLong());
+    }
+
+    default RenderSection getCurrent(int x, int y, int z) {
+        return this.getCurrent(SectionPos.asLong(x, y, z));
+    }
+
+    RenderSection getCurrent(long key);
+
+    RenderSection getConsistent(long key);
+
+    boolean hasSectionConsistent(long key);
+
+    void queuePut(long key, RenderSection newSection);
+
+    RenderSection queueRemove(long key);
+
+    void deleteAll();
+
+    int size();
+
+    void startSafeReadPhase();
+
+    void endSafeReadPhase();
+
+    String getDebugInfo();
+}

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/world/cloned/ClonedChunkSectionCache.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/world/cloned/ClonedChunkSectionCache.java
@@ -1,14 +1,14 @@
 package net.caffeinemc.mods.sodium.client.world.cloned;
 
 import it.unimi.dsi.fastutil.longs.Long2ReferenceLinkedOpenHashMap;
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
-
-import java.util.concurrent.TimeUnit;
 import net.minecraft.core.SectionPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.chunk.LevelChunkSection;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.concurrent.TimeUnit;
 
 public class ClonedChunkSectionCache {
     private static final int MAX_CACHE_SIZE = 512; /* number of entries */
@@ -68,8 +68,8 @@ public class ClonedChunkSectionCache {
         return new ClonedChunkSection(this.level, chunk, section, SectionPos.of(x, y, z));
     }
 
-    public void invalidate(int x, int y, int z) {
-        this.positionToEntry.remove(SectionPos.asLong(x, y, z));
+    public void invalidate(long key) {
+        this.positionToEntry.remove(key);
     }
 
     private static long getMonotonicTimeSource() {


### PR DESCRIPTION
I don't think we have a crashlog for this as a github issue, but it's a arrayindexoutofbounds exception within the occlusion culler when it tries to read the section map but it gets modified during the hashmap probing and breaks.