### PR TITLE
Remove UV_SHRINK entirely.

### DIFF
--- a/fabric/src/main/java/net/caffeinemc/mods/sodium/fabric/render/ImprovedItemModelBuilder.java
+++ b/fabric/src/main/java/net/caffeinemc/mods/sodium/fabric/render/ImprovedItemModelBuilder.java
@@ -12,7 +12,6 @@ import org.joml.Vector3f;
 
 import static net.minecraft.client.resources.model.cuboid.ItemModelGenerator.MIN_Z;
 import static net.minecraft.client.resources.model.cuboid.ItemModelGenerator.MAX_Z;
-import static net.minecraft.client.resources.model.cuboid.ItemModelGenerator.UV_SHRINK;
 
 public class ImprovedItemModelBuilder {
 
@@ -46,15 +45,15 @@ public class ImprovedItemModelBuilder {
 			var v1 = 0.0F;
 
 			if (faceFacing.isHorizontal()) {
-				u0 = minX + UV_SHRINK;
-				v0 = minY + UV_SHRINK;
-				u1 = minX + length - UV_SHRINK;
-				v1 = minY + 1.0F - UV_SHRINK;
+				u0 = minX;
+				v0 = minY;
+				u1 = minX + length;
+				v1 = minY + 1.0F;
 			} else {
-				u0 = minX + UV_SHRINK;
-				v0 = minY + length - UV_SHRINK;
-				u1 = minX + 1.0F - UV_SHRINK;
-				v1 = minY + UV_SHRINK;
+				u0 = minX;
+				v0 = minY + length;
+				u1 = minX + 1.0F;
+				v1 = minY;
 			}
 
 			var fromX = minX;

--- a/fabric/src/main/java/net/caffeinemc/mods/sodium/fabric/render/ImprovedItemModelBuilder.java
+++ b/fabric/src/main/java/net/caffeinemc/mods/sodium/fabric/render/ImprovedItemModelBuilder.java
@@ -12,6 +12,7 @@ import org.joml.Vector3f;
 
 import static net.minecraft.client.resources.model.cuboid.ItemModelGenerator.MIN_Z;
 import static net.minecraft.client.resources.model.cuboid.ItemModelGenerator.MAX_Z;
+import static net.minecraft.client.resources.model.cuboid.ItemModelGenerator.UV_SHRINK;
 
 public class ImprovedItemModelBuilder {
 
@@ -44,17 +45,17 @@ public class ImprovedItemModelBuilder {
 			var u1 = 0.0F;
 			var v1 = 0.0F;
 
-			if (faceFacing.isHorizontal()) {
-				u0 = minX;
-				v0 = minY;
-				u1 = minX + length;
-				v1 = minY + 1.0F;
-			} else {
-				u0 = minX;
-				v0 = minY + length;
-				u1 = minX + 1.0F;
-				v1 = minY;
-			}
+            if (faceFacing.isHorizontal()) {
+                u0 = minX;
+                v0 = minY + UV_SHRINK;
+                u1 = minX + length;
+                v1 = minY + 1.0F - UV_SHRINK;
+            } else {
+                u0 = minX + UV_SHRINK;
+                v0 = minY + length;
+                u1 = minX + 1.0F - UV_SHRINK;
+                v1 = minY;
+            }
 
 			var fromX = minX;
 			var fromY = minY;

--- a/neoforge/src/mod/java/net/caffeinemc/mods/sodium/neoforge/render/ImprovedItemModelBuilder.java
+++ b/neoforge/src/mod/java/net/caffeinemc/mods/sodium/neoforge/render/ImprovedItemModelBuilder.java
@@ -13,7 +13,6 @@ import org.joml.Vector3f;
 
 import static net.minecraft.client.resources.model.cuboid.ItemModelGenerator.MIN_Z;
 import static net.minecraft.client.resources.model.cuboid.ItemModelGenerator.MAX_Z;
-import static net.minecraft.client.resources.model.cuboid.ItemModelGenerator.UV_SHRINK;
 
 public class ImprovedItemModelBuilder {
 
@@ -48,15 +47,15 @@ public class ImprovedItemModelBuilder {
 			var v1 = 0.0F;
 
 			if (faceFacing.isHorizontal()) {
-				u0 = minX + UV_SHRINK;
-				v0 = minY + UV_SHRINK;
-				u1 = minX + length - UV_SHRINK;
-				v1 = minY + 1.0F - UV_SHRINK;
+				u0 = minX;
+				v0 = minY;
+				u1 = minX + length;
+				v1 = minY + 1.0F;
 			} else {
-				u0 = minX + UV_SHRINK;
-				v0 = minY + length - UV_SHRINK;
-				u1 = minX + 1.0F - UV_SHRINK;
-				v1 = minY + UV_SHRINK;
+				u0 = minX;
+				v0 = minY + length;
+				u1 = minX + 1.0F;
+				v1 = minY;
 			}
 
 			var fromX = minX;

--- a/neoforge/src/mod/java/net/caffeinemc/mods/sodium/neoforge/render/ImprovedItemModelBuilder.java
+++ b/neoforge/src/mod/java/net/caffeinemc/mods/sodium/neoforge/render/ImprovedItemModelBuilder.java
@@ -13,6 +13,7 @@ import org.joml.Vector3f;
 
 import static net.minecraft.client.resources.model.cuboid.ItemModelGenerator.MIN_Z;
 import static net.minecraft.client.resources.model.cuboid.ItemModelGenerator.MAX_Z;
+import static net.minecraft.client.resources.model.cuboid.ItemModelGenerator.UV_SHRINK;
 
 public class ImprovedItemModelBuilder {
 
@@ -46,17 +47,17 @@ public class ImprovedItemModelBuilder {
 			var u1 = 0.0F;
 			var v1 = 0.0F;
 
-			if (faceFacing.isHorizontal()) {
-				u0 = minX;
-				v0 = minY;
-				u1 = minX + length;
-				v1 = minY + 1.0F;
-			} else {
-				u0 = minX;
-				v0 = minY + length;
-				u1 = minX + 1.0F;
-				v1 = minY;
-			}
+            if (faceFacing.isHorizontal()) {
+                u0 = minX;
+                v0 = minY + UV_SHRINK;
+                u1 = minX + length;
+                v1 = minY + 1.0F - UV_SHRINK;
+            } else {
+                u0 = minX + UV_SHRINK;
+                v0 = minY + length;
+                u1 = minX + 1.0F - UV_SHRINK;
+                v1 = minY;
+            }
 
 			var fromX = minX;
 			var fromY = minY;


### PR DESCRIPTION
Remove the `UV_SHRINK` from the `ImprovedItemModelBuilder`. The `UV_SHRINK` causes the visual misalignment of the side quads generated by the `ImprovedItemModelBuilder`. This draft assumes that `UV_SHRINK` is no longer needed due to improved modeling method and the built-in sprite bleeding in the item atlas.