### PR TITLE
Parallel draw command buffer filling

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -5,6 +5,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import net.caffeinemc.mods.sodium.client.SodiumClientMod;
 import net.caffeinemc.mods.sodium.client.render.chunk.ChunkRenderMatrices;
+import net.caffeinemc.mods.sodium.client.render.chunk.DefaultChunkRenderer;
 import net.caffeinemc.mods.sodium.client.render.chunk.RenderSectionManager;
 import net.caffeinemc.mods.sodium.client.render.chunk.UniformBufferManager;
 import net.caffeinemc.mods.sodium.client.render.chunk.lists.ChunkRenderList;
@@ -48,16 +49,37 @@ import org.joml.Vector3d;
 import org.joml.Vector4f;
 import org.jspecify.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.SortedSet;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.RecursiveAction;
 import java.util.function.Consumer;
 
 /**
  * Provides an extension to vanilla's {@link LevelRenderer}.
  */
 public class SodiumWorldRenderer {
+    private static final ForkJoinPool BATCH_FILL_POOL = createBatchFillPool();
+
+    private static ForkJoinPool createBatchFillPool() {
+        int cores = Runtime.getRuntime().availableProcessors();
+        int chunkBuilderThreads = Mth.clamp(Math.max(cores / 3, cores - 6), 1, 10);
+        int poolSize = Mth.clamp(cores - chunkBuilderThreads - 1, 1, 4);
+        return new ForkJoinPool(poolSize,
+                pool -> {
+                    var t = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
+                    t.setName("Sodium-BatchFill-" + t.getId());
+                    t.setDaemon(true);
+                    return t;
+                },
+                null, false);
+    }
+
     private final Minecraft client;
 
     private ClientLevel level;
@@ -77,6 +99,9 @@ public class SodiumWorldRenderer {
 
     private RenderSectionManager renderSectionManager;
     private UniformBufferManager uniformBufferManager;
+
+    private CompletableFuture<Void> batchFillFuture = CompletableFuture.completedFuture(null);
+    private CameraTransform batchXf;
 
     /**
      * @return The SodiumWorldRenderer based on the current dimension
@@ -274,6 +299,35 @@ public class SodiumWorldRenderer {
         profiler.pop();
 
         Entity.setViewScale(Mth.clamp((double) this.client.options.getEffectiveRenderDistance() / 8.0D, 1.0D, 2.5D) * this.client.options.entityDistanceScaling().get());
+
+        var cameraPos = camera.position();
+        this.batchXf = new CameraTransform(cameraPos.x(), cameraPos.y(), cameraPos.z());
+        this.batchFillFuture = CompletableFuture.runAsync(() -> {
+            var lists = this.renderSectionManager.getRenderLists();
+            var blockFaceCulling = SodiumClientMod.options().performance.useBlockFaceCulling;
+            var tasks = new ArrayList<RecursiveAction>();
+            var it = lists.iterator(false);
+            while (it.hasNext()) {
+                var list = it.next();
+                var region = list.getRegion();
+                for (var pass : DefaultTerrainRenderPasses.ALL) {
+                    var storage = region.getStorage(pass);
+                    if (storage == null) continue;
+                    if (region.getResources() == null) continue;
+                    var batch = region.getCachedBatch(pass);
+                    var indexed = pass.isTranslucent() && this.useTranslucencySorting;
+                    tasks.add(new RecursiveAction() {
+                        protected void compute() {
+                            DefaultChunkRenderer.fillCommandBuffer(batch, region, storage, list,
+                                    batchXf, pass, blockFaceCulling, indexed);
+                        }
+                    });
+                }
+            }
+            if (!tasks.isEmpty()) {
+                ForkJoinTask.invokeAll(tasks);
+            }
+        }, BATCH_FILL_POOL);
     }
 
     private void processChunkEvents() {
@@ -295,6 +349,9 @@ public class SodiumWorldRenderer {
     }
 
     public void renderLayer(ChunkRenderMatrices matrices, TerrainRenderPass pass, double x, double y, double z, FogParameters fogParameters, GpuSampler terrainSampler) {
+        this.batchFillFuture.join();
+        this.batchFillFuture = CompletableFuture.completedFuture(null);
+
         this.uniformBufferManager.update(matrices, fogParameters);
 
         this.renderSectionManager.getChunkRenderer().render(matrices, this.renderSectionManager.getRenderLists(), pass,

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/DefaultChunkRenderer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/DefaultChunkRenderer.java
@@ -162,29 +162,33 @@ public class DefaultChunkRenderer extends ShaderChunkRenderer {
         this.drawContext.rotate();
     }
 
-    private static void fillCommandBuffer(MultiDrawBatch batch,
-                                          RenderRegion renderRegion,
-                                          SectionRenderDataStorage renderDataStorage,
-                                          ChunkRenderList renderList,
-                                          CameraTransform camera,
-                                          TerrainRenderPass pass,
-                                          boolean useBlockFaceCulling,
-                                          boolean useIndexedTessellation) {
+    public static void fillCommandBuffer(MultiDrawBatch batch,
+                                         RenderRegion renderRegion,
+                                         SectionRenderDataStorage renderDataStorage,
+                                         ChunkRenderList renderList,
+                                         CameraTransform camera,
+                                         TerrainRenderPass pass,
+                                         boolean useBlockFaceCulling,
+                                         boolean useIndexedTessellation) {
         batch.isFilled = true;
+        batch.size = 0;
 
-        var iterator = renderList.sectionsWithGeometryIterator(pass.isTranslucent());
+        byte[] sections = renderList.getSectionsWithGeometryArray();
+        int count = renderList.getSectionsWithGeometryCount();
 
-        if (iterator == null) {
+        if (count == 0) {
             return;
         }
 
-        // The origin of the chunk in world space
         int originX = renderRegion.getChunkX();
         int originY = renderRegion.getChunkY();
         int originZ = renderRegion.getChunkZ();
 
-        while (iterator.hasNext()) {
-            int sectionIndex = iterator.nextByteAsInt();
+        int step = pass.isTranslucent() ? -1 : 1;
+        int start = pass.isTranslucent() ? count - 1 : 0;
+
+        for (int i = start; i >= 0 && i < count; i += step) {
+            int sectionIndex = sections[i] & 0xFF;
 
             var pMeshData = renderDataStorage.getDataPointer(sectionIndex);
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/ChunkRenderList.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/ChunkRenderList.java
@@ -108,6 +108,10 @@ public class ChunkRenderList {
         return new ReversibleByteArrayIterator(this.sectionsWithGeometry, this.sectionsWithGeometryCount, reverse);
     }
 
+    public byte[] getSectionsWithGeometryArray() {
+        return this.sectionsWithGeometry;
+    }
+
     public @Nullable ByteIterator sectionsWithSpritesIterator() {
         if (this.sectionsWithSpritesCount == 0) {
             return null;

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/region/RenderRegion.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/region/RenderRegion.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class RenderRegion {
     public static final int SECTION_VERTEX_COUNT_ESTIMATE = 756;
@@ -66,7 +67,7 @@ public class RenderRegion {
     private final Map<TerrainRenderPass, SectionRenderDataStorage> sectionRenderData = new Reference2ReferenceOpenHashMap<>();
     private DeviceResources resources;
 
-    private final Map<TerrainRenderPass, MultiDrawBatch> cachedBatches = new Reference2ReferenceOpenHashMap<>();
+    private final Map<TerrainRenderPass, MultiDrawBatch> cachedBatches = new ConcurrentHashMap<>();
     private int uniqueId = -1;
 
     public RenderRegion(int x, int y, int z, StagingBuffer stagingBuffer) {


### PR DESCRIPTION
Basically , this parallelizes draw command buffer filling , mostly did it to shift some work off the main thread , used a forkjoinpool , i profiled in jfr and it shaved off almost 0.7ms off of main thread cpu time , worth it for me for me personally as its a small change. set cores max as 4 because more would probably give vanishing returns because context switching might then take more time than the task does now. also made the hash map concurrent just to avoid any reading of stale data if new code needs it.