### PR TITLE
Add a way to specify priority for option overrides and overlays

### DIFF
--- a/common/src/api/java/net/caffeinemc/mods/sodium/api/config/structure/ModOptionsBuilder.java
+++ b/common/src/api/java/net/caffeinemc/mods/sodium/api/config/structure/ModOptionsBuilder.java
@@ -94,6 +94,18 @@ public interface ModOptionsBuilder {
     ModOptionsBuilder registerOptionReplacement(Identifier target, OptionBuilder replacement);
 
     /**
+     * Registers an option override provided by this mod. Overrides allow modifying the behavior or appearance of options defined by other mods.
+     * <p>
+     * The ID of the provided replacement option can match the original option to allow other mods to apply overlays targeting the original option ID. If the replacement option has a different ID, overlays must target the new ID.
+     *
+     * @param target      The ID of the option to override.
+     * @param replacement The option builder that defines the replacement option.
+     * @param priority    The override priority. Higher-priority overrides take precedence over lower-priority overrides. If multiple overrides are registered for the same target with the same priority, an error is raised. Defaults to {@code 0}.
+     * @return The current builder instance.
+     */
+    ModOptionsBuilder registerOptionReplacement(Identifier target, OptionBuilder replacement, int priority);
+
+    /**
      * Registers an option overlay provided by this mod. Overlays allow partially changing an option instead of replacing it entirely.
      * <p>
      * The target option ID must match the ID of an existing option, either defined by another mod or by a replacement option defined by this mod. If the target option has been replaced, overlays must target the ID of the replacement option, which may or may not be the same as the original option ID.
@@ -103,6 +115,18 @@ public interface ModOptionsBuilder {
      * @return The current builder instance.
      */
     ModOptionsBuilder registerOptionOverlay(Identifier target, OptionBuilder overlay);
+
+    /**
+     * Registers an option overlay provided by this mod. Overlays allow partially changing an option instead of replacing it entirely.
+     * <p>
+     * The target option ID must match the ID of an existing option, either defined by another mod or by a replacement option defined by this mod. If the target option has been replaced, overlays must target the ID of the replacement option, which may or may not be the same as the original option ID.
+     *
+     * @param target   The ID of the option to overlay.
+     * @param overlay  The option builder that defines the overlay changes.
+     * @param priority The overlay priority. Higher-priority overlays take precedence over lower-priority overlays. If multiple overlays are registered for the same target with the same priority, an error is raised. Defaults to {@code 0}.
+     * @return The current builder instance.
+     */
+    ModOptionsBuilder registerOptionOverlay(Identifier target, OptionBuilder overlay, int priority);
 
     /**
      * Registers a hook that will be called after an option which has any of the specified flags changed. This can be used to implement custom behavior in response to option changes. To hook on built-in flags, use the identifiers given by {@link OptionFlag#getId()}. The hook is given an array of all flags that triggered the hook. Note that the hook may be called with a set of flags larger than the set of flags it is interested in for performance reasons, since this lets us avoid generating a different flag set for every hook.

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/config/builder/ModOptionsBuilderImpl.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/config/builder/ModOptionsBuilderImpl.java
@@ -101,7 +101,12 @@ class ModOptionsBuilderImpl implements ModOptionsBuilder {
 
     @Override
     public ModOptionsBuilder registerOptionReplacement(Identifier target, OptionBuilder replacement) {
-        var override = new OptionOverride(target, this.configId, ((OptionBuilderImpl<?>) replacement).build());
+        return this.registerOptionReplacement(target, replacement, 0);
+    }
+
+    @Override
+    public ModOptionsBuilder registerOptionReplacement(Identifier target, OptionBuilder replacement, int priority) {
+        var override = new OptionOverride(target, this.configId, ((OptionBuilderImpl<?>) replacement).build(), priority);
         if (this.optionOverrides == null) {
             this.optionOverrides = new ArrayList<>();
         }
@@ -111,7 +116,12 @@ class ModOptionsBuilderImpl implements ModOptionsBuilder {
 
     @Override
     public ModOptionsBuilder registerOptionOverlay(Identifier target, OptionBuilder overlay) {
-        var optionOverlay = new OptionOverlay(target, this.configId, ((OptionBuilderImpl<?>) overlay));
+        return this.registerOptionOverlay(target, overlay, 0);
+    }
+
+    @Override
+    public ModOptionsBuilder registerOptionOverlay(Identifier target, OptionBuilder overlay, int priority) {
+        var optionOverlay = new OptionOverlay(target, this.configId, ((OptionBuilderImpl<?>) overlay), priority);
         if (this.optionOverlays == null) {
             this.optionOverlays = new ArrayList<>();
         }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/config/structure/Config.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/config/structure/Config.java
@@ -80,19 +80,23 @@ public class Config implements ConfigState {
     }
 
     private void applyOptionChanges() {
-        var overrides = new Object2ReferenceOpenHashMap<Identifier, OptionOverride>();
-        var overlays = new Object2ReferenceOpenHashMap<Identifier, OptionOverlay>();
+        var overrides = new Object2ReferenceOpenHashMap<Identifier, ObjectArrayList<OptionOverride>>();
+        var overlays = new Object2ReferenceOpenHashMap<Identifier, ObjectArrayList<OptionOverlay>>();
 
-        // collect overrides and overlays and validate them, also against each other
+        // collect overrides and overlays and validate them
         for (var modConfig : this.modOptions) {
             for (var override : modConfig.overrides()) {
                 if (override.target().getNamespace().equals(modConfig.configId())) {
                     throw new IllegalArgumentException("Override by mod '" + modConfig.configId() + "' targets its own option '" + override.target() + "'");
                 }
 
-                var oldOverride = overrides.put(override.target(), override);
-                if (oldOverride != null) {
-                    throw new IllegalArgumentException("Multiple overrides for option '" + override.target() + "'! Sources: " + oldOverride.source() + " and " + override.source());
+                var existingOverrides = overrides.computeIfAbsent(override.target(), _ -> new ObjectArrayList<>(1));
+                var existingOverridePriority = existingOverrides.isEmpty() ? override.priority() : existingOverrides.getFirst().priority();
+                if (override.priority() > existingOverridePriority) {
+                    existingOverrides.clear();
+                }
+                if (override.priority() >= existingOverridePriority) {
+                    existingOverrides.add(override);
                 }
             }
 
@@ -101,9 +105,13 @@ public class Config implements ConfigState {
                     throw new IllegalArgumentException("Overlay by mod '" + modConfig.configId() + "' targets its own option '" + overlay.target() + "'");
                 }
 
-                var oldOverlay = overlays.put(overlay.target(), overlay);
-                if (oldOverlay != null) {
-                    throw new IllegalArgumentException("Multiple overlays for option '" + overlay.target() + "'! Sources: " + oldOverlay.source() + " and " + overlay.source());
+                var existingOverlays = overlays.computeIfAbsent(overlay.target(), _ -> new ObjectArrayList<>(1));
+                var existingOverlayPriority = existingOverlays.isEmpty() ? overlay.priority() : existingOverlays.getFirst().priority();
+                if (overlay.priority() > existingOverlayPriority) {
+                    existingOverlays.clear();
+                }
+                if (overlay.priority() >= existingOverlayPriority) {
+                    existingOverlays.add(overlay);
                 }
             }
         }
@@ -115,13 +123,16 @@ public class Config implements ConfigState {
                     var options = group.options();
                     for (int i = 0; i < options.size(); i++) {
                         var option = options.get(i);
-                        var override = overrides.get(option.id);
-
-                        // apply override to option if it exists
-                        if (override != null) {
-                            var replacement = override.change();
-                            this.exchangeOption(options, i, replacement, option);
+                        var optionOverrides = overrides.get(option.id);
+                        if (optionOverrides == null || optionOverrides.isEmpty()) {
+                            continue;
                         }
+                        if (optionOverrides.size() > 1) {
+                            throw new IllegalArgumentException("Multiple overrides for option '" + optionOverrides.getFirst().target() + "'! Sources: " + optionOverrides.getFirst().source() + " and " + optionOverrides.getLast().source());
+                        }
+
+                        var replacement = optionOverrides.getFirst().change();
+                        this.exchangeOption(options, i, replacement, option);
                     }
                 }
             }
@@ -134,17 +145,20 @@ public class Config implements ConfigState {
                     var options = group.options();
                     for (int i = 0; i < options.size(); i++) {
                         var option = options.get(i);
-                        var overlay = overlays.get(option.id);
+                        var optionOverlays = overlays.get(option.id);
+                        if (optionOverlays == null || optionOverlays.isEmpty()) {
+                            continue;
+                        }
+                        if (optionOverlays.size() > 1) {
+                            throw new IllegalArgumentException("Multiple overlays for option '" + optionOverlays.getFirst().target() + "'! Sources: " + optionOverlays.getFirst().source() + " and " + optionOverlays.getLast().source());
+                        }
 
-                        // apply overlay to option if it exists
-                        if (overlay != null) {
-                            var change = overlay.change();
-                            try {
-                                var overlaidOption = change.buildWithBaseOption(option);
-                                this.exchangeOption(options, i, overlaidOption, option);
-                            } catch (Exception e) {
-                                throw new IllegalArgumentException("Failed to apply overlay from '" + overlay.source() + "' to option '" + option.id + "'", e);
-                            }
+                        var change = optionOverlays.getFirst().change();
+                        try {
+                            var overlaidOption = change.buildWithBaseOption(option);
+                            this.exchangeOption(options, i, overlaidOption, option);
+                        } catch (Exception e) {
+                            throw new IllegalArgumentException("Failed to apply overlay from '" + optionOverlays.getFirst().source() + "' to option '" + option.id + "'", e);
                         }
                     }
                 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/config/structure/OptionOverlay.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/config/structure/OptionOverlay.java
@@ -3,5 +3,8 @@ package net.caffeinemc.mods.sodium.client.config.structure;
 import net.caffeinemc.mods.sodium.client.config.builder.OptionBuilderImpl;
 import net.minecraft.resources.Identifier;
 
-public record OptionOverlay(Identifier target, String source, OptionBuilderImpl<?> change) {
+public record OptionOverlay(Identifier target, String source, OptionBuilderImpl<?> change, int priority) {
+    public OptionOverlay(Identifier target, String source, OptionBuilderImpl<?> change) {
+        this(target, source, change, 0);
+    }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/config/structure/OptionOverride.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/config/structure/OptionOverride.java
@@ -2,5 +2,8 @@ package net.caffeinemc.mods.sodium.client.config.structure;
 
 import net.minecraft.resources.Identifier;
 
-public record OptionOverride(Identifier target, String source, Option change) {
+public record OptionOverride(Identifier target, String source, Option change, int priority) {
+    public OptionOverride(Identifier target, String source, Option change) {
+        this(target, source, change, 0);
+    }
 }


### PR DESCRIPTION
At the moment, if two (or more) different mods attempt to register an override or an overlay for the same option, it results in a hard crash. This is quite unfortunate, since two mods with overlapping features are not necessarily incompatible, and yet they would be unable to coexist if both of them want/need to override some of Sodium's options.

As an example, say, hypothetically, I maintain a mod which provides an option for borderless fullscreen. Then, hypothetically, a maintainer of a popular variety mod gets a bright idea of providing an option for borderless fullscreen of their own, alongside their other tweaks. They obviously, and still hypothetically, implement it incorrectly. And now our mods are incompatible, simply because we both override `sodium:general.fullscreen_mode`, meaning players must choose between normal borderless fullscreen and the features provided by the second hypothetical mod, which is not ideal.

This PR solves the issue by allowing consumers of Sodium's Config API to specify the priority of their option overrides/overlays, similarly to how we already do this for mixins and such. The override/overlay with the highest priority wins. If there are still multiple contenders with the same priority, an exception is thrown, just as it was before.

The new API is fully backwards compatible and does not break existing mods, as it simply adds new overloads for the `registerOptionReplacement` and `registerOptionOverlay` methods instead of replacing them. The original versions of these methods now simply register overrides and overlays with the default priority of `0`.
