### PR TITLE
Reduce unwanted visibility checks for immediate chunk presentation in RenderSectionManager

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -483,6 +483,7 @@ public class RenderSectionManager {
             return;
         }
 
+        // processing build results can cause invalidation of the render lists or change the connectivity of the graph. They don't necessarily imply each other, so they're tracked separately.
         int changes = this.processChunkBuildResults(results, viewport, uniforms);
         if ((changes & SectionInfoChange.GRAPH) != 0) {
             this.markGraphDirty();

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -483,7 +483,6 @@ public class RenderSectionManager {
             return;
         }
 
-        // processing build results can cause invalidation of the render lists or change the connectivity of the graph. They don't necessarily imply each other, so they're tracked separately.
         int changes = this.processChunkBuildResults(results, viewport, uniforms);
         if ((changes & SectionInfoChange.GRAPH) != 0) {
             this.markGraphDirty();
@@ -498,15 +497,26 @@ public class RenderSectionManager {
     }
 
     private boolean isSectionFrustumVisible(Viewport viewport, RenderSection section) {
-        // unloaded sections are considered visible as to not be an impossible requirement for immediate presentation
-        return section == null || this.renderTree == null || this.renderTree.isSectionVisible(viewport, section);
+        return section == null || this.renderTree.isSectionVisible(viewport, section);
     }
 
     private boolean isSectionImmediatePresentationCandidate(Viewport viewport, RenderSection section) {
         if (this.cameraPosition == null) {
             return false;
         }
-        var distanceSquared = section.getSquaredDistance(
+
+        if (this.renderTree == null) {
+            return true;
+        }
+
+        int camChunkX = (int) this.cameraPosition.x() >> 4;
+        int camChunkZ = (int) this.cameraPosition.z() >> 4;
+
+        if (Math.abs(section.getChunkX() - camChunkX) > 5 || Math.abs(section.getChunkZ() - camChunkZ) > 5) {
+            return false;
+        }
+
+        double distanceSquared = section.getSquaredDistance(
                 (float) this.cameraPosition.x(),
                 (float) this.cameraPosition.y(),
                 (float) this.cameraPosition.z()
@@ -517,7 +527,6 @@ public class RenderSectionManager {
         }
 
         return distanceSquared < IMMEDIATE_PRESENT_DISTANCE &&
-                // check that visible or adjacent to a visible section
                 (this.isSectionFrustumVisible(viewport, section)
                         || this.isSectionFrustumVisible(viewport, section.adjacentDown)
                         || this.isSectionFrustumVisible(viewport, section.adjacentUp)
@@ -526,6 +535,8 @@ public class RenderSectionManager {
                         || this.isSectionFrustumVisible(viewport, section.adjacentWest)
                         || this.isSectionFrustumVisible(viewport, section.adjacentEast));
     }
+
+
 
     private int processChunkBuildResults(ArrayList<BuilderTaskOutput> results, Viewport viewport, UniformBufferManager uniforms) {
         var sectionsWithOutputs = applyBuildOutputs(results);

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -36,10 +36,8 @@ import net.caffeinemc.mods.sodium.client.world.LevelSlice;
 import net.caffeinemc.mods.sodium.client.world.cloned.ChunkRenderContext;
 import net.caffeinemc.mods.sodium.client.world.cloned.ClonedChunkSectionCache;
 import net.minecraft.client.Camera;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
-import net.minecraft.core.BlockPos;
 import net.minecraft.core.SectionPos;
 import net.minecraft.util.Mth;
 import net.minecraft.world.level.chunk.ChunkAccess;
@@ -497,10 +495,6 @@ public class RenderSectionManager {
         }
     }
 
-    private boolean isSectionFrustumVisible(Viewport viewport, RenderSection section) {
-        return section == null || this.renderTree.isSectionVisible(viewport, section);
-    }
-
     private boolean isSectionImmediatePresentationCandidate(Viewport viewport, RenderSection section) {
         if (this.cameraPosition == null) {
             return false;
@@ -510,14 +504,7 @@ public class RenderSectionManager {
             return true;
         }
 
-        int camChunkX = (int) this.cameraPosition.x() >> 4;
-        int camChunkZ = (int) this.cameraPosition.z() >> 4;
-
-        if (Math.abs(section.getChunkX() - camChunkX) > 5 || Math.abs(section.getChunkZ() - camChunkZ) > 5) {
-            return false;
-        }
-
-        double distanceSquared = section.getSquaredDistance(
+        var distanceSquared = section.getSquaredDistance(
                 (float) this.cameraPosition.x(),
                 (float) this.cameraPosition.y(),
                 (float) this.cameraPosition.z()
@@ -526,18 +513,20 @@ public class RenderSectionManager {
         if (distanceSquared < NEARBY_REBUILD_DISTANCE) {
             return true;
         }
+        if (distanceSquared >= IMMEDIATE_PRESENT_DISTANCE) {
+            return false;
+        }
 
-        return distanceSquared < IMMEDIATE_PRESENT_DISTANCE &&
-                (this.isSectionFrustumVisible(viewport, section)
-                        || this.isSectionFrustumVisible(viewport, section.adjacentDown)
-                        || this.isSectionFrustumVisible(viewport, section.adjacentUp)
-                        || this.isSectionFrustumVisible(viewport, section.adjacentNorth)
-                        || this.isSectionFrustumVisible(viewport, section.adjacentSouth)
-                        || this.isSectionFrustumVisible(viewport, section.adjacentWest)
-                        || this.isSectionFrustumVisible(viewport, section.adjacentEast));
+        // unloaded sections are considered visible as to not be an impossible requirement for immediate presentation
+        return (section.getAdjacentMask() != GraphDirectionSet.ALL ||
+                this.renderTree.isSectionVisible(viewport, section) ||
+                this.renderTree.isSectionVisible(viewport, section.adjacentDown) ||
+                this.renderTree.isSectionVisible(viewport, section.adjacentUp) ||
+                this.renderTree.isSectionVisible(viewport, section.adjacentNorth) ||
+                this.renderTree.isSectionVisible(viewport, section.adjacentSouth) ||
+                this.renderTree.isSectionVisible(viewport, section.adjacentWest) ||
+                this.renderTree.isSectionVisible(viewport, section.adjacentEast));
     }
-
-
 
     private int processChunkBuildResults(ArrayList<BuilderTaskOutput> results, Viewport viewport, UniformBufferManager uniforms) {
         var sectionsWithOutputs = applyBuildOutputs(results);


### PR DESCRIPTION
I’ve optimized  the criteria for immediate presentation in RenderSectionManager. Instead of running  visibility checks on all nearby chunks regardless of distance, the logic now prioritizes the chunk's proximity and existing visibility state. This will help shave off some stuttering during high-load rendering especially on high render distances and many chunks being visible.