### PR TITLE
Remove extra ABGR conversion fixes #3779

### DIFF
--- a/frapi/src/main/java/net/caffeinemc/mods/sodium/client/render/frapi/render/NonTerrainBlockRenderContext.java
+++ b/frapi/src/main/java/net/caffeinemc/mods/sodium/client/render/frapi/render/NonTerrainBlockRenderContext.java
@@ -121,7 +121,7 @@ public class NonTerrainBlockRenderContext extends AbstractBlockRenderContext imp
         if (this.tintCacheIndex == tintIndex) {
             return this.tintCacheValue;
         } else {
-            int tintColor = ColorARGB.toABGR(this.computeTintColor(level, state, pos, tintIndex));
+            int tintColor = this.computeTintColor(level, state, pos, tintIndex);
             this.tintCacheIndex = tintIndex;
             this.tintCacheValue = tintColor;
             return tintColor;


### PR DESCRIPTION
Fixes #3779 

Remove extra "ColorARGB.toABGR()" conversion in the non-terrain block render context.

I can't reproduce the color issue from #3779 with this new fix, so it seems good.