### PR TITLE
Fix generated item side-face stitching 

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/model/ImprovedItemModelBuilderBase.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/model/ImprovedItemModelBuilderBase.java
@@ -134,11 +134,11 @@ public class ImprovedItemModelBuilderBase {
         public List<SideFace> buildSideFaces() {
             var output = new ReferenceArrayList<SideFace>();
 
-            // Merges and collects all faces from different directions.
-            buildMergedFaces(output, this.up, SideDirection.UP);
-            buildMergedFaces(output, this.down, SideDirection.DOWN);
-            buildMergedFaces(output, this.left, SideDirection.LEFT);
-            buildMergedFaces(output, this.right, SideDirection.RIGHT);
+            // Collects all faces from different directions.
+            buildFaces(output, this.up, SideDirection.UP);
+            buildFaces(output, this.down, SideDirection.DOWN);
+            buildFaces(output, this.left, SideDirection.LEFT);
+            buildFaces(output, this.right, SideDirection.RIGHT);
 
             return output;
         }
@@ -174,53 +174,18 @@ public class ImprovedItemModelBuilderBase {
             }
         }
 
-        /*
-          <--merged-->    <-----merged----->
-        001111111111110000111111111111111111
-          ^           ^
-          |           |
-        min = ?     max = index - 1 = 14 - 1 = 13
-        accum = 0   accum = 12
-                    min = index - accum = 14 - 12 = 2
-        SideFace(facing, anchor, min=2, max=13)
-         */
-        private static void buildMergedFaces(
+        private static void buildFaces(
                 Collection<SideFace> faceOutput,
                 Int2ObjectMap<BitSet> storage,
                 SideDirection faceFacing
         ) {
-            // Merge all planes (anchors) in the map.
+            // Collect all planes (anchors) in the map.
             for (int anchor : storage.keySet()) {
                 var faces = storage.get(anchor); // Get the plane bit set.
-                var accum = 0; // Initialize the merge accumulation counter.
 
-                // For all bits in the plane, scan the occupied bits (per-pixel side quads) and merge consecutive bits
-                // into segments as SideFace.
-                // The scan starts from the position (index) of the first per-pixel side quad (first set bit) to the
-                // last per-pixel side quad (highest set bit).
-                // The scan runs to faces.length() + 1 is to ensure that the final accumulated segment is also emitted,
-                // since the bit immediately after the highest set bit is always clear.
-                for (var index = faces.nextSetBit(0); index < faces.length() + 1; index ++) {
-                    if (faces.get(index)) {
-                        // The bit is set, accumulate the length of the segment.
-                        accum ++;
-                    } else {
-                        // The bit is clear, meaning that the previous consecutive segment has ended, or a new segment
-                        // has not started yet.
-                        // If we do have a previously accumulated segment,
-                        if (accum > 0) {
-                            // Pop the segment out to the faceOutput as a merged SideFace.
-                            faceOutput.add(new SideFace(
-                                    faceFacing,
-                                    index - accum,
-                                    index - 1,
-                                    anchor
-                            ));
-                        }
-
-                        // Reset the accumulation counter for new segments.
-                        accum = 0;
-                    }
+                // Collect each occupied bit as a per-pixel SideFace.
+                for (var index = faces.nextSetBit(0); index >= 0; index = faces.nextSetBit(index + 1)) {
+                    faceOutput.add(new SideFace(faceFacing, index, index, anchor));
                 }
             }
         }


### PR DESCRIPTION
This fixes #3715.

### Background
Isolation and cause [analysis](https://github.com/CaffeineMC/sodium/issues/3715#issuecomment-4879772053) is present in the original issue (long story short, it was caused by this [PR](https://github.com/CaffeineMC/sodium/pull/3551)).

### Why
Previously, generated item side faces were being merged into longer quads. This reduced quad count, but it also meant "UV_SHRINK" was only applied to the outer ends of each merged run instead of each side texel (UV_SHRINK is present in the Fabric and Neoforge specific item-builders). This is most visible on simple generated item textures such as torches, levers, and other torch-like items. The stitching error is more visible on these items because they have large flat regions and long exposed side-face runs, so the shifted side-face texel boundaries are easy to compare against the front face.

### Fix
This reverts that previous optimization for generated side-faces. This PR changes the generated item side-face builder to emit each occupied side texel as its own "SideFace/quad" again. 

Torch after my fix:
<img width="507" height="371" alt="image" src="https://github.com/user-attachments/assets/e9269786-ac8f-44f6-9436-8efaf756bbe9" />

### Tradeoff
Since this removes the previous side-face merging optimization for generated item side faces, performance might be marginally worse on low-res resource packs, but it could be more noticeable while using high-res resource packs.