### PR TITLE
Fix TS Crashes Resulting from Unsafe Concurrency

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -557,7 +557,7 @@ public class RenderSectionManager {
                 this.meshTaskSizeEstimator.addData(this.meshTaskSizeEstimator.resultForSection(section, resultSize));
 
                 if (buildOutput.translucentData != null) {
-                    this.sortTriggering.integrateTranslucentData(oldData, buildOutput.translucentData, this.cameraPosition, this::scheduleSort);
+                    this.sortTriggering.integrateTranslucentData(oldData, buildOutput.translucentData, buildOutput.getSorter(), this.cameraPosition, this::scheduleSort);
 
                     // a rebuild always generates new translucent data which means applyTriggerChanges isn't necessary
                     section.setTranslucentData(buildOutput.translucentData);

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderMeshingTask.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderMeshingTask.java
@@ -237,8 +237,8 @@ public class ChunkBuilderMeshingTask extends ChunkBuilderTask<ChunkBuildOutput> 
                 output.markAsNotContainingNewIndexData();
             } else if (translucentData instanceof PresentTranslucentData present) {
                 try {
-                    var sorter = present.getSorter();
-                    sorter.writeIndexBuffer(this, true);
+                    var sorter = present.getSorter(true);
+                    sorter.writeIndexBuffer(this);
                     output.setSorter(sorter);
                 } catch (Exception ex) {
                     // Create a new crash report for exceptions thrown during sorting

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderSortingTask.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderSortingTask.java
@@ -28,7 +28,7 @@ public class ChunkBuilderSortingTask extends ChunkBuilderTask<ChunkSortOutput> {
         ProfilerFiller profiler = Profiler.get();
         profiler.push("translucency sorting");
 
-        this.sorter.writeIndexBuffer(this, false);
+        this.sorter.writeIndexBuffer(this);
 
         profiler.pop();
         return new ChunkSortOutput(this.section, this.submitTime, this.sorter);
@@ -36,7 +36,7 @@ public class ChunkBuilderSortingTask extends ChunkBuilderTask<ChunkSortOutput> {
 
     public static ChunkBuilderSortingTask createTask(RenderSection render, int frame, Vector3dc absoluteCameraPos) {
         if (render.getTranslucentData() instanceof DynamicData dynamicData) {
-            return new ChunkBuilderSortingTask(render, frame, absoluteCameraPos, dynamicData.getSorter());
+            return new ChunkBuilderSortingTask(render, frame, absoluteCameraPos, dynamicData.getSorter(false));
         }
         return null;
     }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/AnyOrderData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/AnyOrderData.java
@@ -32,7 +32,7 @@ public class AnyOrderData extends PresentTranslucentData {
     }
 
     @Override
-    public Sorter getSorter() {
+    public Sorter getSorter(boolean initial) {
         var sorter = this.sorterOnce;
         if (sorter == null) {
             throw new IllegalStateException("Sorter already used!");

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicBSPData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicBSPData.java
@@ -45,7 +45,7 @@ public class DynamicBSPData extends DynamicData {
         }
 
         @Override
-        void writeSort(CombinedCameraPos cameraPos, boolean initial) {
+        void writeSort(CombinedCameraPos cameraPos) {
             DynamicBSPData.this.rootNode.collectSortedQuads(this.getIndexBuffer(), cameraPos.getRelativeCameraPos());
         }
     }
@@ -62,7 +62,7 @@ public class DynamicBSPData extends DynamicData {
     }
 
     @Override
-    public DynamicSorter getSorter() {
+    public DynamicSorter getSorter(boolean initial) {
         // release references to the modified quad list,
         // since we sort during the meshing task for the first time (in particular, when there was a non-null updated quad list)
         this.updatedQuadsList = null;

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicBSPData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicBSPData.java
@@ -41,7 +41,7 @@ public class DynamicBSPData extends DynamicData {
 
     private class DynamicBSPSorter extends DynamicSorter {
         private DynamicBSPSorter(int quadCount) {
-            super(quadCount, DynamicBSPData.this);
+            super(quadCount, DynamicBSPData.this, DynamicBSPData.this.geometryPlanes);
         }
 
         @Override

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicData.java
@@ -20,7 +20,7 @@ public abstract class DynamicData extends PresentTranslucentData {
         return SortType.DYNAMIC;
     }
 
-    public abstract DynamicSorter getSorter();
+    public abstract DynamicSorter getSorter(boolean initial);
 
     public GeometryPlanes getGeometryPlanes() {
         return this.geometryPlanes;

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicData.java
@@ -6,7 +6,7 @@ import net.minecraft.core.SectionPos;
 import org.joml.Vector3dc;
 
 public abstract class DynamicData extends PresentTranslucentData {
-    private GeometryPlanes geometryPlanes;
+    protected GeometryPlanes geometryPlanes;
     private final Vector3dc initialCameraPos;
 
     DynamicData(SectionPos sectionPos, int inputQuadCount, GeometryPlanes geometryPlanes, Vector3dc initialCameraPos) {
@@ -20,13 +20,10 @@ public abstract class DynamicData extends PresentTranslucentData {
         return SortType.DYNAMIC;
     }
 
+    @Override
     public abstract DynamicSorter getSorter(boolean initial);
 
-    public GeometryPlanes getGeometryPlanes() {
-        return this.geometryPlanes;
-    }
-
-    public void discardGeometryPlanes() {
+    public void discardGeometryPlanesAfterIntegration() {
         this.geometryPlanes = null;
     }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicSorter.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicSorter.java
@@ -1,15 +1,23 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data;
 
+import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.trigger.GeometryPlanes;
+
 public abstract class DynamicSorter extends PresentSorter {
     private final int quadCount;
     protected final TranslucentData sourceData;
+    private final GeometryPlanes geometryPlanes;
 
-    DynamicSorter(int quadCount, TranslucentData sourceData) {
+    DynamicSorter(int quadCount, DynamicData sourceData, GeometryPlanes geometryPlanes) {
         this.quadCount = quadCount;
         this.sourceData = sourceData;
+        this.geometryPlanes = geometryPlanes;
     }
 
     abstract void writeSort(CombinedCameraPos cameraPos);
+
+    public GeometryPlanes getGeometryPlanes() {
+        return this.geometryPlanes;
+    }
 
     @Override
     public void writeIndexBuffer(CombinedCameraPos cameraPos) {
@@ -20,7 +28,7 @@ public abstract class DynamicSorter extends PresentSorter {
     public int getQuadCount() {
         return this.quadCount;
     }
-    
+
     public int getResultSize() {
         return TranslucentData.quadCountToIndexBytes(this.quadCount);
     }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicSorter.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicSorter.java
@@ -9,12 +9,12 @@ public abstract class DynamicSorter extends PresentSorter {
         this.sourceData = sourceData;
     }
 
-    abstract void writeSort(CombinedCameraPos cameraPos, boolean initial);
+    abstract void writeSort(CombinedCameraPos cameraPos);
 
     @Override
-    public void writeIndexBuffer(CombinedCameraPos cameraPos, boolean initial) {
+    public void writeIndexBuffer(CombinedCameraPos cameraPos) {
         this.initBufferWithQuadLength(this.quadCount);
-        this.writeSort(cameraPos, initial);
+        this.writeSort(cameraPos);
     }
 
     public int getQuadCount() {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicTopoData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicTopoData.java
@@ -73,8 +73,8 @@ public class DynamicTopoData extends DynamicData {
     }
 
     @Override
-    public DynamicSorter getSorter() {
-        return new DynamicTopoSorter(this.getInputQuadCount(), this.pendingTriggerIsDirect, this.consecutiveTopoSortFailures, this.GFNITrigger, this.directTrigger);
+    public DynamicSorter getSorter(boolean initial) {
+        return new DynamicTopoSorter(this.getInputQuadCount(), this.pendingTriggerIsDirect, initial, this.consecutiveTopoSortFailures, this.GFNITrigger, this.directTrigger, this.quads, this.centroids, this.distancesByNormal);
     }
 
     public boolean GFNITriggerEnabled() {
@@ -96,7 +96,12 @@ public class DynamicTopoData extends DynamicData {
     public boolean checkAndApplyGFNITriggerOff(DynamicTopoSorter sorter) {
         if (this.GFNITrigger && !sorter.GFNITrigger) {
             this.GFNITrigger = false;
-            this.checkDirectSortingFallback();
+
+            // once the GFNI trigger is turned off, the topo sort data is never used again, so it can be freed to save memory.
+            this.computeCentroids(this.quads);
+            this.quads = null;
+            this.distancesByNormal = null;
+
             return true;
         }
         return false;
@@ -126,24 +131,6 @@ public class DynamicTopoData extends DynamicData {
         }
     }
 
-    private void copyStateFrom(DynamicTopoSorter sorter) {
-        this.GFNITrigger = sorter.GFNITrigger;
-        this.directTrigger = sorter.directTrigger;
-        this.consecutiveTopoSortFailures = sorter.consecutiveTopoSortFailuresNew;
-
-        this.checkDirectSortingFallback();
-    }
-
-    private void checkDirectSortingFallback() {
-        // once the GFNI trigger is turned off, the topo sort data is never used again, so it can be freed to save memory.
-        if (!this.GFNITrigger && this.quads != null) {
-            this.computeCentroids(this.quads);
-
-            this.quads = null;
-            this.distancesByNormal = null;
-        }
-    }
-
     @Override
     public void prepareTrigger(boolean isDirectTrigger) {
         this.pendingTriggerIsDirect = isDirectTrigger;
@@ -151,6 +138,7 @@ public class DynamicTopoData extends DynamicData {
 
     public class DynamicTopoSorter extends DynamicSorter implements IntConsumer {
         private final boolean isDirectTrigger;
+        private final boolean initial;
         private final int consecutiveTopoSortFailures;
 
         private boolean directTrigger;
@@ -159,13 +147,22 @@ public class DynamicTopoData extends DynamicData {
 
         private IntBuffer intBuffer;
 
-        private DynamicTopoSorter(int quadCount, boolean isDirectTrigger, int consecutiveTopoSortFailures, boolean GFNITrigger, boolean directTrigger) {
+        private final TQuad[] quads;
+        private final Vector3fc[] centroids;
+        private final Object2ReferenceMap<Vector3fc, float[]> distancesByNormal;
+
+        private DynamicTopoSorter(int quadCount, boolean isDirectTrigger, boolean initial, int consecutiveTopoSortFailures, boolean GFNITrigger, boolean directTrigger, TQuad[] quads, Vector3fc[] centroids, Object2ReferenceMap<Vector3fc, float[]> distancesByNormal) {
             super(quadCount, DynamicTopoData.this);
             this.isDirectTrigger = isDirectTrigger;
+            this.initial = initial;
             this.consecutiveTopoSortFailures = consecutiveTopoSortFailures;
             this.consecutiveTopoSortFailuresNew = consecutiveTopoSortFailures;
             this.GFNITrigger = GFNITrigger;
             this.directTrigger = directTrigger;
+
+            this.quads = quads;
+            this.centroids = centroids;
+            this.distancesByNormal = distancesByNormal;
         }
 
         private static int getAttemptsForTime(long ns) {
@@ -186,23 +183,23 @@ public class DynamicTopoData extends DynamicData {
         }
 
         @Override
-        void writeSort(CombinedCameraPos cameraPos, boolean initial) {
+        void writeSort(CombinedCameraPos cameraPos) {
             // uses a topo sort or a distance sort depending on what is enabled
             IntBuffer indexBuffer = this.getIntBuffer();
 
             if (this.GFNITrigger && !this.isDirectTrigger) {
                 this.intBuffer = indexBuffer;
-                var sortStart = initial ? 0 : System.nanoTime();
-                var result = TopoGraphSorting.topoGraphSort(this, DynamicTopoData.this.quads, DynamicTopoData.this.distancesByNormal, cameraPos.getRelativeCameraPos(), false);
+                var sortStart = this.initial ? 0 : System.nanoTime();
+                var result = TopoGraphSorting.topoGraphSort(this, this.quads, this.distancesByNormal, cameraPos.getRelativeCameraPos(), false);
                 this.intBuffer = null;
 
-                var sortTime = initial ? 0 : System.nanoTime() - sortStart;
+                var sortTime = this.initial ? 0 : System.nanoTime() - sortStart;
 
                 // if we've already failed, there's reduced patience for sorting since the
                 // probability of failure and wasted compute time is higher. Initial sorting is
-                // often very slow when the cpu is loaded and the JIT isn't ready yet, so it's
+                // often very slow when the cpu is loaded, and the JIT isn't ready yet, so it's
                 // ignored here.
-                if (!initial && sortTime > (this.consecutiveTopoSortFailuresNew > 0
+                if (!this.initial && sortTime > (this.consecutiveTopoSortFailuresNew > 0
                         ? MAX_FAILING_TOPO_SORT_TIME_NS
                         : MAX_TOPO_SORT_TIME_NS)) {
                     this.directTrigger = true;
@@ -227,11 +224,7 @@ public class DynamicTopoData extends DynamicData {
 
             if (this.directTrigger) {
                 indexBuffer.rewind();
-                distanceSortDirect(indexBuffer, DynamicTopoData.this.centroids, DynamicTopoData.this.quads, cameraPos.getRelativeCameraPos());
-            }
-
-            if (initial) {
-                DynamicTopoData.this.copyStateFrom(this);
+                distanceSortDirect(indexBuffer, this.centroids, this.quads, cameraPos.getRelativeCameraPos());
             }
         }
     }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicTopoData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/DynamicTopoData.java
@@ -152,7 +152,7 @@ public class DynamicTopoData extends DynamicData {
         private final Object2ReferenceMap<Vector3fc, float[]> distancesByNormal;
 
         private DynamicTopoSorter(int quadCount, boolean isDirectTrigger, boolean initial, int consecutiveTopoSortFailures, boolean GFNITrigger, boolean directTrigger, TQuad[] quads, Vector3fc[] centroids, Object2ReferenceMap<Vector3fc, float[]> distancesByNormal) {
-            super(quadCount, DynamicTopoData.this);
+            super(quadCount, DynamicTopoData.this, DynamicTopoData.this.geometryPlanes);
             this.isDirectTrigger = isDirectTrigger;
             this.initial = initial;
             this.consecutiveTopoSortFailures = consecutiveTopoSortFailures;

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/PresentTranslucentData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/PresentTranslucentData.java
@@ -1,8 +1,8 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data;
 
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.SortType;
-import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.quad.TQuad;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.TranslucentGeometryCollector;
+import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.quad.TQuad;
 import net.minecraft.core.SectionPos;
 
 /**
@@ -17,7 +17,7 @@ public abstract class PresentTranslucentData extends TranslucentData {
         this.inputQuadCount = inputQuadCount;
     }
 
-    public abstract Sorter getSorter();
+    public abstract Sorter getSorter(boolean initial);
 
     @Override
     public boolean oldDataMatches(TranslucentGeometryCollector collector, SortType sortType, TQuad[] quads) {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/SharedIndexSorter.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/SharedIndexSorter.java
@@ -16,7 +16,7 @@ public record SharedIndexSorter(int quadCount) implements Sorter {
     }
 
     @Override
-    public void writeIndexBuffer(CombinedCameraPos cameraPos, boolean initial) {
+    public void writeIndexBuffer(CombinedCameraPos cameraPos) {
         // no-op
     }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/Sorter.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/Sorter.java
@@ -1,7 +1,7 @@
 package net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data;
 
 public interface Sorter extends PresentSortData {
-    void writeIndexBuffer(CombinedCameraPos cameraPos, boolean initial);
+    void writeIndexBuffer(CombinedCameraPos cameraPos);
 
     void destroy();
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/StaticNormalRelativeData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/StaticNormalRelativeData.java
@@ -26,7 +26,7 @@ public class StaticNormalRelativeData extends PresentTranslucentData {
     }
 
     @Override
-    public Sorter getSorter() {
+    public Sorter getSorter(boolean initial) {
         var sorter = this.sorterOnce;
         if (sorter == null) {
             throw new IllegalStateException("Sorter already used!");

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/StaticSorter.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/StaticSorter.java
@@ -6,7 +6,7 @@ class StaticSorter extends PresentSorter {
     }
 
     @Override
-    public void writeIndexBuffer(CombinedCameraPos cameraPos, boolean initial) {
+    public void writeIndexBuffer(CombinedCameraPos cameraPos) {
         // no-op
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/StaticTopoData.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/StaticTopoData.java
@@ -25,7 +25,7 @@ public class StaticTopoData extends PresentTranslucentData {
     }
 
     @Override
-    public Sorter getSorter() {
+    public Sorter getSorter(boolean initial) {
         var sorter = this.sorterOnce;
         if (sorter == null) {
             throw new IllegalStateException("Sorter already used!");

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/TopoGraphSorting.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/data/TopoGraphSorting.java
@@ -258,6 +258,10 @@ public class TopoGraphSorting {
             IntConsumer indexConsumer, TQuad[] allQuads,
             Object2ReferenceMap<Vector3fc, float[]> distancesByNormal,
             Vector3fc cameraPos, boolean failOnIntersection) {
+        if (allQuads == null) {
+            var debug = true;
+        }
+
         // if enabled, check for visibility and produce a mapping of indices
         TQuad[] quads;
         int[] activeToRealIndex = null;

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/trigger/DirectTriggers.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/trigger/DirectTriggers.java
@@ -211,7 +211,6 @@ class DirectTriggers implements SectionTriggers<DynamicTopoData> {
         }
     }
 
-    @Override
     public void integrateSection(SortTriggering ts, SectionPos sectionPos, DynamicTopoData data,
             CameraMovement movement) {
         // create data with last camera position

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/trigger/GFNITriggers.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/trigger/GFNITriggers.java
@@ -59,10 +59,8 @@ class GFNITriggers implements SectionTriggers<DynamicData> {
         this.normalLists.values().removeIf(normalList -> this.removeSectionFromList(normalList, sectionPos));
     }
 
-    @Override
-    public void integrateSection(SortTriggering ts, SectionPos pos, DynamicData data, CameraMovement movement) {
-        long sectionPos = pos.asLong();
-        var geometryPlanes = data.getGeometryPlanes();
+    public void integrateSection(SortTriggering ts, SectionPos pos, GeometryPlanes geometryPlanes, CameraMovement movement) {
+        var sectionPos = pos.asLong();
 
         // go through all normal lists and check against the normals that the group
         // builder has. if the normal list has data for the section, but the group
@@ -104,8 +102,6 @@ class GFNITriggers implements SectionTriggers<DynamicData> {
                 this.addSectionInNewNormalLists(normalPlane);
             }
         }
-
-        data.discardGeometryPlanes();
 
         // check if catchup trigger is necessary
         if (movement.hasChanged()) {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/trigger/SortTriggering.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/trigger/SortTriggering.java
@@ -4,9 +4,7 @@ import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.caffeinemc.mods.sodium.client.SodiumClientMod;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.SortBehavior;
 import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.SortType;
-import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data.DynamicData;
-import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data.DynamicTopoData;
-import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data.TranslucentData;
+import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.data.*;
 import net.minecraft.core.SectionPos;
 import org.joml.Vector3dc;
 import org.joml.Vector3fc;
@@ -21,7 +19,7 @@ import java.util.function.BiConsumer;
  * <p>
  * TODO:
  * - investigate why there's a similar number of STA and DYN sections. This might be normal, the counters might be broken or the heuristic is actually wrong.
- * 
+ *
  * @author douira (the translucent_sorting package)
  */
 public class SortTriggering {
@@ -63,13 +61,11 @@ public class SortTriggering {
         void processTriggers(SortTriggering ts, CameraMovement movement);
 
         void removeSection(long sectionPos, TranslucentData data);
-
-        void integrateSection(SortTriggering ts, SectionPos sectionPos, T data, CameraMovement movement);
     }
 
     /**
      * Triggers the sections that the given camera movement crosses face planes of.
-     * 
+     *
      * @param triggerSectionCallback called for each section that is triggered
      * @param movement               the camera movement to trigger for
      */
@@ -165,7 +161,7 @@ public class SortTriggering {
     /**
      * Removes a section from direct and GFNI triggering. This removes all its face
      * planes.
-     * 
+     *
      * @param oldData    the data of the section to remove
      * @param sectionPos the section to remove
      */
@@ -179,12 +175,9 @@ public class SortTriggering {
     }
 
     /**
-     * Integrates the data from a geometry collector into GFNI. The geometry
-     * collector contains the translucent face planes of a single section. This
-     * method may also remove the section if it has become irrelevant.
+     * Integrates the data from a geometry collector into GFNI or direct triggering.
      */
-    public void integrateTranslucentData(TranslucentData oldData, TranslucentData newData, Vector3dc cameraPos,
-                                         BiConsumer<Long, Boolean> triggerSectionCallback) {
+    public void integrateTranslucentData(TranslucentData oldData, TranslucentData newData, Sorter sorter, Vector3dc cameraPos, BiConsumer<Long, Boolean> triggerSectionCallback) {
         if (oldData == newData) {
             return;
         }
@@ -200,20 +193,22 @@ public class SortTriggering {
             this.catchupData = dynamicData;
             var movement = new CameraMovement(dynamicData.getInitialCameraPos(), cameraPos);
 
+            // retrieve the geometry planes for integrating this section from the sorter that was used.
+            /* This ensures that even if we delete the geometry planes from the data itself, any sorters that still have reference to it are able to re-integrate the dynamic TS data. The scenario is that when there are two racing meshing tasks, of which the second one can reuse the original data but the first one makes new data. The first one makes it so the old and new data are different, and then the second one re-uses the previous old data, which is still available because they were dispatched at the same time and before the first task was completed to update the TS data on the RS. This means that the old and new data are different, so that integration is necessary, but the new data was already integrated two results ago. The solution is that we store the geometry planes necessary for integration on the sorter, since it can hold a reference to them even if they get cleared from the TS data after it's been integrated.*/
+            var geometryPlanes = ((DynamicSorter) sorter).getGeometryPlanes();
+
             if (dynamicData instanceof DynamicTopoData topoSortData) {
                 if (topoSortData.GFNITriggerEnabled()) {
-                    this.gfni.integrateSection(this, pos, topoSortData, movement);
-                } else {
-                    // remove the trigger data since this section is never going to get gfni
-                    // triggering (there's no option to add sections to GFNI later currently)
-                    topoSortData.discardGeometryPlanes();
+                    this.gfni.integrateSection(this, pos, geometryPlanes, movement);
                 }
                 if (topoSortData.directTriggerEnabled()) {
                     this.direct.integrateSection(this, pos, topoSortData, movement);
                 }
             } else {
-                this.gfni.integrateSection(this, pos, dynamicData, movement);
+                this.gfni.integrateSection(this, pos, geometryPlanes, movement);
             }
+
+            dynamicData.discardGeometryPlanesAfterIntegration();
 
             this.triggerSectionCallback = null;
             this.catchupData = null;


### PR DESCRIPTION
Fix crashes resulting from unsafe concurrency handling when multiple sorting tasks run for the same translucent topo data

Fixes #3748
Fixes #3742

Also fixes https://github.com/CaffeineMC/sodium/issues/3737 now.