### PR TITLE
 Cache max draw size in MultiDrawBatch instead of scanning every frame

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gpu/device/batch/GLDrawBatch.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gpu/device/batch/GLDrawBatch.java
@@ -22,23 +22,14 @@ public final class GLDrawBatch extends MultiDrawBatch {
     }
 
     @Override
-    public int getIndexBufferSize() {
-        int elements = 0;
-
-        for (var index = 0; index < this.size; index++) {
-            elements = Math.max(elements, MemoryIntrinsics.getInt(this.pElementCount + ((long) index * Integer.BYTES)));
-        }
-
-        return elements;
-    }
-
-    @Override
     public void put(int size, int elementCount, int baseVertex, long elementOffset) {
         MemoryIntrinsics.putInt(pElementCount + (size << 2), UInt32.uncheckedDowncast(elementCount));
         MemoryIntrinsics.putInt(pBaseVertex + (size << 2), UInt32.uncheckedDowncast(baseVertex));
 
         // * 4 to convert to bytes (the index buffer contains integers)
         MemoryIntrinsics.putAddress(pElementPointer + (size << Pointer.POINTER_SHIFT), elementOffset << 2);
+
+        this.updateMaxElementCount(elementCount);
     }
 
     @Override

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gpu/device/batch/MultiDrawBatch.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gpu/device/batch/MultiDrawBatch.java
@@ -1,17 +1,11 @@
 package net.caffeinemc.mods.sodium.client.gpu.device.batch;
 
-import com.mojang.blaze3d.buffers.GpuBufferSlice;
-import com.mojang.blaze3d.systems.RenderPass;
 import net.caffeinemc.mods.sodium.client.gpu.device.backend.DrawBackend;
 import net.caffeinemc.mods.sodium.client.gpu.device.context.DrawContext;
 
 public abstract class MultiDrawBatch {
     public int size;
     public boolean isFilled;
-
-    // Tracks the largest element count across all draw commands in this batch.
-    // Updated during put() so getIndexBufferSize() can return it instantly
-    // instead of scanning native memory every frame.
     private int maxElementCount;
 
     public static MultiDrawBatch newBatch(int capacity) {
@@ -32,21 +26,12 @@ public abstract class MultiDrawBatch {
         return this.size <= 0;
     }
 
-
-     //Returns the number of elements in the largest draw within this batch.
-     //Used by the caller to ensure the shared index buffer is big enough.
-    public int getIndexBufferSize() {
+    public int getMaxElementCount() {
         return this.maxElementCount;
     }
 
-
-     //Called by subclasses when appending a draw command. Keeps the cached
-    // maximum up to date so we don't have to scan the full batch later.
-
     protected final void updateMaxElementCount(int elementCount) {
-        if (elementCount > this.maxElementCount) {
-            this.maxElementCount = elementCount;
-        }
+        this.maxElementCount = Math.max(this.maxElementCount, elementCount);
     }
 
     public abstract void put(int size, int elementCount, int baseVertex, long elementOffset);

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gpu/device/batch/MultiDrawBatch.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gpu/device/batch/MultiDrawBatch.java
@@ -9,6 +9,11 @@ public abstract class MultiDrawBatch {
     public int size;
     public boolean isFilled;
 
+    // Tracks the largest element count across all draw commands in this batch.
+    // Updated during put() so getIndexBufferSize() can return it instantly
+    // instead of scanning native memory every frame.
+    private int maxElementCount;
+
     public static MultiDrawBatch newBatch(int capacity) {
         return switch (DrawBackend.BACKEND) {
             case OPENGL -> new GLDrawBatch(capacity);
@@ -20,13 +25,29 @@ public abstract class MultiDrawBatch {
     public final void clear() {
         this.size = 0;
         this.isFilled = false;
+        this.maxElementCount = 0;
     }
 
     public boolean isEmpty() {
         return this.size <= 0;
     }
 
-    public abstract int getIndexBufferSize();
+
+     //Returns the number of elements in the largest draw within this batch.
+     //Used by the caller to ensure the shared index buffer is big enough.
+    public int getIndexBufferSize() {
+        return this.maxElementCount;
+    }
+
+
+     //Called by subclasses when appending a draw command. Keeps the cached
+    // maximum up to date so we don't have to scan the full batch later.
+
+    protected final void updateMaxElementCount(int elementCount) {
+        if (elementCount > this.maxElementCount) {
+            this.maxElementCount = elementCount;
+        }
+    }
 
     public abstract void put(int size, int elementCount, int baseVertex, long elementOffset);
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gpu/device/batch/VKIndirectDrawBatch.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gpu/device/batch/VKIndirectDrawBatch.java
@@ -22,21 +22,12 @@ public final class VKIndirectDrawBatch extends MultiDrawBatch {
     }
 
     @Override
-    public int getIndexBufferSize() {
-        int elements = 0;
-
-        for (var index = 0; index < this.size; index++) {
-            elements = Math.max(elements, MemoryIntrinsics.getInt(this.pCommands + ((long) index * VkDrawIndexedIndirectCommand.SIZEOF) + VkDrawIndexedIndirectCommand.INDEXCOUNT));
-        }
-
-        return elements;
-    }
-
-    @Override
     public void put(int size, int elementCount, int baseVertex, long elementOffset) {
         MemoryIntrinsics.putInt(pCommands + (size * VkDrawIndexedIndirectCommand.SIZEOF) + VkDrawIndexedIndirectCommand.INDEXCOUNT, elementCount);
         MemoryIntrinsics.putInt(pCommands + (size * VkDrawIndexedIndirectCommand.SIZEOF) + VkDrawIndexedIndirectCommand.VERTEXOFFSET, UInt32.uncheckedDowncast(baseVertex));
         MemoryIntrinsics.putInt(pCommands + (size * VkDrawIndexedIndirectCommand.SIZEOF) + VkDrawIndexedIndirectCommand.FIRSTINDEX, UInt32.uncheckedDowncast(elementOffset));
+
+        this.updateMaxElementCount(elementCount);
     }
 
     @Override

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gpu/device/batch/VKMultiDrawBatch.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gpu/device/batch/VKMultiDrawBatch.java
@@ -18,21 +18,12 @@ public final class VKMultiDrawBatch extends MultiDrawBatch {
     }
 
     @Override
-    public int getIndexBufferSize() {
-        int elements = 0;
-
-        for (var index = 0; index < this.size; index++) {
-            elements = Math.max(elements, MemoryIntrinsics.getInt(this.pCommands + ((long) index * VkMultiDrawIndexedInfoEXT.SIZEOF) + VkMultiDrawIndexedInfoEXT.INDEXCOUNT));
-        }
-
-        return elements;
-    }
-
-    @Override
     public void put(int size, int elementCount, int baseVertex, long elementOffset) {
         MemoryIntrinsics.putInt(pCommands + (size * VkMultiDrawIndexedInfoEXT.SIZEOF) + VkMultiDrawIndexedInfoEXT.INDEXCOUNT, elementCount);
         MemoryIntrinsics.putInt(pCommands + (size * VkMultiDrawIndexedInfoEXT.SIZEOF) + VkMultiDrawIndexedInfoEXT.VERTEXOFFSET, UInt32.uncheckedDowncast(baseVertex));
         MemoryIntrinsics.putInt(pCommands + (size * VkMultiDrawIndexedInfoEXT.SIZEOF) + VkMultiDrawIndexedInfoEXT.FIRSTINDEX, UInt32.uncheckedDowncast(elementOffset));
+
+        this.updateMaxElementCount(elementCount);
     }
 
     @Override

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/DefaultChunkRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/DefaultChunkRenderer.java
@@ -3,14 +3,11 @@ package net.caffeinemc.mods.sodium.client.render.chunk;
 import com.mojang.blaze3d.IndexType;
 import com.mojang.blaze3d.buffers.GpuBuffer;
 import com.mojang.blaze3d.buffers.GpuBufferSlice;
-import com.mojang.blaze3d.opengl.GlStateManager;
 import com.mojang.blaze3d.systems.RenderPass;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.textures.FilterMode;
 import com.mojang.blaze3d.textures.GpuSampler;
-import com.mojang.blaze3d.vulkan.VulkanCommandEncoder;
 import net.caffeinemc.mods.sodium.client.SodiumClientMod;
-import net.caffeinemc.mods.sodium.client.gpu.device.backend.DrawBackend;
 import net.caffeinemc.mods.sodium.client.gpu.device.batch.MultiDrawBatch;
 import net.caffeinemc.mods.sodium.client.gpu.device.context.DrawContext;
 import net.caffeinemc.mods.sodium.client.model.quad.properties.ModelQuadFacing;
@@ -25,17 +22,7 @@ import net.caffeinemc.mods.sodium.client.render.viewport.CameraTransform;
 import net.caffeinemc.mods.sodium.client.util.BitwiseMath;
 import net.caffeinemc.mods.sodium.client.util.FogParameters;
 import net.caffeinemc.mods.sodium.client.util.UInt32;
-import net.caffeinemc.mods.sodium.mixin.core.CommandEncoderAccessor;
-import net.caffeinemc.mods.sodium.mixin.core.GlRenderPassAccessor;
-import net.caffeinemc.mods.sodium.mixin.core.RenderPassAccessor;
-import net.caffeinemc.mods.sodium.mixin.core.VulkanRenderPassAccessor;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.MappableRingBuffer;
-import org.lwjgl.opengl.GL46C;
-import org.lwjgl.system.MemoryStack;
-import org.lwjgl.system.MemoryUtil;
-import org.lwjgl.vulkan.VK13;
-import org.lwjgl.vulkan.VkCommandBuffer;
 
 import java.util.Iterator;
 import java.util.Optional;
@@ -102,7 +89,7 @@ public class DefaultChunkRenderer extends ShaderChunkRenderer {
             // When the shared index buffer is being used, we must ensure the storage has been allocated *before*
             // the tessellation is prepared.
             if (!useIndexedTessellation) {
-                this.sharedIndexBuffer.ensureCapacity(batch.getIndexBufferSize());
+                this.sharedIndexBuffer.ensureCapacity(batch.getMaxElementCount());
             }
 
         }


### PR DESCRIPTION
getIndexBufferSize() was doing a full O(n) walk through native memory every frame for every non-empty region — just to check if the shared index buffer is big enough ,  on most frames the buffer is already allocated at the right size, so all those reads are wasted.
My Pr moves the tracking into put() so the max element count is known the moment the batch is built. getIndexBufferSize() now returns the cached value in constant time.
All three backends (GL, VK multi-draw, VK indirect) had the same pattern — removed the scan from each and added the cache update call.