### PR TITLE
Fix crash when reusing dynamic index data

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/ChunkSortOutput.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/ChunkSortOutput.java
@@ -14,19 +14,19 @@ public class ChunkSortOutput extends BuilderTaskOutput {
     public ChunkSortOutput(RenderSection render, int buildTime, Sorter data) {
         this(render, buildTime);
         this.setSorter(data);
+        this.setContainsNewIndexData(true);
     }
 
     public void setSorter(Sorter sorter) {
         this.sorter = sorter;
-        this.containsNewIndexData = true;
+    }
+
+    public void setContainsNewIndexData(boolean containsNewIndexData) {
+        this.containsNewIndexData = containsNewIndexData;
     }
 
     public Sorter getSorter() {
         return this.sorter;
-    }
-
-    public void markAsNotContainingNewIndexData() {
-        this.containsNewIndexData = false;
     }
 
     public boolean containsNewIndexData() {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderMeshingTask.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderMeshingTask.java
@@ -234,12 +234,19 @@ public class ChunkBuilderMeshingTask extends ChunkBuilderTask<ChunkBuildOutput> 
 
         if (sortEnabled) {
             if (reuseUploadedData) {
-                output.markAsNotContainingNewIndexData();
+                // TODO: problem: when reusing index data, we may be doing so based on uploaded indexes that are not corresponding to the translucent data that ends up getting set on the section.
+                output.setContainsNewIndexData(false);
+
+                // set a sorter so that it retains a copy of the geometry planes for potential re-integration into the triggering system
+                if (translucentData instanceof DynamicData dynamicData) {
+                    output.setSorter(dynamicData.getSorter(false));
+                }
             } else if (translucentData instanceof PresentTranslucentData present) {
                 try {
                     var sorter = present.getSorter(true);
                     sorter.writeIndexBuffer(this);
                     output.setSorter(sorter);
+                    output.setContainsNewIndexData(true);
                 } catch (Exception ex) {
                     // Create a new crash report for exceptions thrown during sorting
                     throw this.fillCrashInfo(CrashReport.forThrowable(ex, "Encountered exception while writing index buffer for translucent geometry"), slice, null);


### PR DESCRIPTION
 Fix crash when reusing dynamic index data by supplying sorter even when it was not used. I've noted a potential problem as a TODO comment, but I don't have a good idea on how to resolve that issue yet without larger changes.