### PR TITLE
Skip marking static sprites as active

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/texture/SpriteUtilImpl.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/texture/SpriteUtilImpl.java
@@ -11,6 +11,10 @@ public class SpriteUtilImpl implements SpriteUtil {
     public void markSpriteActive(@NonNull TextureAtlasSprite sprite) {
         Objects.requireNonNull(sprite);
 
+        if (!hasAnimation(sprite)) {
+            return;
+        }
+
         ((SpriteContentsExtension) sprite.contents()).sodium$setActive(true);
     }
 


### PR DESCRIPTION
Skips the `sodium$setActive(true)` call on non-animated sprites, since it is only needed on animated sprites.