### PR TITLE
Fix ambient occlusion in non-terrain block rendering fixes #3780

### DIFF
--- a/frapi/src/main/java/net/caffeinemc/mods/sodium/client/render/frapi/render/NonTerrainBlockRenderContext.java
+++ b/frapi/src/main/java/net/caffeinemc/mods/sodium/client/render/frapi/render/NonTerrainBlockRenderContext.java
@@ -146,7 +146,9 @@ public class NonTerrainBlockRenderContext extends AbstractBlockRenderContext imp
 
         Vec3 offset = blockState.getOffset(pos);
         this.offset.set(x + offset.x, y + offset.y, z + offset.z);
+        this.useAmbientOcclusion = this.allowAO;
         this.defaultAo = this.allowAO && blockState.getLightEmission() == 0;
+        this.defaultLightMode = this.defaultAo ? LightMode.SMOOTH : LightMode.FLAT;
 
         this.lightDataCache.reset(pos, level);
         this.prepareCulling(this.enableCulling);


### PR DESCRIPTION
Fixes #3780

The Fabric non-terrain block renderer was receiving the ambient occlusion setting through the constructor but wasn't applying it to the block's lighting state. Because of that, moving/non-terrain blocks could use flat lighting when they were supposed to use the smooth AO lighting, making them render too dark.

I can't reproduce the lighting issue with the setup from #3780 with the new fix, so it seems good.

