### PR TITLE
Avoid repeated region lookups when building render lists

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/VisibleChunkCollector.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/lists/VisibleChunkCollector.java
@@ -4,6 +4,7 @@ import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.caffeinemc.mods.sodium.client.render.chunk.LocalSectionIndex;
 import net.caffeinemc.mods.sodium.client.render.chunk.region.RenderRegion;
 import net.caffeinemc.mods.sodium.client.render.chunk.region.RenderRegionManager;
+import org.jspecify.annotations.Nullable;
 
 /**
  * The async visible chunk collector is passed into a section tree to collect visible chunks.
@@ -14,6 +15,12 @@ public class VisibleChunkCollector implements CoordinateSectionVisitor, RenderLi
 
     private final ObjectArrayList<ChunkRenderList> sortedRenderLists;
 
+    // sections of the same region are visited in runs, so memoizing the last region avoids most of the region map lookups
+    private int lastRegionX = Integer.MIN_VALUE;
+    private int lastRegionY;
+    private int lastRegionZ;
+    private @Nullable ChunkRenderList lastRenderList;
+
     public VisibleChunkCollector(RenderRegionManager regions, int frame) {
         this.regions = regions;
         this.frame = frame;
@@ -23,10 +30,24 @@ public class VisibleChunkCollector implements CoordinateSectionVisitor, RenderLi
 
     @Override
     public void visit(int x, int y, int z) {
-        var region = this.regions.getForChunk(x, y, z);
+        int regionX = x >> RenderRegion.REGION_WIDTH_SH;
+        int regionY = y >> RenderRegion.REGION_HEIGHT_SH;
+        int regionZ = z >> RenderRegion.REGION_LENGTH_SH;
 
-        // since this is async, the region might have been removed in the meantime
-        if (region == null) {
+        ChunkRenderList renderList;
+
+        if (regionX == this.lastRegionX && regionY == this.lastRegionY && regionZ == this.lastRegionZ) {
+            renderList = this.lastRenderList;
+        } else {
+            renderList = this.getRenderList(x, y, z);
+
+            this.lastRegionX = regionX;
+            this.lastRegionY = regionY;
+            this.lastRegionZ = regionZ;
+            this.lastRenderList = renderList;
+        }
+
+        if (renderList == null) {
             return;
         }
 
@@ -34,6 +55,18 @@ public class VisibleChunkCollector implements CoordinateSectionVisitor, RenderLi
         int rY = y & (RenderRegion.REGION_HEIGHT - 1);
         int rZ = z & (RenderRegion.REGION_LENGTH - 1);
         var sectionIndex = LocalSectionIndex.pack(rX, rY, rZ);
+
+        // flags don't need to be checked here since only sections with contents (RenderSectionFlags.MASK_NEEDS_RENDER) are added to the octree
+        renderList.add(sectionIndex);
+    }
+
+    private @Nullable ChunkRenderList getRenderList(int x, int y, int z) {
+        var region = this.regions.getForChunk(x, y, z);
+
+        // since this is async, the region might have been removed in the meantime
+        if (region == null) {
+            return null;
+        }
 
         ChunkRenderList renderList = region.getRenderList();
 
@@ -43,8 +76,7 @@ public class VisibleChunkCollector implements CoordinateSectionVisitor, RenderLi
             this.sortedRenderLists.add(renderList);
         }
 
-        // flags don't need to be checked here since only sections with contents (RenderSectionFlags.MASK_NEEDS_RENDER) are added to the octree
-        renderList.add(sectionIndex);
+        return renderList;
     }
 
     private static int[] sortItems = new int[RenderRegion.REGION_SIZE];


### PR DESCRIPTION
The collector did a region map lookup for every visited section on every render list update. The traversal visits sections of the same region in long runs, so remembering the last region skips almost all of those lookups. The reset logic still runs once per region through the existing frame check.