### PR TITLE
Fence Sodium terrain globals per render submit

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -310,6 +310,12 @@ public class SodiumWorldRenderer {
         this.initRenderer();
     }
 
+    public void endFrame() {
+        if (this.uniformBufferManager != null) {
+            this.uniformBufferManager.endFrame();
+        }
+    }
+
     private void initRenderer() {
         this.deleteRendererState();
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/ChunkRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/ChunkRenderer.java
@@ -1,6 +1,7 @@
 package net.caffeinemc.mods.sodium.client.render.chunk;
 
 import com.mojang.blaze3d.buffers.GpuBuffer;
+import com.mojang.blaze3d.buffers.GpuBufferSlice;
 import com.mojang.blaze3d.textures.GpuSampler;
 import net.caffeinemc.mods.sodium.client.render.chunk.lists.ChunkRenderListIterable;
 import net.caffeinemc.mods.sodium.client.render.chunk.terrain.TerrainRenderPass;
@@ -22,10 +23,10 @@ public interface ChunkRenderer {
      * @param parameters              The current fog state
      * @param indexedRenderingEnabled Whether indexed rendering is enabled
      * @param terrainSampler          The sampler to use for the atlas
-     * @param uniformData             The buffer containing the uniform data for this frame
+     * @param uniformData             The buffer slice containing the uniform data for this frame
      * @param sectionTimeInfo         The storage buffer containing fade timings
      */
-    void render(ChunkRenderMatrices matrices, ChunkRenderListIterable renderLists, TerrainRenderPass pass, CameraTransform camera, FogParameters parameters, boolean indexedRenderingEnabled, GpuSampler terrainSampler, GpuBuffer uniformData, GpuBuffer sectionTimeInfo);
+    void render(ChunkRenderMatrices matrices, ChunkRenderListIterable renderLists, TerrainRenderPass pass, CameraTransform camera, FogParameters parameters, boolean indexedRenderingEnabled, GpuSampler terrainSampler, GpuBufferSlice uniformData, GpuBuffer sectionTimeInfo);
 
     /**
      * Rotates the data for a new frame.

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/DefaultChunkRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/DefaultChunkRenderer.java
@@ -63,7 +63,7 @@ public class DefaultChunkRenderer extends ShaderChunkRenderer {
                        CameraTransform camera,
                        FogParameters parameters,
                        boolean indexedRenderingEnabled,
-                       GpuSampler terrainSampler, GpuBuffer uniformData, GpuBuffer sectionTimeInfo) {
+                       GpuSampler terrainSampler, GpuBufferSlice uniformData, GpuBuffer sectionTimeInfo) {
         super.begin(renderPass, parameters, terrainSampler);
 
         final boolean useBlockFaceCulling = SodiumClientMod.options().performance.useBlockFaceCulling;

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/UniformBufferManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/UniformBufferManager.java
@@ -12,16 +12,21 @@ import net.caffeinemc.mods.sodium.mixin.core.render.texture.TextureAtlasAccessor
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.TextureFilteringMethod;
 import net.minecraft.client.multiplayer.ClientLevel;
-import net.minecraft.client.renderer.MappableRingBuffer;
+import net.minecraft.client.renderer.DynamicUniformStorage;
 import net.minecraft.client.renderer.texture.TextureAtlas;
 import org.joml.Matrix4f;
+import org.jspecify.annotations.NonNull;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.system.MemoryUtil;
 
 import java.nio.ByteBuffer;
 
 public class UniformBufferManager {
-    private final MappableRingBuffer uniformData;
+    private static final int GLOBAL_UNIFORM_SIZE = 256;
+    private static final int INITIAL_GLOBAL_UNIFORM_CAPACITY = 8;
+
+    private final DynamicUniformStorage<GlobalUniforms> uniformStorage;
+    private GpuBufferSlice uniformData;
 
     private final GpuBuffer sectionTimeInfo;
     private final GpuBufferSlice.MappedView sectionTimeInfoMap;
@@ -37,7 +42,7 @@ public class UniformBufferManager {
 
         int maxRegions = regionsX * regionsY * regionsX * 2;
 
-        this.uniformData = new MappableRingBuffer(() -> "Sodium uniform buffer", GpuBuffer.USAGE_UNIFORM | GpuBuffer.USAGE_MAP_WRITE, 256);
+        this.uniformStorage = new DynamicUniformStorage<>("Sodium terrain uniforms", GLOBAL_UNIFORM_SIZE, INITIAL_GLOBAL_UNIFORM_CAPACITY);
 
         this.sectionTimeInfo = RenderSystem.getDevice().createBuffer(() -> "Section time info", GpuBuffer.USAGE_UNIFORM_TEXEL_BUFFER | GpuBuffer.USAGE_COPY_DST | GpuBuffer.USAGE_MAP_WRITE,
                 (long) maxRegions * 256L * Integer.BYTES);
@@ -52,13 +57,16 @@ public class UniformBufferManager {
         this.hasUpdatedThisFrame = false;
     }
 
+    public void endFrame() {
+        this.uniformStorage.endFrame();
+        this.uniformData = null;
+    }
+
     public void update(ChunkRenderMatrices matrices, FogParameters fogParameters) {
         if (this.hasUpdatedThisFrame) {
             return;
         }
         this.hasUpdatedThisFrame = true;
-
-        this.uniformData.rotate();
 
         double subTexelPrecision = (1 << GPULimits.getSubTexelPrecisionBits());
         double subTexelOffset = 1.0f / CompactChunkVertex.TEXTURE_MAX_VALUE;
@@ -67,23 +75,26 @@ public class UniformBufferManager {
                 .getTextureManager()
                 .getTexture(TextureAtlas.LOCATION_BLOCKS);
 
-        try (var data = this.uniformData.currentBuffer().map(false, true)) {
-            Std140Builder.intoBuffer(data.data())
-                    .putMat4f(new Matrix4f(matrices.projection()))
-                    .putMat4f(new Matrix4f(matrices.modelView()))
-                    .putVec4(fogParameters.red(), fogParameters.green(), fogParameters.blue(), fogParameters.alpha())
-                    .putVec2(fogParameters.environmentalStart(), fogParameters.environmentalEnd())
-                    .putVec2(fogParameters.renderStart(), fogParameters.renderEnd())
-                    .putVec2(1.0f / textureAtlas.sodium$getWidth(), 1.0f / textureAtlas.sodium$getHeight())
-                    .putVec2((float) (subTexelOffset - (((1.0D / textureAtlas.sodium$getWidth()) / subTexelPrecision))),
-                            (float) (subTexelOffset - (((1.0D / textureAtlas.sodium$getHeight()) / subTexelPrecision))))
-                    .putFloat((float) (1.0 / (Minecraft.getInstance().options.chunkSectionFadeInTime().get() * 1000.0)))
-                    .putInt(Minecraft.getInstance().options.textureFiltering().get() == TextureFilteringMethod.RGSS ? 1 : 0).get();
-        }
+        this.uniformData = this.uniformStorage.writeUniform(new GlobalUniforms(
+                new Matrix4f(matrices.projection()),
+                new Matrix4f(matrices.modelView()),
+                fogParameters.red(), fogParameters.green(), fogParameters.blue(), fogParameters.alpha(),
+                fogParameters.environmentalStart(), fogParameters.environmentalEnd(),
+                fogParameters.renderStart(), fogParameters.renderEnd(),
+                1.0f / textureAtlas.sodium$getWidth(), 1.0f / textureAtlas.sodium$getHeight(),
+                (float) (subTexelOffset - (((1.0D / textureAtlas.sodium$getWidth()) / subTexelPrecision))),
+                (float) (subTexelOffset - (((1.0D / textureAtlas.sodium$getHeight()) / subTexelPrecision))),
+                (float) (1.0 / (Minecraft.getInstance().options.chunkSectionFadeInTime().get() * 1000.0)),
+                Minecraft.getInstance().options.textureFiltering().get() == TextureFilteringMethod.RGSS ? 1 : 0
+        ));
     }
 
-    public GpuBuffer getUniformBuffer() {
-        return this.uniformData.currentBuffer();
+    public GpuBufferSlice getUniformBuffer() {
+        if (this.uniformData == null) {
+            throw new IllegalStateException("Global terrain uniforms have not been updated");
+        }
+
+        return this.uniformData;
     }
 
     public GpuBuffer getSectionTimeInfo() {
@@ -109,6 +120,40 @@ public class UniformBufferManager {
             this.sectionTimeInfoMap.close();
         }
         this.sectionTimeInfo.close();
-        this.uniformData.close();
+        this.uniformStorage.close();
+    }
+
+    private record GlobalUniforms(
+            Matrix4f projection,
+            Matrix4f modelView,
+            float fogRed,
+            float fogGreen,
+            float fogBlue,
+            float fogAlpha,
+            float environmentalFogStart,
+            float environmentalFogEnd,
+            float renderFogStart,
+            float renderFogEnd,
+            float textureAtlasWidthInverse,
+            float textureAtlasHeightInverse,
+            float subTexelOffsetX,
+            float subTexelOffsetY,
+            float fadeInFactor,
+            int useRgbaTextureFiltering
+    ) implements DynamicUniformStorage.DynamicUniform {
+        @Override
+        public void write(@NonNull ByteBuffer byteBuffer) {
+            Std140Builder.intoBuffer(byteBuffer)
+                    .putMat4f(this.projection)
+                    .putMat4f(this.modelView)
+                    .putVec4(this.fogRed, this.fogGreen, this.fogBlue, this.fogAlpha)
+                    .putVec2(this.environmentalFogStart, this.environmentalFogEnd)
+                    .putVec2(this.renderFogStart, this.renderFogEnd)
+                    .putVec2(this.textureAtlasWidthInverse, this.textureAtlasHeightInverse)
+                    .putVec2(this.subTexelOffsetX, this.subTexelOffsetY)
+                    .putFloat(this.fadeInFactor)
+                    .putInt(this.useRgbaTextureFiltering)
+                    .get();
+        }
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/core/render/world/LevelRendererMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/core/render/world/LevelRendererMixin.java
@@ -119,6 +119,11 @@ public abstract class LevelRendererMixin implements LevelRendererExtension {
         this.renderer.scheduleTerrainUpdate();
     }
 
+    @Inject(method = "endFrame", at = @At("RETURN"))
+    private void sodium$endFrame(CallbackInfo ci) {
+        this.renderer.endFrame();
+    }
+
     /**
      * @reason Redirect to our renderer
      * @author IMS


### PR DESCRIPTION
Use `DynamicUniformStorage` for Sodium terrain globals so each terrain render
writes a fresh uniform slice instead of rotating the shared ring buffer before
the current submit has completed.

Sodium's 3-slot `MappableRingBuffer` could be rotated during terrain setup before
the panorama screenshot render submitted, causing the queued render to use an
invalid/stale UBO and hit: `Cannot wait on a fence for the current submit`

Rotate the dynamic uniform storage at `LevelRenderer.endFrame()` after the real
submit instead.

Fixes #3747