### PR TITLE
Fix generated item side-face stitching v2

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/model/ImprovedItemModelBuilderBase.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/immediate/model/ImprovedItemModelBuilderBase.java
@@ -1,5 +1,7 @@
 package net.caffeinemc.mods.sodium.client.render.immediate.model;
 
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ReferenceArrayList;
@@ -84,15 +86,14 @@ public class ImprovedItemModelBuilderBase {
     The coordinate of the end point of the quad (B) is (anchor, max).
     Side quad AB is on the plane of anchor x.*/
 
-    // Stores the side faces using BitSet maps. Each direction has its own map to avoid performance overhead of
-    // enumerating all faces from different directions together.
-    // Each map contains bit sets that represent "planes" of anchors in the same direction.
-    // The bits in the bit set indicate which parts of the plane have per-pixel side quads.
+    // Stores the side faces using maps split by direction. Each direction has its own map to avoid performance overhead
+    // of enumerating all faces from different directions together. Each map contains planes of anchors in the same
+    // direction, and each plane tracks which parts have per-pixel side quads.
     public record FaceStorage(
-            Int2ObjectMap<BitSet> up,
-            Int2ObjectMap<BitSet> down,
-            Int2ObjectMap<BitSet> left,
-            Int2ObjectMap<BitSet> right
+            Int2ObjectMap<FacePlane> up,
+            Int2ObjectMap<FacePlane> down,
+            Int2ObjectMap<FacePlane> left,
+            Int2ObjectMap<FacePlane> right
     ) {
         public FaceStorage() {
             this(
@@ -144,7 +145,7 @@ public class ImprovedItemModelBuilderBase {
         }
 
         private static void tryInsertFace(
-                Int2ObjectMap<BitSet> storage,
+                Int2ObjectMap<FacePlane> storage,
                 SideDirection faceFacing,
                 SpriteContents sprite,
                 int frame,
@@ -165,64 +166,96 @@ public class ImprovedItemModelBuilderBase {
 
             // Only insert a per-pixel side quad if the side face is exposed (not blocked by opaque neighbors).
             if (neighborTransparent) {
-                // Calculate the anchor and the pixel-level offset on the plane of the anchor,
+                // Calculate the anchor and the pixel-level offset on the plane of the anchor.
                 var anchor = faceFacing.isHorizontal() ? pixelY : pixelX;
                 var offset = faceFacing.isHorizontal() ? pixelX : pixelY;
 
                 // Mark the corresponding part of the plane of given anchor as occupied.
-                storage.computeIfAbsent(anchor, _ -> new BitSet()).set(offset);
+                storage.computeIfAbsent(anchor, _ -> new FacePlane()).set(
+                        offset,
+                        frame,
+                        getPixelColor(sprite, frame, pixelX, pixelY)
+                );
             }
         }
 
-        /*
-          <--merged-->    <-----merged----->
-        001111111111110000111111111111111111
-          ^           ^
-          |           |
-        min = ?     max = index - 1 = 14 - 1 = 13
-        accum = 0   accum = 12
-                    min = index - accum = 14 - 12 = 2
-        SideFace(facing, anchor, min=2, max=13)
-         */
+        private static int getPixelColor(SpriteContents sprite, int frame, int pixelX, int pixelY) {
+            var animatedTexture = sprite.animatedTexture;
+
+            if (animatedTexture == null) {
+                return sprite.originalImage.getPixel(pixelX, pixelY);
+            }
+
+            return sprite.originalImage.getPixel(
+                    pixelX + animatedTexture.getFrameX(frame) * sprite.width(),
+                    pixelY + animatedTexture.getFrameY(frame) * sprite.height()
+            );
+        }
+
         private static void buildMergedFaces(
                 Collection<SideFace> faceOutput,
-                Int2ObjectMap<BitSet> storage,
+                Int2ObjectMap<FacePlane> storage,
                 SideDirection faceFacing
         ) {
             // Merge all planes (anchors) in the map.
             for (int anchor : storage.keySet()) {
-                var faces = storage.get(anchor); // Get the plane bit set.
-                var accum = 0; // Initialize the merge accumulation counter.
+                var plane = storage.get(anchor); // Get the plane.
+                var faces = plane.faces();
+                var min = -1;
+                var previous = -1;
 
-                // For all bits in the plane, scan the occupied bits (per-pixel side quads) and merge consecutive bits
-                // into segments as SideFace.
-                // The scan starts from the position (index) of the first per-pixel side quad (first set bit) to the
-                // last per-pixel side quad (highest set bit).
-                // The scan runs to faces.length() + 1 is to ensure that the final accumulated segment is also emitted,
-                // since the bit immediately after the highest set bit is always clear.
-                for (var index = faces.nextSetBit(0); index < faces.length() + 1; index ++) {
-                    if (faces.get(index)) {
-                        // The bit is set, accumulate the length of the segment.
-                        accum ++;
-                    } else {
-                        // The bit is clear, meaning that the previous consecutive segment has ended, or a new segment
-                        // has not started yet.
-                        // If we do have a previously accumulated segment,
-                        if (accum > 0) {
-                            // Pop the segment out to the faceOutput as a merged SideFace.
-                            faceOutput.add(new SideFace(
-                                    faceFacing,
-                                    index - accum,
-                                    index - 1,
-                                    anchor
-                            ));
-                        }
-
-                        // Reset the accumulation counter for new segments.
-                        accum = 0;
+                for (var index = faces.nextSetBit(0); index >= 0; index = faces.nextSetBit(index + 1)) {
+                    if (min < 0) {
+                        min = index;
+                    } else if (index != previous + 1 || !plane.hasSameColors(previous, index)) {
+                        faceOutput.add(new SideFace(faceFacing, min, previous, anchor));
+                        min = index;
                     }
+
+                    previous = index;
+                }
+
+                if (min >= 0) {
+                    faceOutput.add(new SideFace(faceFacing, min, previous, anchor));
                 }
             }
+        }
+    }
+
+    private static class FacePlane {
+        private final BitSet faces = new BitSet();
+        private final Int2ObjectMap<Int2IntMap> colorsByIndex = new Int2ObjectOpenHashMap<>();
+
+        public BitSet faces() {
+            return this.faces;
+        }
+
+        public void set(int index, int frame, int color) {
+            this.faces.set(index);
+            this.colorsByIndex
+                    .computeIfAbsent(index, _ -> new Int2IntOpenHashMap())
+                    .put(frame, color);
+        }
+
+        public boolean hasSameColors(int firstIndex, int secondIndex) {
+            var firstColors = this.colorsByIndex.get(firstIndex);
+            var secondColors = this.colorsByIndex.get(secondIndex);
+
+            if (firstColors == null || secondColors == null || firstColors.size() != secondColors.size()) {
+                return false;
+            }
+
+            for (Int2IntMap.Entry entry : firstColors.int2IntEntrySet()) {
+                if (!secondColors.containsKey(entry.getIntKey())) {
+                    return false;
+                }
+
+                if (secondColors.get(entry.getIntKey()) != entry.getIntValue()) {
+                    return false;
+                }
+            }
+
+            return true;
         }
     }
 

--- a/common/src/main/resources/sodium-common.accesswidener
+++ b/common/src/main/resources/sodium-common.accesswidener
@@ -24,3 +24,7 @@ accessible field net/minecraft/client/resources/model/cuboid/ItemModelGenerator 
 accessible method net/minecraft/client/resources/model/cuboid/ItemModelGenerator isTransparent (Lnet/minecraft/client/renderer/texture/SpriteContents;IIIII)Z
 accessible class net/minecraft/client/resources/model/cuboid/ItemModelGenerator$SideDirection
 accessible method net/minecraft/client/resources/model/cuboid/ItemModelGenerator$SideDirection isHorizontal ()Z
+accessible field net/minecraft/client/renderer/texture/SpriteContents originalImage Lcom/mojang/blaze3d/platform/NativeImage;
+accessible field net/minecraft/client/renderer/texture/SpriteContents animatedTexture Lnet/minecraft/client/renderer/texture/SpriteContents$AnimatedTexture;
+accessible method net/minecraft/client/renderer/texture/SpriteContents$AnimatedTexture getFrameX (I)I
+accessible method net/minecraft/client/renderer/texture/SpriteContents$AnimatedTexture getFrameY (I)I

--- a/fabric/src/main/resources/sodium-fabric.accesswidener
+++ b/fabric/src/main/resources/sodium-fabric.accesswidener
@@ -24,3 +24,7 @@ accessible field net/minecraft/client/resources/model/cuboid/ItemModelGenerator 
 accessible method net/minecraft/client/resources/model/cuboid/ItemModelGenerator isTransparent (Lnet/minecraft/client/renderer/texture/SpriteContents;IIIII)Z
 accessible class net/minecraft/client/resources/model/cuboid/ItemModelGenerator$SideDirection
 accessible method net/minecraft/client/resources/model/cuboid/ItemModelGenerator$SideDirection isHorizontal ()Z
+accessible field net/minecraft/client/renderer/texture/SpriteContents originalImage Lcom/mojang/blaze3d/platform/NativeImage;
+accessible field net/minecraft/client/renderer/texture/SpriteContents animatedTexture Lnet/minecraft/client/renderer/texture/SpriteContents$AnimatedTexture;
+accessible method net/minecraft/client/renderer/texture/SpriteContents$AnimatedTexture getFrameX (I)I
+accessible method net/minecraft/client/renderer/texture/SpriteContents$AnimatedTexture getFrameY (I)I

--- a/frapi/src/main/resources/sodium-frapi.accesswidener
+++ b/frapi/src/main/resources/sodium-frapi.accesswidener
@@ -27,3 +27,7 @@ accessible field net/minecraft/client/resources/model/cuboid/ItemModelGenerator 
 accessible method net/minecraft/client/resources/model/cuboid/ItemModelGenerator isTransparent (Lnet/minecraft/client/renderer/texture/SpriteContents;IIIII)Z
 accessible class net/minecraft/client/resources/model/cuboid/ItemModelGenerator$SideDirection
 accessible method net/minecraft/client/resources/model/cuboid/ItemModelGenerator$SideDirection isHorizontal ()Z
+accessible field net/minecraft/client/renderer/texture/SpriteContents originalImage Lcom/mojang/blaze3d/platform/NativeImage;
+accessible field net/minecraft/client/renderer/texture/SpriteContents animatedTexture Lnet/minecraft/client/renderer/texture/SpriteContents$AnimatedTexture;
+accessible method net/minecraft/client/renderer/texture/SpriteContents$AnimatedTexture getFrameX (I)I
+accessible method net/minecraft/client/renderer/texture/SpriteContents$AnimatedTexture getFrameY (I)I

--- a/neoforge/src/mod/resources/META-INF/accesstransformer.cfg
+++ b/neoforge/src/mod/resources/META-INF/accesstransformer.cfg
@@ -24,3 +24,7 @@ public net.minecraft.client.resources.model.cuboid.ItemModelGenerator UV_SHRINK
 public net.minecraft.client.resources.model.cuboid.ItemModelGenerator isTransparent(Lnet/minecraft/client/renderer/texture/SpriteContents;IIIII)Z
 public net.minecraft.client.resources.model.cuboid.ItemModelGenerator$SideDirection
 public net.minecraft.client.resources.model.cuboid.ItemModelGenerator$SideDirection isHorizontal()Z
+public net.minecraft.client.renderer.texture.SpriteContents originalImage
+public net.minecraft.client.renderer.texture.SpriteContents animatedTexture
+public net.minecraft.client.renderer.texture.SpriteContents$AnimatedTexture getFrameX(I)I
+public net.minecraft.client.renderer.texture.SpriteContents$AnimatedTexture getFrameY(I)I


### PR DESCRIPTION
This fixes #3715.
This is a v2 of a previous PR (by me), which, instead of fixing the optimization it reverted it.

### Background
Isolation and cause [analysis](https://github.com/CaffeineMC/sodium/issues/3715#issuecomment-4879772053) is present in the original issue (long story short, it was caused by this [PR](https://github.com/CaffeineMC/sodium/pull/3551)).

### Why
Previously, generated item side faces were being merged into longer quads. This reduced quad count, but it also meant "UV_SHRINK" was only applied to the outer ends of each merged run instead of each side texel (UV_SHRINK is present in the Fabric and Neoforge specific item-builders). This is most visible on simple generated item textures such as torches, levers, and other torch-like items. The stitching error is more visible on these items because they have large flat regions and long exposed side-face runs, so the shifted side-face texel boundaries are easy to compare against the front face.

### Fix
I did a previous PR on this same issue, which just reverted the optimization. This time, instead of reverting it completely, it keeps the side-face merging optimization, but makes it conditional. Adjacent side texels are now only merged when their sprite pixel colors match across the relevant animation frames. This preserves merged quads for visually identical runs, while splitting runs where merging could shift visible texel boundaries.

Example:
A A A A -> one merged side face
A A B B -> two merged side faces
A B C D -> four side faces

### Test
Torch after my fix:
<img width="507" height="371" alt="Screenshot 2026-07-13 002340" src="https://github.com/user-attachments/assets/8f38da2b-0d77-4666-bff3-2ed4dda88cd2" />


### Tradeoff
This keeps the optimization for same-color side-face runs, so it avoids fully reverting the previous optimization. The optimization is only lost where adjacent exposed side texels differ visually, which is the case where merging can produce incorrect stitching.