### PR TITLE
fix vertex indexing, shadow attributes, normal fallbacks, transform math, and option equality

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/config/structure/StatefulOption.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/config/structure/StatefulOption.java
@@ -11,6 +11,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -78,7 +79,7 @@ public abstract class StatefulOption<V> extends Option {
     }
 
     public void modifyValue(V value) {
-        if (this.modifiedValue != value) {
+        if (!Objects.equals(this.modifiedValue, value)) {
             this.modifiedValue = value;
             this.state.invalidateDependents(this.dependents);
         }
@@ -101,14 +102,14 @@ public abstract class StatefulOption<V> extends Option {
         this.value = this.binding.load();
 
         var newValue = this.validateValue(this.value);
-        if (newValue != this.value) {
+        if (!Objects.equals(newValue, this.value)) {
             this.value = newValue;
             this.binding.save(this.value);
             this.state.notifyStorageWrite(this.storage);
         }
 
         this.modifiedValue = this.value;
-        if (this.value != previousValue) {
+        if (!Objects.equals(this.value, previousValue)) {
             this.state.invalidateDependents(this.dependents);
             this.state.invalidateDependents(this.applyDependents);
         }
@@ -116,7 +117,7 @@ public abstract class StatefulOption<V> extends Option {
 
     public V getValidatedValue() {
         var newValue = this.validateValue(this.modifiedValue);
-        if (newValue != this.modifiedValue) {
+        if (!Objects.equals(newValue, this.modifiedValue)) {
             this.modifiedValue = newValue;
             this.state.invalidateDependents(this.dependents);
         }
@@ -132,7 +133,7 @@ public abstract class StatefulOption<V> extends Option {
 
     @Override
     public boolean hasChanged() {
-        return this.modifiedValue != this.value;
+        return !Objects.equals(this.modifiedValue, this.value);
     }
 
     @Override

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/buffers/ChunkVertexConsumer.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/buffers/ChunkVertexConsumer.java
@@ -129,6 +129,8 @@ public class ChunkVertexConsumer implements VertexConsumer {
         this.writtenAttributes = 0;
 
         if (this.vertexIndex == 4) {
+            this.vertexIndex = 0;
+
             int normal = this.calculateNormal();
 
             ModelQuadFacing cullFace = ModelQuadFacing.fromPackedNormal(normal);
@@ -154,8 +156,6 @@ public class ChunkVertexConsumer implements VertexConsumer {
             if (sprite != null) {
                 this.modelBuilder.addSprite(sprite);
             }
-
-            this.vertexIndex = 0;
         }
 
         return this;

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/entity/shadows/ShadowFeatureRendererMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/features/render/entity/shadows/ShadowFeatureRendererMixin.java
@@ -126,6 +126,6 @@ public class ShadowFeatureRendererMixin {
         float yt = MatrixHelper.transformPositionY(matPosition, x, y, z);
         float zt = MatrixHelper.transformPositionZ(matPosition, x, y, z);
 
-        EntityVertex.write(ptr, xt, yt, zt, color, u, v, LightCoordsUtil.FULL_BRIGHT, OverlayTexture.NO_OVERLAY, normal);
+        EntityVertex.write(ptr, xt, yt, zt, color, u, v, OverlayTexture.NO_OVERLAY, LightCoordsUtil.FULL_BRIGHT, normal);
     }
 }

--- a/frapi/src/main/java/net/caffeinemc/mods/sodium/client/render/frapi/render/QuadToPosPipe.java
+++ b/frapi/src/main/java/net/caffeinemc/mods/sodium/client/render/frapi/render/QuadToPosPipe.java
@@ -39,9 +39,13 @@ public class QuadToPosPipe implements Consumer<QuadView> {
         for (int i = 0; i < 4; i++) {
             quad.copyPos(i, this.vec);
 
-            this.vec.x = MatrixHelper.transformPositionX(this.matrix, this.vec.x, this.vec.y, this.vec.z);
-            this.vec.y = MatrixHelper.transformPositionY(this.matrix, this.vec.x, this.vec.y, this.vec.z);
-            this.vec.z = MatrixHelper.transformPositionZ(this.matrix, this.vec.x, this.vec.y, this.vec.z);
+            float x = this.vec.x;
+            float y = this.vec.y;
+            float z = this.vec.z;
+
+            this.vec.x = MatrixHelper.transformPositionX(this.matrix, x, y, z);
+            this.vec.y = MatrixHelper.transformPositionY(this.matrix, x, y, z);
+            this.vec.z = MatrixHelper.transformPositionZ(this.matrix, x, y, z);
 
             this.posConsumer.accept(this.vec);
         }

--- a/neoforge/src/mod/java/net/caffeinemc/mods/sodium/mixin/core/model/quad/BakedQuadMixin.java
+++ b/neoforge/src/mod/java/net/caffeinemc/mods/sodium/mixin/core/model/quad/BakedQuadMixin.java
@@ -92,7 +92,7 @@ public abstract class BakedQuadMixin implements BakedQuadView {
     @Override
     public int getVertexNormal(int idx) {
         //this.vertices[ModelQuadUtil.vertexOffset(idx) + ModelQuadUtil.NORMAL_INDEX];
-        return this.bakedNormals == BakedNormals.UNSPECIFIED ? -1 : this.bakedNormals.normal(idx);
+        return this.bakedNormals == null || this.bakedNormals == BakedNormals.UNSPECIFIED ? 0 : this.bakedNormals.normal(idx);
     }
 
     @Override


### PR DESCRIPTION
- fixed argument ordering in `ShadowFeatureRendererMixin` where `LightCoordsUtil.FULL_BRIGHT` and `OverlayTexture.NO_OVERLAY` were passed in reverse order to `EntityVertex.write()`. Because `EntityVertex.write()` expects `overlay` followed by `light`, passing them inverted caused lightmap coords to be written to the overlay attribute and overlay texture coords to be written to the lightmap attribute, corrupting shadow vertex data.
- reset `vertexIndex = 0` immediately upon reaching 4 vertices in `ChunkVertexConsumer.potentiallyEndVertex()`. Previously, if `collector.appendQuad()` returned `true` (indicating a culled/degenerate translucent quad), the method returned early without resetting `vertexIndex`, causing the subsequent `addVertex()` call to attempt writing to index 4 of the 4-element `vertices` array and throwing an `ArrayIndexOutOfBoundsException`.
- cached initial `x`, `y`, and `z` values into local variables in `QuadToPosPipe.accept()`. Mutating `this.vec.x` in place with `transformPositionX()` caused the subsequent `transformPositionY()` and `transformPositionZ()` calls to read the already-transformed `x` coordinate instead of the original component, corrupting the resulting `y` and `z` positions.
- changed the fallback return value of `getVertexNormal()` in `BakedQuadMixin` (NeoForge) from `-1` to `0` when `bakedNormals` is null or `UNSPECIFIED`. Sodium uses `0` as the sentinel value indicating absent vertex normals to trigger fallback to `getFaceNormal()`; returning `-1` (`0xFFFFFFFF`) caused the renderer to treat `-1` as a valid packed normal vector, unpacking garbage floats and breaking model lighting on NeoForge.
- replaced reference inequality (`!=`) with `!Objects.equals()` in `StatefulOption`. For boxed types outside the JVM cache range of `-128..127` (such as chunk fade duration at 750 or FPS limit at 260), separate `Integer` instances with identical values evaluated to not equal, causing options to spuriously report `hasChanged() == true` and keep the apply button and dirty indicators active even after reverting changes.