### PR TITLE
Fix command line not being restored after NeoForge early window init

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/workarounds/context_creation/WindowMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/workarounds/context_creation/WindowMixin.java
@@ -8,7 +8,9 @@ import net.caffeinemc.mods.sodium.client.compatibility.workarounds.nvidia.Nvidia
 import net.caffeinemc.mods.sodium.client.services.PlatformRuntimeInformation;
 import org.lwjgl.glfw.GLFW;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Coerce;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 import java.util.function.IntSupplier;
@@ -18,7 +20,13 @@ import java.util.function.Supplier;
 
 @Mixin(Window.class)
 public class WindowMixin {
-    @Redirect(method = "createGlfwWindow", at = @At(value = "INVOKE", target = "Lorg/lwjgl/glfw/GLFW;glfwCreateWindow(IILjava/lang/CharSequence;JJ)J"), expect = 0, require = 0)
+    @Redirect(
+            method = "createGlfwWindow",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lorg/lwjgl/glfw/GLFW;glfwCreateWindow(IILjava/lang/CharSequence;JJ)J"),
+            expect = 0,
+            require = 0)
     private static long wrapGlfwCreateWindow(int width, int height, CharSequence title, long monitor, long share) {
         NvidiaWorkarounds.applyEnvironmentChanges();
         AmdWorkarounds.applyEnvironmentChanges();
@@ -36,8 +44,17 @@ public class WindowMixin {
     }
 
     @SuppressWarnings("all")
-    @WrapOperation(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/neoforged/fml/loading/ImmediateWindowHandler;setupMinecraftWindow(Ljava/util/function/IntSupplier;Ljava/util/function/IntSupplier;Ljava/util/function/Supplier;Ljava/util/function/LongSupplier;)J"), expect = 0, require = 0)
-    private long wrapGlfwCreateWindowForge(final IntSupplier width, final IntSupplier height, final Supplier<String> title, final LongSupplier monitor, Operation<Long> op) {
+    @WrapOperation(
+            method = "<init>",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/neoforged/fml/loading/ImmediateWindowHandler;setupMinecraftWindow" +
+                            "(Ljava/util/function/IntSupplier;Ljava/util/function/IntSupplier;" +
+                            "Ljava/util/function/Supplier;Ljava/util/function/LongSupplier;)J"),
+            expect = 0,
+            require = 0)
+    private long wrapGlfwCreateWindowForge(final IntSupplier width, final IntSupplier height,
+            final Supplier<String> title, final LongSupplier monitor, Operation<Long> op) {
         boolean applyWorkaroundsLate = !PlatformRuntimeInformation.getInstance()
                 .platformHasEarlyLoadingScreen();
 
@@ -53,6 +70,40 @@ public class WindowMixin {
                 NvidiaWorkarounds.undoEnvironmentChanges();
                 AmdWorkarounds.undoEnvironmentChanges();
             }
+        }
+    }
+
+    @SuppressWarnings("all")
+    @WrapOperation(
+            method = "createGlfwWindow",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/neoforged/fml/loading/EarlyLoadingScreenController;takeOverGlfwWindow()J"),
+            expect = 0,
+            require = 0)
+    private static long wrapTakeOverGlfwWindow(@Coerce Object earlyLoadingScreen, Operation<Long> op) {
+        return takeOverGlfwWindowAndRestoreEnvironmentChanges(earlyLoadingScreen, op);
+    }
+
+    @SuppressWarnings("all")
+    @WrapOperation(
+            method = "takeOverWindow",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/neoforged/fml/loading/EarlyLoadingScreenController;takeOverGlfwWindow()J"),
+            expect = 0,
+            require = 0)
+    private long wrapTakeOverGlfwWindowLegacy(@Coerce Object earlyLoadingScreen, Operation<Long> op) {
+        return takeOverGlfwWindowAndRestoreEnvironmentChanges(earlyLoadingScreen, op);
+    }
+
+    @Unique
+    private static long takeOverGlfwWindowAndRestoreEnvironmentChanges(Object earlyLoadingScreen, Operation<Long> op) {
+        try {
+            return op.call(earlyLoadingScreen);
+        } finally {
+            NvidiaWorkarounds.undoEnvironmentChanges();
+            AmdWorkarounds.undoEnvironmentChanges();
         }
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/workarounds/context_creation/WindowMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/workarounds/context_creation/WindowMixin.java
@@ -8,9 +8,7 @@ import net.caffeinemc.mods.sodium.client.compatibility.workarounds.nvidia.Nvidia
 import net.caffeinemc.mods.sodium.client.services.PlatformRuntimeInformation;
 import org.lwjgl.glfw.GLFW;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Coerce;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 import java.util.function.IntSupplier;
@@ -20,13 +18,7 @@ import java.util.function.Supplier;
 
 @Mixin(Window.class)
 public class WindowMixin {
-    @Redirect(
-            method = "createGlfwWindow",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lorg/lwjgl/glfw/GLFW;glfwCreateWindow(IILjava/lang/CharSequence;JJ)J"),
-            expect = 0,
-            require = 0)
+    @Redirect(method = "createGlfwWindow", at = @At(value = "INVOKE", target = "Lorg/lwjgl/glfw/GLFW;glfwCreateWindow(IILjava/lang/CharSequence;JJ)J"), expect = 0, require = 0)
     private static long wrapGlfwCreateWindow(int width, int height, CharSequence title, long monitor, long share) {
         NvidiaWorkarounds.applyEnvironmentChanges();
         AmdWorkarounds.applyEnvironmentChanges();
@@ -44,17 +36,8 @@ public class WindowMixin {
     }
 
     @SuppressWarnings("all")
-    @WrapOperation(
-            method = "<init>",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/neoforged/fml/loading/ImmediateWindowHandler;setupMinecraftWindow" +
-                            "(Ljava/util/function/IntSupplier;Ljava/util/function/IntSupplier;" +
-                            "Ljava/util/function/Supplier;Ljava/util/function/LongSupplier;)J"),
-            expect = 0,
-            require = 0)
-    private long wrapGlfwCreateWindowForge(final IntSupplier width, final IntSupplier height,
-            final Supplier<String> title, final LongSupplier monitor, Operation<Long> op) {
+    @WrapOperation(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/neoforged/fml/loading/ImmediateWindowHandler;setupMinecraftWindow(Ljava/util/function/IntSupplier;Ljava/util/function/IntSupplier;Ljava/util/function/Supplier;Ljava/util/function/LongSupplier;)J"), expect = 0, require = 0)
+    private long wrapGlfwCreateWindowForge(final IntSupplier width, final IntSupplier height, final Supplier<String> title, final LongSupplier monitor, Operation<Long> op) {
         boolean applyWorkaroundsLate = !PlatformRuntimeInformation.getInstance()
                 .platformHasEarlyLoadingScreen();
 
@@ -70,40 +53,6 @@ public class WindowMixin {
                 NvidiaWorkarounds.undoEnvironmentChanges();
                 AmdWorkarounds.undoEnvironmentChanges();
             }
-        }
-    }
-
-    @SuppressWarnings("all")
-    @WrapOperation(
-            method = "createGlfwWindow",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/neoforged/fml/loading/EarlyLoadingScreenController;takeOverGlfwWindow()J"),
-            expect = 0,
-            require = 0)
-    private static long wrapTakeOverGlfwWindow(@Coerce Object earlyLoadingScreen, Operation<Long> op) {
-        return takeOverGlfwWindowAndRestoreEnvironmentChanges(earlyLoadingScreen, op);
-    }
-
-    @SuppressWarnings("all")
-    @WrapOperation(
-            method = "takeOverWindow",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/neoforged/fml/loading/EarlyLoadingScreenController;takeOverGlfwWindow()J"),
-            expect = 0,
-            require = 0)
-    private long wrapTakeOverGlfwWindowLegacy(@Coerce Object earlyLoadingScreen, Operation<Long> op) {
-        return takeOverGlfwWindowAndRestoreEnvironmentChanges(earlyLoadingScreen, op);
-    }
-
-    @Unique
-    private static long takeOverGlfwWindowAndRestoreEnvironmentChanges(Object earlyLoadingScreen, Operation<Long> op) {
-        try {
-            return op.call(earlyLoadingScreen);
-        } finally {
-            NvidiaWorkarounds.undoEnvironmentChanges();
-            AmdWorkarounds.undoEnvironmentChanges();
         }
     }
 }

--- a/neoforge/src/main/java/net/caffeinemc/mods/sodium/service/SodiumWorkarounds.java
+++ b/neoforge/src/main/java/net/caffeinemc/mods/sodium/service/SodiumWorkarounds.java
@@ -7,8 +7,18 @@ import net.caffeinemc.mods.sodium.client.compatibility.workarounds.amd.AmdWorkar
 import net.caffeinemc.mods.sodium.client.compatibility.workarounds.nvidia.NvidiaWorkarounds;
 import net.neoforged.fml.loading.FMLConfig;
 import net.neoforged.neoforgespi.earlywindow.GraphicsBootstrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 public class SodiumWorkarounds implements GraphicsBootstrapper {
+    private static final Logger LOGGER = LoggerFactory.getLogger("Sodium-Workarounds");
+    private static final long EARLY_WINDOW_RESTORE_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(30);
+    private static final long EARLY_WINDOW_RESTORE_POLL_INTERVAL_MILLIS = 10L;
+
     @Override
     public String name() {
         return "sodium";
@@ -20,11 +30,92 @@ public class SodiumWorkarounds implements GraphicsBootstrapper {
         GraphicsAdapterProbe.findAdapters();
         Workarounds.init();
 
-        // When early window control is disabled, NeoForge creates no early GL context, so context creation happens later in Window#createGlfwWindow. We want to avoid doing the workarounds twice if the context is going to be created later and thus our mixin to Window#createGlfwWindow runs that also applies them.
+        // When early window control is disabled, NeoForge creates no early GL context, so context creation happens
+        // later in Window#createGlfwWindow. We want to avoid applying the workarounds twice if the context is going to
+        // be created later and our mixin to Window#createGlfwWindow runs.
         // See https://github.com/CaffeineMC/sodium/issues/3664 for more details.
         if (FMLConfig.getBoolConfigValue(FMLConfig.ConfigValue.EARLY_WINDOW_CONTROL)) {
             NvidiaWorkarounds.applyEnvironmentChanges();
             AmdWorkarounds.applyEnvironmentChanges();
+            restoreEnvironmentChangesAfterEarlyWindowInit();
         }
+    }
+
+    private static void restoreEnvironmentChangesAfterEarlyWindowInit() {
+        Thread thread = new Thread(SodiumWorkarounds::waitForEarlyWindowAndRestoreEnvironmentChanges,
+                "sodium-workaround-cleanup");
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    private static void waitForEarlyWindowAndRestoreEnvironmentChanges() {
+        try {
+            if (!waitForEarlyWindowRenderer()) {
+                LOGGER.warn("Timed out waiting for NeoForge's early renderer; restoring graphics " +
+                        "driver workaround environment changes now");
+            }
+        } catch (Throwable t) {
+            LOGGER.warn("Failed while waiting for NeoForge's early renderer; restoring graphics " +
+                    "driver workaround environment changes now", t);
+        } finally {
+            NvidiaWorkarounds.undoEnvironmentChanges();
+            AmdWorkarounds.undoEnvironmentChanges();
+        }
+    }
+
+    private static boolean waitForEarlyWindowRenderer() throws ReflectiveOperationException, InterruptedException {
+        Class<?> windowHandlerClass = Class.forName("net.neoforged.fml.loading.ImmediateWindowHandler");
+        Field providerField = windowHandlerClass.getDeclaredField("provider");
+        providerField.setAccessible(true);
+
+        long deadline = System.nanoTime() + EARLY_WINDOW_RESTORE_TIMEOUT_NANOS;
+
+        while (System.nanoTime() < deadline) {
+            Object provider = providerField.get(null);
+
+            if (provider != null && hasEarlyWindowRendererInitialized(provider)) {
+                return true;
+            }
+
+            Thread.sleep(EARLY_WINDOW_RESTORE_POLL_INTERVAL_MILLIS);
+        }
+
+        return false;
+    }
+
+    private static boolean hasEarlyWindowRendererInitialized(Object provider) throws ReflectiveOperationException {
+        // NeoForge >=21.10.x initializes the early GL context from a renderer future after creating the provider window.
+        // Waiting for it avoids restoring the spoofed command line before the driver has initialized.
+        Field rendererFutureField = findField(provider.getClass(), "rendererFuture");
+
+        if (rendererFutureField != null) {
+            rendererFutureField.setAccessible(true);
+            Object rendererFuture = rendererFutureField.get(provider);
+
+            return rendererFuture instanceof Future<?> future && future.isDone();
+        }
+
+        Field windowField = findField(provider.getClass(), "window");
+
+        if (windowField != null) {
+            windowField.setAccessible(true);
+            return windowField.getLong(provider) != 0L;
+        }
+
+        return false;
+    }
+
+    private static Field findField(Class<?> clazz, String name) {
+        Class<?> current = clazz;
+
+        while (current != null) {
+            try {
+                return current.getDeclaredField(name);
+            } catch (NoSuchFieldException ignored) {
+                current = current.getSuperclass();
+            }
+        }
+
+        return null;
     }
 }

--- a/neoforge/src/main/java/net/caffeinemc/mods/sodium/service/SodiumWorkarounds.java
+++ b/neoforge/src/main/java/net/caffeinemc/mods/sodium/service/SodiumWorkarounds.java
@@ -7,18 +7,8 @@ import net.caffeinemc.mods.sodium.client.compatibility.workarounds.amd.AmdWorkar
 import net.caffeinemc.mods.sodium.client.compatibility.workarounds.nvidia.NvidiaWorkarounds;
 import net.neoforged.fml.loading.FMLConfig;
 import net.neoforged.neoforgespi.earlywindow.GraphicsBootstrapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.lang.reflect.Field;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 public class SodiumWorkarounds implements GraphicsBootstrapper {
-    private static final Logger LOGGER = LoggerFactory.getLogger("Sodium-Workarounds");
-    private static final long EARLY_WINDOW_RESTORE_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(30);
-    private static final long EARLY_WINDOW_RESTORE_POLL_INTERVAL_MILLIS = 10L;
-
     @Override
     public String name() {
         return "sodium";
@@ -37,85 +27,6 @@ public class SodiumWorkarounds implements GraphicsBootstrapper {
         if (FMLConfig.getBoolConfigValue(FMLConfig.ConfigValue.EARLY_WINDOW_CONTROL)) {
             NvidiaWorkarounds.applyEnvironmentChanges();
             AmdWorkarounds.applyEnvironmentChanges();
-            restoreEnvironmentChangesAfterEarlyWindowInit();
         }
-    }
-
-    private static void restoreEnvironmentChangesAfterEarlyWindowInit() {
-        Thread thread = new Thread(SodiumWorkarounds::waitForEarlyWindowAndRestoreEnvironmentChanges,
-                "sodium-workaround-cleanup");
-        thread.setDaemon(true);
-        thread.start();
-    }
-
-    private static void waitForEarlyWindowAndRestoreEnvironmentChanges() {
-        try {
-            if (!waitForEarlyWindowRenderer()) {
-                LOGGER.warn("Timed out waiting for NeoForge's early renderer; restoring graphics " +
-                        "driver workaround environment changes now");
-            }
-        } catch (Throwable t) {
-            LOGGER.warn("Failed while waiting for NeoForge's early renderer; restoring graphics " +
-                    "driver workaround environment changes now", t);
-        } finally {
-            NvidiaWorkarounds.undoEnvironmentChanges();
-            AmdWorkarounds.undoEnvironmentChanges();
-        }
-    }
-
-    private static boolean waitForEarlyWindowRenderer() throws ReflectiveOperationException, InterruptedException {
-        Class<?> windowHandlerClass = Class.forName("net.neoforged.fml.loading.ImmediateWindowHandler");
-        Field providerField = windowHandlerClass.getDeclaredField("provider");
-        providerField.setAccessible(true);
-
-        long deadline = System.nanoTime() + EARLY_WINDOW_RESTORE_TIMEOUT_NANOS;
-
-        while (System.nanoTime() < deadline) {
-            Object provider = providerField.get(null);
-
-            if (provider != null && hasEarlyWindowRendererInitialized(provider)) {
-                return true;
-            }
-
-            Thread.sleep(EARLY_WINDOW_RESTORE_POLL_INTERVAL_MILLIS);
-        }
-
-        return false;
-    }
-
-    private static boolean hasEarlyWindowRendererInitialized(Object provider) throws ReflectiveOperationException {
-        // NeoForge >=21.10.x initializes the early GL context from a renderer future after creating the provider window.
-        // Waiting for it avoids restoring the spoofed command line before the driver has initialized.
-        Field rendererFutureField = findField(provider.getClass(), "rendererFuture");
-
-        if (rendererFutureField != null) {
-            rendererFutureField.setAccessible(true);
-            Object rendererFuture = rendererFutureField.get(provider);
-
-            return rendererFuture instanceof Future<?> future && future.isDone();
-        }
-
-        Field windowField = findField(provider.getClass(), "window");
-
-        if (windowField != null) {
-            windowField.setAccessible(true);
-            return windowField.getLong(provider) != 0L;
-        }
-
-        return false;
-    }
-
-    private static Field findField(Class<?> clazz, String name) {
-        Class<?> current = clazz;
-
-        while (current != null) {
-            try {
-                return current.getDeclaredField(name);
-            } catch (NoSuchFieldException ignored) {
-                current = current.getSuperclass();
-            }
-        }
-
-        return null;
     }
 }

--- a/neoforge/src/main/java/net/caffeinemc/mods/sodium/service/SodiumWorkarounds.java
+++ b/neoforge/src/main/java/net/caffeinemc/mods/sodium/service/SodiumWorkarounds.java
@@ -7,8 +7,18 @@ import net.caffeinemc.mods.sodium.client.compatibility.workarounds.amd.AmdWorkar
 import net.caffeinemc.mods.sodium.client.compatibility.workarounds.nvidia.NvidiaWorkarounds;
 import net.neoforged.fml.loading.FMLConfig;
 import net.neoforged.neoforgespi.earlywindow.GraphicsBootstrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 public class SodiumWorkarounds implements GraphicsBootstrapper {
+    private static final Logger LOGGER = LoggerFactory.getLogger("Sodium-Workarounds");
+    private static final long EARLY_WINDOW_RESTORE_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(30);
+    private static final long EARLY_WINDOW_RESTORE_POLL_INTERVAL_MILLIS = 10L;
+
     @Override
     public String name() {
         return "sodium";
@@ -27,6 +37,85 @@ public class SodiumWorkarounds implements GraphicsBootstrapper {
         if (FMLConfig.getBoolConfigValue(FMLConfig.ConfigValue.EARLY_WINDOW_CONTROL)) {
             NvidiaWorkarounds.applyEnvironmentChanges();
             AmdWorkarounds.applyEnvironmentChanges();
+            restoreEnvironmentChangesAfterEarlyWindowInit();
         }
+    }
+
+    private static void restoreEnvironmentChangesAfterEarlyWindowInit() {
+        Thread thread = new Thread(SodiumWorkarounds::waitForEarlyWindowAndRestoreEnvironmentChanges,
+                "sodium-workaround-cleanup");
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    private static void waitForEarlyWindowAndRestoreEnvironmentChanges() {
+        try {
+            if (!waitForEarlyWindowRenderer()) {
+                LOGGER.warn("Timed out waiting for NeoForge's early renderer; restoring graphics " +
+                        "driver workaround environment changes now");
+            }
+        } catch (Throwable t) {
+            LOGGER.warn("Failed while waiting for NeoForge's early renderer; restoring graphics " +
+                    "driver workaround environment changes now", t);
+        } finally {
+            NvidiaWorkarounds.undoEnvironmentChanges();
+            AmdWorkarounds.undoEnvironmentChanges();
+        }
+    }
+
+    private static boolean waitForEarlyWindowRenderer() throws ReflectiveOperationException, InterruptedException {
+        Class<?> windowHandlerClass = Class.forName("net.neoforged.fml.loading.ImmediateWindowHandler");
+        Field providerField = windowHandlerClass.getDeclaredField("provider");
+        providerField.setAccessible(true);
+
+        long deadline = System.nanoTime() + EARLY_WINDOW_RESTORE_TIMEOUT_NANOS;
+
+        while (System.nanoTime() < deadline) {
+            Object provider = providerField.get(null);
+
+            if (provider != null && hasEarlyWindowRendererInitialized(provider)) {
+                return true;
+            }
+
+            Thread.sleep(EARLY_WINDOW_RESTORE_POLL_INTERVAL_MILLIS);
+        }
+
+        return false;
+    }
+
+    private static boolean hasEarlyWindowRendererInitialized(Object provider) throws ReflectiveOperationException {
+        // NeoForge >=21.10.x initializes the early GL context from a renderer future after creating the provider window.
+        // Waiting for it avoids restoring the spoofed command line before the driver has initialized.
+        Field rendererFutureField = findField(provider.getClass(), "rendererFuture");
+
+        if (rendererFutureField != null) {
+            rendererFutureField.setAccessible(true);
+            Object rendererFuture = rendererFutureField.get(provider);
+
+            return rendererFuture instanceof Future<?> future && future.isDone();
+        }
+
+        Field windowField = findField(provider.getClass(), "window");
+
+        if (windowField != null) {
+            windowField.setAccessible(true);
+            return windowField.getLong(provider) != 0L;
+        }
+
+        return false;
+    }
+
+    private static Field findField(Class<?> clazz, String name) {
+        Class<?> current = clazz;
+
+        while (current != null) {
+            try {
+                return current.getDeclaredField(name);
+            } catch (NoSuchFieldException ignored) {
+                current = current.getSuperclass();
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
Fixes #3733

On newer NeoForge, Sodium applies the Nvidia/AMD command line workaround from the early window bootstrap path, but the normal `Window#createGlfwWindow` restore path is not hit for that early GL context.

This leaves the spoofed command line in the PEB after startup.

This waits for NeoForge's early renderer to initialize, then restores the command line using the existing undo path. The workaround still stays active long enough for the driver to initialize, but it should no longer remain visible for the rest of the process.

<img width="1301" height="643" alt="image" src="https://github.com/user-attachments/assets/8d6893af-6d56-4b23-adfe-75ca29e8f5e3" />
